### PR TITLE
fix(waveform): real-time energy display with smooth animation

### DIFF
--- a/DictusApp/Audio/AudioRecorder.swift
+++ b/DictusApp/Audio/AudioRecorder.swift
@@ -137,7 +137,11 @@ class AudioRecorder: ObservableObject {
             DispatchQueue.main.async {
                 guard let self, let wk = self.whisperKit else { return }
                 guard self.isRecording else { return }
-                self.bufferEnergy = wk.audioProcessor.relativeEnergy
+                // Only take the last 30 values — one per waveform bar.
+                // WHY: relativeEnergy grows continuously (600+ values after 10s).
+                // Using the full array compresses the entire history into 30 bars,
+                // creating a timeline instead of a real-time level indicator.
+                self.bufferEnergy = Array(wk.audioProcessor.relativeEnergy.suffix(30))
                 self.bufferSeconds = Double(wk.audioProcessor.audioSamples.count)
                     / Double(WhisperKit.sampleRate)
             }
@@ -177,7 +181,7 @@ class AudioRecorder: ObservableObject {
                     guard let self, let wk = self.whisperKit else { return }
                     // Only publish energy/duration while actively recording
                     guard self.isRecording else { return }
-                    self.bufferEnergy = wk.audioProcessor.relativeEnergy
+                    self.bufferEnergy = Array(wk.audioProcessor.relativeEnergy.suffix(30))
                     self.bufferSeconds = Double(wk.audioProcessor.audioSamples.count)
                         / Double(WhisperKit.sampleRate)
                 }

--- a/DictusApp/Audio/RawAudioCapture.swift
+++ b/DictusApp/Audio/RawAudioCapture.swift
@@ -158,10 +158,10 @@ class RawAudioCapture: ObservableObject {
             self.audioSamples.append(contentsOf: samples)
             self.bufferSeconds = Double(self.audioSamples.count) / 16000.0
 
-            // Maintain a rolling window of energy values (last 50 = ~2s at ~25Hz callback rate)
+            // Maintain a rolling window of energy values (last 30 = matches barCount in BrandWaveform)
             self.bufferEnergy.append(energy)
-            if self.bufferEnergy.count > 50 {
-                self.bufferEnergy.removeFirst(self.bufferEnergy.count - 50)
+            if self.bufferEnergy.count > 30 {
+                self.bufferEnergy.removeFirst(self.bufferEnergy.count - 30)
             }
         }
     }

--- a/DictusApp/DictationCoordinator.swift
+++ b/DictusApp/DictationCoordinator.swift
@@ -498,8 +498,13 @@ class DictationCoordinator: ObservableObject {
         guard now.timeIntervalSince(lastWaveformWriteDate) >= 0.2 else { return }
         lastWaveformWriteDate = now
 
+        // Cap to 30 values (one per waveform bar) before encoding.
+        // WHY: AudioRecorder already sends .suffix(30), but this is a safety cap
+        // to ensure the keyboard never receives oversized arrays.
+        let cappedEnergy = Array(energy.suffix(30))
+
         // Encode energy as JSON and write to App Group
-        if let data = try? JSONEncoder().encode(energy) {
+        if let data = try? JSONEncoder().encode(cappedEnergy) {
             defaults.set(data, forKey: SharedKeys.waveformEnergy)
         }
         defaults.set(bufferSeconds, forKey: SharedKeys.recordingElapsedSeconds)

--- a/DictusApp/Onboarding/WelcomePage.swift
+++ b/DictusApp/Onboarding/WelcomePage.swift
@@ -5,29 +5,23 @@ import DictusCore
 
 /// Welcome page shown on first launch with animated brand waveform and tagline.
 ///
-/// WHY BrandWaveform with idle animation:
-/// A gentle breathing waveform creates an alive first impression instead of a static logo.
-/// A Timer generates random low-energy values (0.1-0.4) every 0.5s, making the bars
-/// subtly pulse. This is purely decorative — no audio is being captured.
+/// WHY BrandWaveform with processing (sinusoidal) animation:
+/// A smooth traveling sine wave creates a polished first impression instead of
+/// random jittery bars. The sinusoidal mode is inherently fluid (60fps via
+/// TimelineView) and requires no Timer — simpler code, better visual result.
 struct WelcomePage: View {
     let onNext: () -> Void
 
     @State private var showContent = false
-    @State private var idleEnergy: [Float] = Array(repeating: 0.15, count: 30)
-
-    /// Timer that generates gentle random energy values for the breathing animation.
-    private let idleTimer = Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()
 
     var body: some View {
         VStack(spacing: 0) {
             Spacer()
 
-            // Animated brand waveform with gentle idle breathing
-            BrandWaveform(energyLevels: idleEnergy, maxHeight: 100)
+            // Smooth sinusoidal waveform — same as the transcription processing animation
+            BrandWaveform(maxHeight: 100, isProcessing: true)
+                .opacity(0.5)
                 .padding(.bottom, 24)
-                .onReceive(idleTimer) { _ in
-                    idleEnergy = (0..<30).map { _ in Float.random(in: 0.1...0.4) }
-                }
 
             // "dictus" wordmark
             Text("dictus")

--- a/DictusCore/Sources/DictusCore/Design/BrandWaveform.swift
+++ b/DictusCore/Sources/DictusCore/Design/BrandWaveform.swift
@@ -38,25 +38,47 @@ public struct BrandWaveform: View {
     /// Without this, white bars on a light background are invisible.
     @Environment(\.colorScheme) private var colorScheme
 
+    /// Smoothed display levels for fluid animation.
+    /// WHY @State instead of using energyLevels directly:
+    /// energyLevels arrive at ~60Hz (app) or ~5Hz (keyboard). Direct rendering causes
+    /// either micro-jitter (60Hz) or visible jumps (5Hz). displayLevels lerps toward
+    /// energyLevels every frame, producing smooth motion regardless of input rate.
+    @State private var displayLevels: [Float] = Array(repeating: 0, count: 30)
+
     /// Number of bars to display.
     private let barCount = 30
 
     /// Consistent spacing between bars.
     private let barSpacing: CGFloat = 2
 
+    /// Smoothing factor for lerp interpolation (0 = no change, 1 = instant snap).
+    /// WHY 0.3: Balances responsiveness (voice feels reactive) with smoothness
+    /// (no jitter between frames). Lower values feel sluggish, higher values
+    /// reintroduce the jitter we're trying to fix.
+    private let smoothingFactor: Float = 0.3
+
+    /// Exponential decay factor for bars returning to zero when energy drops.
+    /// WHY separate from smoothingFactor: We want bars to rise quickly (responsive)
+    /// but fall slowly (visually pleasing decay). 0.85 = bars take ~10 frames to
+    /// fully settle, creating a smooth "fade out" instead of a harsh snap to zero.
+    private let decayFactor: Float = 0.85
+
     public var body: some View {
-        if isProcessing {
-            // WHY TimelineView instead of withAnimation:
-            // sin(2π*(x+0)) == sin(2π*(x+1)), so animating a phase from 0→1 produces
-            // identical start/end values — SwiftUI sees no change and nothing moves.
-            // TimelineView gives us a continuous clock to compute the phase from real time.
-            TimelineView(.animation) { timeline in
-                let phase = timeline.date.timeIntervalSinceReferenceDate / 2.0
-                waveformContent(processingPhase: phase)
-            }
-        } else {
-            waveformContent(processingPhase: 0)
-                .animation(.easeOut(duration: 0.08), value: energyLevels)
+        // WHY TimelineView for both recording AND processing:
+        // Recording mode needs continuous frame updates to lerp displayLevels toward
+        // energyLevels. Without TimelineView, SwiftUI only rerenders when energyLevels
+        // changes — which means 5Hz keyboard updates produce 5fps animation.
+        // TimelineView gives us a 60fps render loop for smooth interpolation in both modes.
+        TimelineView(.animation) { timeline in
+            let phase = isProcessing
+                ? timeline.date.timeIntervalSinceReferenceDate / 2.0
+                : 0
+            waveformContent(processingPhase: phase)
+                .onChange(of: timeline.date) { _ in
+                    if !isProcessing {
+                        updateDisplayLevels()
+                    }
+                }
         }
     }
 
@@ -77,10 +99,18 @@ public struct BrandWaveform: View {
             let barWidth = max((size.width - totalSpacing) / CGFloat(barCount), 2)
 
             for index in 0..<barCount {
-                let energy = energyForBar(at: index, processingPhase: processingPhase)
-                // Zero minHeight when NOT processing -- bars disappear at zero energy
-                let minHeight: CGFloat = isProcessing ? 4 : 0
-                let height = max(minHeight + CGFloat(energy) * (maxHeight - minHeight), isProcessing ? 4 : 0)
+                let energy: Float
+                if isProcessing {
+                    energy = processingEnergy(at: index, phase: processingPhase)
+                } else {
+                    energy = index < displayLevels.count ? displayLevels[index] : 0
+                }
+
+                // Minimum bar height so the waveform baseline is always visible,
+                // even in complete silence. 2pt = thin line, enough to see the
+                // colored bar pattern (blue center, gray edges) without looking "active".
+                let minHeight: CGFloat = isProcessing ? 4 : 2
+                let height = max(minHeight + CGFloat(energy) * (maxHeight - minHeight), minHeight)
 
                 let x = CGFloat(index) * (barWidth + barSpacing)
                 let y = (size.height - height) / 2
@@ -93,36 +123,69 @@ public struct BrandWaveform: View {
         .frame(height: maxHeight)
     }
 
-    /// Map bar index to an energy value from the energyLevels array,
-    /// or generate a synthetic sinusoidal value when in processing mode.
+    /// Update displayLevels toward target energyLevels using lerp + exponential decay.
     ///
-    /// WHY interpolation (normal mode):
-    /// energyLevels may have fewer or more entries than barCount.
-    /// We map each bar position proportionally into the array.
+    /// Called every frame by TimelineView. Each bar interpolates independently:
+    /// - If target > current: lerp UP (responsive to voice)
+    /// - If target < current: decay DOWN (smooth fade-out)
     ///
-    /// WHY sinusoidal (processing mode):
-    /// Creates a smooth traveling wave: each bar computes its energy from a sine
-    /// function offset by processingPhase. The wave "moves" across the bars as
-    /// processingPhase animates from 0 to 1.
-    private func energyForBar(at index: Int, processingPhase: Double) -> Float {
-        if isProcessing {
-            let normalizedIndex = Double(index) / Double(max(barCount - 1, 1))
-            let sineValue = sin(2 * .pi * (normalizedIndex + processingPhase))
-            // Map sine (-1...1) to energy (0.2...0.7) for a subtle ambient effect
-            return Float(0.2 + 0.25 * (sineValue + 1.0))
+    /// WHY lerp for rise, decay for fall:
+    /// Rising bars should feel snappy (voice → immediate visual response).
+    /// Falling bars should feel natural (voice stops → gradual settle, not a snap).
+    private func updateDisplayLevels() {
+        let targets = targetLevels()
+
+        var updated = displayLevels
+        for i in 0..<barCount {
+            let target = i < targets.count ? targets[i] : Float(0)
+            let current = updated[i]
+
+            if target > current {
+                // Rising: lerp toward target
+                updated[i] = current + (target - current) * smoothingFactor
+            } else {
+                // Falling: exponential decay toward target
+                updated[i] = target + (current - target) * decayFactor
+            }
+
+            // Snap to zero below perceptual threshold to avoid infinite decay
+            if updated[i] < 0.005 {
+                updated[i] = 0
+            }
         }
 
-        guard !energyLevels.isEmpty else { return 0 }
-        let position = Float(index) / Float(max(barCount - 1, 1))
-        let arrayIndex = position * Float(energyLevels.count - 1)
-        let lower = Int(arrayIndex)
-        let upper = min(lower + 1, energyLevels.count - 1)
-        let fraction = arrayIndex - Float(lower)
-        let value = energyLevels[lower] * (1 - fraction) + energyLevels[upper] * fraction
-        // Silence threshold: ambient mic noise produces small non-zero energy (0.01-0.05).
-        // Treat anything below 0.05 as true silence so bars are perfectly still.
-        let thresholded = value < 0.05 ? Float(0) : value
-        return min(max(thresholded, 0), 1)
+        displayLevels = updated
+    }
+
+    /// Map energyLevels (variable count) to exactly barCount target values.
+    /// Applies silence thresholding to eliminate ambient mic noise.
+    private func targetLevels() -> [Float] {
+        guard !energyLevels.isEmpty else {
+            return Array(repeating: Float(0), count: barCount)
+        }
+
+        var result = [Float]()
+        for index in 0..<barCount {
+            let position = Float(index) / Float(max(barCount - 1, 1))
+            let arrayIndex = position * Float(energyLevels.count - 1)
+            let lower = Int(arrayIndex)
+            let upper = min(lower + 1, energyLevels.count - 1)
+            let fraction = arrayIndex - Float(lower)
+            let value = energyLevels[lower] * (1 - fraction) + energyLevels[upper] * fraction
+            // Silence threshold: ambient mic noise produces small non-zero energy (0.01-0.05).
+            // Treat anything below 0.05 as true silence so bars are perfectly still.
+            let thresholded = value < 0.05 ? Float(0) : value
+            result.append(min(max(thresholded, 0), 1))
+        }
+        return result
+    }
+
+    /// Generate sinusoidal energy for processing mode.
+    private func processingEnergy(at index: Int, phase: Double) -> Float {
+        let normalizedIndex = Double(index) / Double(max(barCount - 1, 1))
+        let sineValue = sin(2 * .pi * (normalizedIndex + phase))
+        // Map sine (-1...1) to energy (0.2...0.7) for a subtle ambient effect
+        return Float(0.2 + 0.25 * (sineValue + 1.0))
     }
 
     /// Brand-inspired color resolved to a plain Color for Canvas rendering.


### PR DESCRIPTION
## Summary
- **Waveform reacts to real voice levels**: AudioRecorder now sends only the last 30 energy values instead of the full growing array (600+ values after 10s), so each bar = 1 recent audio chunk
- **Smooth 60fps animation**: BrandWaveform uses internal lerp smoothing (rise) + exponential decay (fall) via TimelineView, fluid in both app (60Hz) and keyboard (5Hz) contexts
- **Visible baseline in silence**: Bars keep a 2pt minimum height so the colored pattern (blue center, gray edges) stays visible even when quiet
- **Onboarding polish**: WelcomePage now uses the smooth sinusoidal processing animation instead of random jittery Timer-based energy

## Files changed
| File | Change |
|------|--------|
| `AudioRecorder.swift` | `.suffix(30)` on both warmUp and startRecording callbacks |
| `BrandWaveform.swift` | `@State displayLevels` + lerp/decay smoothing + TimelineView for recording mode |
| `DictationCoordinator.swift` | Safety cap at 30 values before App Group JSON write |
| `RawAudioCapture.swift` | Rolling window 50 → 30 to match barCount |
| `WelcomePage.swift` | Replace Timer+random with `isProcessing: true` sinusoidal animation |

## Test plan
- [ ] Start recording in silence → bars show thin 2pt baseline (blue center, gray edges)
- [ ] Speak → bars react visibly to voice volume
- [ ] Stop speaking → bars decay progressively (no snap to zero)
- [ ] Test via keyboard → smooth animation despite 5Hz updates
- [ ] Chain multiple recordings → animation never breaks
- [ ] Processing animation (sinusoidal) unchanged
- [ ] Cold start recording → waveform works via RawAudioCapture
- [ ] Onboarding WelcomePage → smooth sine wave animation

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)