### PR TITLE
fix(#102): prevent installTap SIGABRT via format guards + ObjC NSException catcher

### DIFF
--- a/Dictus.xcodeproj/project.pbxproj
+++ b/Dictus.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		AA000042 /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = AA900020 /* WhisperKit */; };
 		AA000043 /* RecordingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100043 /* RecordingView.swift */; };
 		AA000045 /* UnifiedAudioEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100045 /* UnifiedAudioEngine.swift */; };
+		AA000200 /* ObjCExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = AA100200 /* ObjCExceptionCatcher.m */; };
 		AA000050 /* ModelManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100050 /* ModelManager.swift */; };
 		AA000051 /* ModelManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100051 /* ModelManagerView.swift */; };
 		AA000060 /* ToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100060 /* ToolbarView.swift */; };
@@ -173,6 +174,9 @@
 		AA100041 /* TranscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionService.swift; sourceTree = "<group>"; };
 		AA100043 /* RecordingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingView.swift; sourceTree = "<group>"; };
 		AA100045 /* UnifiedAudioEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedAudioEngine.swift; sourceTree = "<group>"; };
+		AA100200 /* ObjCExceptionCatcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjCExceptionCatcher.m; sourceTree = "<group>"; };
+		AA100201 /* ObjCExceptionCatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCExceptionCatcher.h; sourceTree = "<group>"; };
+		AA100202 /* DictusApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DictusApp-Bridging-Header.h"; sourceTree = "<group>"; };
 		AA100050 /* ModelManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelManager.swift; sourceTree = "<group>"; };
 		AA100051 /* ModelManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelManagerView.swift; sourceTree = "<group>"; };
 		AA100060 /* ToolbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarView.swift; sourceTree = "<group>"; };
@@ -331,6 +335,7 @@
 				AA100005 /* DictusApp.entitlements */,
 				AA100007 /* Info.plist */,
 				AA100P10 /* PrivacyInfo.xcprivacy */,
+				AA100202 /* DictusApp-Bridging-Header.h */,
 			);
 			path = DictusApp;
 			sourceTree = "<group>";
@@ -413,6 +418,8 @@
 				AA1000F0 /* SpeechModelProtocol.swift */,
 				AA100041 /* TranscriptionService.swift */,
 				AA100045 /* UnifiedAudioEngine.swift */,
+				AA100201 /* ObjCExceptionCatcher.h */,
+				AA100200 /* ObjCExceptionCatcher.m */,
 			);
 			path = Audio;
 			sourceTree = "<group>";
@@ -780,6 +787,7 @@
 				AA000006 /* DictationView.swift in Sources */,
 				AA0000F5 /* LiveActivityManager.swift in Sources */,
 				AA000045 /* UnifiedAudioEngine.swift in Sources */,
+				AA000200 /* ObjCExceptionCatcher.m in Sources */,
 				AA000041 /* TranscriptionService.swift in Sources */,
 				AA000043 /* RecordingView.swift in Sources */,
 				AA000050 /* ModelManager.swift in Sources */,
@@ -1019,6 +1027,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "DictusApp/DictusApp-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
@@ -1041,6 +1050,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "DictusApp/DictusApp-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 			};

--- a/DictusApp/Audio/ObjCExceptionCatcher.h
+++ b/DictusApp/Audio/ObjCExceptionCatcher.h
@@ -1,0 +1,23 @@
+// DictusApp/Audio/ObjCExceptionCatcher.h
+// Tiny Objective-C shim that catches NSException thrown by AVFoundation APIs
+// (installTapOnBus, engine.start) and converts them into a Swift-catchable NSError.
+// Swift's do/catch cannot intercept NSException — the process aborts with SIGABRT.
+// See issues #71 and #102 for crashes this protects against.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ObjCExceptionCatcher : NSObject
+
+/// Execute `block` inside an @try/@catch for NSException.
+/// Returns YES if the block completed normally, NO if it raised an NSException.
+/// On NO, `error` (if non-null) is populated with the exception reason and name.
+/// Swift imports this as `catchException(_:)` which throws on NSException.
++ (BOOL)tryBlock:(__attribute__((noescape)) void (^)(void))block
+           error:(NSError *_Nullable *_Nullable)error
+NS_SWIFT_NAME(catchException(_:));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/DictusApp/Audio/ObjCExceptionCatcher.m
+++ b/DictusApp/Audio/ObjCExceptionCatcher.m
@@ -1,0 +1,27 @@
+// DictusApp/Audio/ObjCExceptionCatcher.m
+#import "ObjCExceptionCatcher.h"
+
+@implementation ObjCExceptionCatcher
+
++ (BOOL)tryBlock:(__attribute__((noescape)) void (^)(void))block
+           error:(NSError *_Nullable *_Nullable)error {
+    @try {
+        block();
+        return YES;
+    } @catch (NSException *exception) {
+        if (error) {
+            NSMutableDictionary *info = [NSMutableDictionary dictionary];
+            info[NSLocalizedDescriptionKey] = exception.reason ?: @"Objective-C exception";
+            info[@"ExceptionName"] = exception.name ?: @"unknown";
+            if (exception.userInfo) {
+                info[@"ExceptionUserInfo"] = exception.userInfo;
+            }
+            *error = [NSError errorWithDomain:@"DictusAudio.ObjCException"
+                                         code:-1
+                                     userInfo:info];
+        }
+        return NO;
+    }
+}
+
+@end

--- a/DictusApp/Audio/UnifiedAudioEngine.swift
+++ b/DictusApp/Audio/UnifiedAudioEngine.swift
@@ -11,6 +11,8 @@ enum AudioEngineError: Error, LocalizedError {
     case permissionDenied
     case permissionUndetermined
     case phoneCallActive
+    case audioHardwareUnavailable
+    case installTapFailed(String)
 
     var errorDescription: String? {
         switch self {
@@ -20,6 +22,10 @@ enum AudioEngineError: Error, LocalizedError {
             return "Microphone permission not yet requested"
         case .phoneCallActive:
             return "Micro indisponible pendant un appel"
+        case .audioHardwareUnavailable:
+            return "Micro indisponible, réessayez dans un instant"
+        case .installTapFailed(let reason):
+            return "Micro indisponible (\(reason))"
         }
     }
 }
@@ -300,11 +306,28 @@ class UnifiedAudioEngine: ObservableObject {
         lastWaveformDiagnosticsWrite = 0
 
         let inputNode = engine.inputNode
-        let hwFormat = inputNode.outputFormat(forBus: 0)
+        var hwFormat = inputNode.outputFormat(forBus: 0)
 
         // Guard: zero-channel format means hardware is unavailable (phone call active)
         guard hwFormat.channelCount > 0 else {
             throw AudioEngineError.phoneCallActive
+        }
+
+        // B.2 — One-shot retry when hardware reports a valid channel count but
+        // sampleRate == 0. Seen on wake-from-URL-scheme: setActive(true) returns
+        // success but the input node hasn't finished negotiating the format.
+        // installTap throws `IsFormatSampleRateAndChannelCountValid` NSException
+        // in that window, causing SIGABRT (#102).
+        if hwFormat.sampleRate == 0 {
+            usleep(50_000)
+            hwFormat = inputNode.outputFormat(forBus: 0)
+        }
+
+        guard hwFormat.sampleRate > 0, hwFormat.channelCount > 0 else {
+            PersistentLog.log(.dictationFailed(
+                error: "invalid hwFormat: sr=\(hwFormat.sampleRate) ch=\(hwFormat.channelCount)"
+            ))
+            throw AudioEngineError.audioHardwareUnavailable
         }
 
         // Guard: detect telephony audio route (phone call in progress)
@@ -332,15 +355,43 @@ class UnifiedAudioEngine: ObservableObject {
         // but the engine isn't running. The next call crashes on installTap.
         inputNode.removeTap(onBus: 0)
 
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: hwFormat) { [weak self] buffer, _ in
-            self?.processBuffer(buffer)
+        // Wrap installTap in an Objective-C @try/@catch. AVFoundation raises an
+        // NSException (uncatchable in Swift) when the format is invalid in ways
+        // our pre-flight guards don't cover (#71, #102). Without this shim the
+        // process aborts with SIGABRT. Swift imports the Objective-C
+        // `tryBlock:error:` as a throwing method.
+        do {
+            try ObjCExceptionCatcher.catchException {
+                inputNode.installTap(onBus: 0, bufferSize: 4096, format: hwFormat) { [weak self] buffer, _ in
+                    self?.processBuffer(buffer)
+                }
+            }
+        } catch {
+            let reason = (error as NSError).localizedDescription
+            PersistentLog.log(.dictationFailed(error: "installTap NSException: \(reason)"))
+            throw AudioEngineError.installTapFailed(reason)
         }
 
+        // engine.start() can throw both Swift errors (AUIOClient_StartIO) and
+        // Objective-C NSExceptions. Wrap in both ObjCExceptionCatcher AND Swift do/catch.
+        var swiftStartError: Error?
         do {
-            try engine.start()
+            try ObjCExceptionCatcher.catchException {
+                do {
+                    try self.engine.start()
+                } catch {
+                    swiftStartError = error
+                }
+            }
         } catch {
             inputNode.removeTap(onBus: 0)
-            throw error
+            let reason = (error as NSError).localizedDescription
+            PersistentLog.log(.dictationFailed(error: "engine.start NSException: \(reason)"))
+            throw AudioEngineError.installTapFailed(reason)
+        }
+        if let swiftStartError {
+            inputNode.removeTap(onBus: 0)
+            throw swiftStartError
         }
 
         if #available(iOS 14.0, *) {

--- a/DictusApp/DictationCoordinator.swift
+++ b/DictusApp/DictationCoordinator.swift
@@ -256,7 +256,11 @@ class DictationCoordinator: ObservableObject {
 
         PersistentLog.log(.dictationStarted(fromURL: fromURL, appState: "\(appState.rawValue)", engineRunning: audioEngine.isEngineRunning))
 
-        // Check if a model is downloaded and ready
+        // Check if a model is downloaded and ready.
+        // Force a cross-process sync before reading — right after a URL-scheme wake
+        // the App Group defaults can return a stale `false`, producing a bogus
+        // "no model downloaded" error on the first attempt (observed in #102).
+        defaults.synchronize()
         let modelReady = defaults.bool(forKey: SharedKeys.modelReady)
         guard modelReady else {
             PersistentLog.log(.dictationFailed(error: "No model downloaded"))

--- a/DictusApp/DictusApp-Bridging-Header.h
+++ b/DictusApp/DictusApp-Bridging-Header.h
@@ -1,0 +1,4 @@
+// DictusApp/DictusApp-Bridging-Header.h
+// Bridging header for DictusApp target — exposes Objective-C code to Swift.
+
+#import "Audio/ObjCExceptionCatcher.h"

--- a/DictusApp/Info.plist
+++ b/DictusApp/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>10</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusKeyboard/Info.plist
+++ b/DictusKeyboard/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.0</string>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>10</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>


### PR DESCRIPTION
## Summary

- **Three-layer defense** against `installTapOnBus` NSException crashes (`SIGABRT`) reported in #102
- **A.** Guard `hwFormat.sampleRate > 0` + one-shot 50ms retry when hardware reports invalid format on wake from URL scheme
- **B.** Force `defaults.synchronize()` before `modelReady` read — fixes false "no model downloaded" error after cold start
- **C.** Wrap `installTap` + `engine.start()` in Objective-C `@try/@catch` shim (`ObjCExceptionCatcher`) — converts uncatchable NSException into recoverable Swift error with logging

## Files changed

| File | Change |
|---|---|
| `UnifiedAudioEngine.swift` | Format guard, retry, ObjC wrapper, 2 new enum cases |
| `DictationCoordinator.swift` | `synchronize()` before `modelReady` read |
| `ObjCExceptionCatcher.h/.m` | **New** — ObjC `@try/@catch` → `NSError` shim |
| `DictusApp-Bridging-Header.h` | **New** — imports ObjC header |
| `project.pbxproj` | Register new files + bridging header setting |
| `Info.plist` ×2 | Build number 9 → 10 |

## Test plan

- [x] xcodebuild Debug + Release: **BUILD SUCCEEDED**
- [x] Warm start dictation (app open → mic → speak → stop → transcription)
- [x] Cold start dictation (app killed → keyboard mic → URL scheme → speak → stop)
- [x] 2 days of daily usage with no crash or regression
- [x] No visual regression (layout, overlay, waveform, Dynamic Island unchanged)

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)