### PR TITLE
fix(#72): audio session conflicts — volume fix + zombie engine recovery

### DIFF
--- a/DictusApp/Audio/UnifiedAudioEngine.swift
+++ b/DictusApp/Audio/UnifiedAudioEngine.swift
@@ -57,6 +57,9 @@ class UnifiedAudioEngine: ObservableObject {
     /// COMPUTED from engine.isRunning — always accurate, fixes #38.
     var isEngineRunning: Bool { engine.isRunning }
 
+    /// Current accumulated sample count (for zombie engine health check).
+    var currentSampleCount: Int { audioSamples.count }
+
     // MARK: - Private
 
     private let engine = AVAudioEngine()
@@ -123,10 +126,15 @@ class UnifiedAudioEngine: ObservableObject {
 
     /// Configure the audio session. Must be called from foreground.
     ///
-    /// WHY these specific options:
-    /// .playAndRecord + [.defaultToSpeaker, .allowBluetooth] matches what WhisperKit uses
-    /// internally in startRecordingLive(). Using the same options ensures WhisperKit's
-    /// transcribe() doesn't conflict with our session config.
+    /// WHY .duckOthers:
+    /// Automatically lowers other apps' volume (~60%) while Dictus's engine is active.
+    /// Matches Wispr Flow behavior — music dips slightly during dictation.
+    /// Note: both .duckOthers and .mixWithOthers hijack AirPods controls (tracked in #85).
+    /// Since AirPods are hijacked either way, .duckOthers gives better volume UX.
+    ///
+    /// WHY no .defaultToSpeaker:
+    /// .defaultToSpeaker routes playback to the loudspeaker, which boosts perceived volume
+    /// when mixed with music. Without it, audio routes normally (earpiece/AirPods).
     ///
     /// WHY setActive every time (no sessionConfigured guard for setActive):
     /// iOS interrupts the audio session when the app goes to background. Even if the
@@ -134,7 +142,7 @@ class UnifiedAudioEngine: ObservableObject {
     func configureAudioSession() throws {
         let session = AVAudioSession.sharedInstance()
         if !sessionConfigured {
-            try session.setCategory(.playAndRecord, options: [.defaultToSpeaker, .allowBluetooth, .mixWithOthers])
+            try session.setCategory(.playAndRecord, options: [.allowBluetooth, .duckOthers])
         }
         try session.setActive(true)
         try? session.setAllowHapticsAndSystemSoundsDuringRecording(true)
@@ -257,6 +265,23 @@ class UnifiedAudioEngine: ObservableObject {
         bufferSeconds = 0
     }
 
+    /// Force restart the engine (stop + removeTap + reconfigure + start).
+    /// Used to recover from zombie engine state where isRunning == true but tap receives no buffers.
+    func forceRestart() {
+        engine.inputNode.removeTap(onBus: 0)
+        engine.stop()
+        sessionConfigured = false
+        PersistentLog.log(.audioEngineStopped)
+
+        do {
+            try configureAudioSession()
+            try startEngine()
+            PersistentLog.log(.engineWarmUpSuccess(context: "forceRestart"))
+        } catch {
+            PersistentLog.log(.engineWarmUpFailed(context: "forceRestart", error: error.localizedDescription))
+        }
+    }
+
     // MARK: - Private Helpers
 
     /// Start the AVAudioEngine with a tap on the input node.
@@ -278,10 +303,11 @@ class UnifiedAudioEngine: ObservableObject {
         }
 
         // Guard: detect telephony audio route (phone call in progress)
+        // WHY only check inputs for "telephony" (not builtInReceiver on outputs):
+        // Without .defaultToSpeaker, iOS routes output to builtInReceiver by default.
+        // That's normal operation, not a phone call indicator.
         let currentRoute = AVAudioSession.sharedInstance().currentRoute
-        let hasTelephony = currentRoute.outputs.contains {
-            $0.portType == .builtInReceiver
-        } || currentRoute.inputs.contains {
+        let hasTelephony = currentRoute.inputs.contains {
             $0.portType.rawValue.lowercased().contains("telephony")
         }
         if hasTelephony {

--- a/DictusApp/DictationCoordinator.swift
+++ b/DictusApp/DictationCoordinator.swift
@@ -279,6 +279,7 @@ class DictationCoordinator: ObservableObject {
                     LiveActivityManager.shared.transitionToRecording()
                     try audioEngine.startRecording()
                     PersistentLog.log(.audioEngineStarted)
+                    await verifyAudioFlow()
                 } catch {
                     PersistentLog.log(.dictationFailed(error: "Warm start: \(error.localizedDescription)"))
                     handleError(error.localizedDescription)
@@ -309,6 +310,7 @@ class DictationCoordinator: ObservableObject {
                     updateStatus(.recording)
                     LiveActivityManager.shared.transitionToRecording()
                     PersistentLog.log(.audioEngineStarted)
+                    await verifyAudioFlow()
 
                     // Load the transcription model in parallel while recording
                     try await ensureEngineReady()
@@ -676,6 +678,44 @@ class DictationCoordinator: ObservableObject {
         }
 
         DarwinNotificationCenter.post(DarwinNotificationName.statusChanged)
+    }
+
+    /// Verify audio samples are actually being captured after startRecording.
+    /// Detects "zombie engine" state where engine.isRunning but tap receives no buffers.
+    /// If 0 samples after 2s, force-restarts the engine and retries once.
+    private func verifyAudioFlow() async {
+        do {
+            try await Task.sleep(nanoseconds: 2_000_000_000)
+        } catch { return } // Task cancelled (user stopped recording)
+
+        guard status == .recording else { return }
+
+        let sampleCount = audioEngine.currentSampleCount
+        if sampleCount > 0 { return } // Healthy — samples flowing
+
+        PersistentLog.log(.dictationFailed(error: "Zombie engine: 0 samples after 2s, force-restarting"))
+
+        // Force restart: stop engine, reconfigure, restart
+        audioEngine.forceRestart()
+        do {
+            try audioEngine.startRecording()
+        } catch {
+            handleError("Micro indisponible. Relancez l'application.")
+            return
+        }
+
+        // Check again after restart
+        do {
+            try await Task.sleep(nanoseconds: 2_000_000_000)
+        } catch { return }
+
+        guard status == .recording else { return }
+
+        if audioEngine.currentSampleCount == 0 {
+            handleError("Micro indisponible. Relancez l'application.")
+        } else {
+            PersistentLog.log(.engineWarmUpSuccess(context: "zombie-recovery"))
+        }
     }
 
     /// Handle errors by updating status and writing error to App Group.


### PR DESCRIPTION
## Summary

- Replace `.defaultToSpeaker` with `.duckOthers` — music now ducks during dictation instead of getting louder
- Fix false positive in phone call detection (#71 guard): `builtInReceiver` is normal output without `.defaultToSpeaker`, only check telephony inputs now
- Add zombie engine health check: detects 0 samples after 2s, force-restarts engine, retries once
- AirPods control hijacking tracked separately in #85

## Files changed (2)

| File | Change |
|------|--------|
| `DictusApp/Audio/UnifiedAudioEngine.swift` | `.duckOthers` + no `.defaultToSpeaker`, fixed phone call guard, `currentSampleCount`, `forceRestart()` |
| `DictusApp/DictationCoordinator.swift` | `verifyAudioFlow()` health check in warm + cold start paths |

## Test plan

- [x] Volume ducks during recording (matches Wispr Flow)
- [x] Normal recording works (warm start + cold start)
- [x] No false "Micro indisponible pendant un appel" error
- [x] Zombie engine recovery (reproduce with Wispr Flow between dictations)
- [x] No regression on top-row key popups (#69)

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)