### PR TITLE
fix(#71): prevent SIGABRT crash when recording during phone call

### DIFF
--- a/DictusApp/Audio/UnifiedAudioEngine.swift
+++ b/DictusApp/Audio/UnifiedAudioEngine.swift
@@ -10,6 +10,7 @@ import DictusCore
 enum AudioEngineError: Error, LocalizedError {
     case permissionDenied
     case permissionUndetermined
+    case phoneCallActive
 
     var errorDescription: String? {
         switch self {
@@ -17,6 +18,8 @@ enum AudioEngineError: Error, LocalizedError {
             return "Microphone permission denied"
         case .permissionUndetermined:
             return "Microphone permission not yet requested"
+        case .phoneCallActive:
+            return "Micro indisponible pendant un appel"
         }
     }
 }
@@ -268,6 +271,22 @@ class UnifiedAudioEngine: ObservableObject {
 
         let inputNode = engine.inputNode
         let hwFormat = inputNode.outputFormat(forBus: 0)
+
+        // Guard: zero-channel format means hardware is unavailable (phone call active)
+        guard hwFormat.channelCount > 0 else {
+            throw AudioEngineError.phoneCallActive
+        }
+
+        // Guard: detect telephony audio route (phone call in progress)
+        let currentRoute = AVAudioSession.sharedInstance().currentRoute
+        let hasTelephony = currentRoute.outputs.contains {
+            $0.portType == .builtInReceiver
+        } || currentRoute.inputs.contains {
+            $0.portType.rawValue.lowercased().contains("telephony")
+        }
+        if hasTelephony {
+            throw AudioEngineError.phoneCallActive
+        }
 
         // Create converter from hardware format to 16kHz mono
         guard let conv = AVAudioConverter(from: hwFormat, to: targetFormat) else {

--- a/DictusKeyboard/KeyboardRootView.swift
+++ b/DictusKeyboard/KeyboardRootView.swift
@@ -104,6 +104,7 @@ struct KeyboardRootView: View {
                                 showingEmoji = false
                                 state.startRecording()
                             },
+                            statusMessage: state.statusMessage,
                             suggestions: [],
                             suggestionMode: .idle,
                             onSuggestionTap: { _ in }
@@ -137,6 +138,7 @@ struct KeyboardRootView: View {
                     hasFullAccess: controller.hasFullAccess,
                     dictationStatus: state.dictationStatus,
                     onMicTap: { state.startRecording() },
+                    statusMessage: state.statusMessage,
                     suggestions: suggestionState.suggestions,
                     suggestionMode: suggestionState.mode,
                     onSuggestionTap: { index in

--- a/DictusKeyboard/KeyboardState.swift
+++ b/DictusKeyboard/KeyboardState.swift
@@ -266,6 +266,15 @@ class KeyboardState: ObservableObject {
                 coldStartGraceEnd = nil
                 if status == .idle || status == .ready || status == .failed {
                     activeSessionID = nil
+                    // Read and display error message from App Group
+                    if status == .failed, let errorMsg = defaults.string(forKey: SharedKeys.lastError) {
+                        statusMessage = errorMsg
+                        defaults.removeObject(forKey: SharedKeys.lastError)
+                        defaults.synchronize()
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
+                            self?.statusMessage = nil
+                        }
+                    }
                 }
             }
 

--- a/DictusKeyboard/Views/ToolbarView.swift
+++ b/DictusKeyboard/Views/ToolbarView.swift
@@ -15,6 +15,7 @@ struct ToolbarView: View {
     var onMicTap: () -> Void
 
     // Suggestion bar integration parameters (default to idle/empty)
+    var statusMessage: String? = nil
     var suggestions: [String] = []
     var suggestionMode: SuggestionMode = .idle
     var onSuggestionTap: ((Int) -> Void)? = nil
@@ -34,7 +35,13 @@ struct ToolbarView: View {
                 // The gear icon is rarely needed during active typing, and users can
                 // access settings between typing sessions when the bar reverts to idle.
                 HStack {
-                    if suggestions.isEmpty {
+                    if let message = statusMessage {
+                        Text(message)
+                            .font(.caption)
+                            .foregroundColor(.red)
+                            .lineLimit(1)
+                            .frame(maxWidth: .infinity)
+                    } else if suggestions.isEmpty {
                         Link(destination: URL(string: "dictus://")!) {
                             Image(systemName: "gearshape.fill")
                                 .font(.system(size: gearIconSize, weight: .medium))


### PR DESCRIPTION
## Summary

- Add pre-flight checks in `UnifiedAudioEngine.startEngine()` before `installTap(onBus:)` to detect active phone calls
- Two guards: zero-channel audio format detection + telephony route check
- Converts fatal ObjC NSException into catchable Swift `AudioEngineError.phoneCallActive`
- Surface error message ("Micro indisponible pendant un appel") in keyboard toolbar for 3 seconds

## Files changed (4)

| File | Change |
|------|--------|
| `DictusApp/Audio/UnifiedAudioEngine.swift` | +1 error case, +2 guards before installTap |
| `DictusKeyboard/KeyboardState.swift` | Read `lastError` from App Group on `.failed` status |
| `DictusKeyboard/Views/ToolbarView.swift` | Display `statusMessage` text in toolbar |
| `DictusKeyboard/KeyboardRootView.swift` | Pass `statusMessage` to ToolbarView |

## Test plan

- [x] Recording during phone call from app: no crash, mic button does nothing
- [x] Recording during phone call from keyboard: cold start opens app, no crash, returns to idle
- [x] Normal dictation after hanging up: works correctly
- [x] Wispr Flow has identical behavior (market validation)
- [x] Verify no regression on top-row key popups (#69)
- [x] Verify warm start dictation works normally
- [x] Verify cold start dictation works normally

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)