### PR TITLE
fix(#107,#75,#67): overhaul keyboard correction UX, haptics, and autocorrect safety

### DIFF
--- a/DictusCore/Sources/DictusCore/HapticFeedback.swift
+++ b/DictusCore/Sources/DictusCore/HapticFeedback.swift
@@ -89,7 +89,7 @@ public enum HapticFeedback {
     /// Calling prepare() on every touchDown ensures the engine is ready for
     /// the NEXT tap even during rapid typing (>6 taps/second).
     public static func prepareForNextTap() {
-        lightGenerator.prepare()
+        selectionGenerator.prepare()
     }
     #endif
 
@@ -133,16 +133,23 @@ public enum HapticFeedback {
         #endif
     }
 
-    /// Light impact feedback for keyboard key taps.
+    /// Selection feedback for keyboard key taps.
     ///
-    /// WHY .light style: Matches the native iOS keyboard tactile feel.
-    /// Users expect key taps to be subtle -- heavier feedback would feel wrong
-    /// compared to the system keyboard they're used to.
-    ///
-    /// WHY .prepare() after impactOccurred():
-    /// Calling prepare() immediately after firing re-primes the Taptic Engine
-    /// for the next tap. This keeps latency at ~0ms for rapid typing.
+    /// WHY selectionGenerator instead of lightGenerator:
+    /// UIImpactFeedbackGenerator(.light) feels noticeably heavier than Apple's
+    /// native keyboard. UISelectionFeedbackGenerator produces the subtle "tick"
+    /// Apple uses for pickers — closer to the native keyboard feel.
     public static func keyTapped() {
+        #if canImport(UIKit) && !os(macOS)
+        guard isEnabled() else { return }
+        selectionGenerator.selectionChanged()
+        selectionGenerator.prepare()
+        #endif
+    }
+
+    /// Light impact feedback when autocorrect changes a word.
+    /// Slightly stronger than a normal key tap to signal "something changed".
+    public static func autocorrectApplied() {
         #if canImport(UIKit) && !os(macOS)
         guard isEnabled() else { return }
         lightGenerator.impactOccurred()

--- a/DictusCore/Sources/DictusCore/UserDictionary.swift
+++ b/DictusCore/Sources/DictusCore/UserDictionary.swift
@@ -32,9 +32,10 @@ public final class UserDictionary {
     /// Stored as [String: Int] where key = lowercase word, value = times typed.
     private static let pendingKey = "dictus.userDictionary.pending"
 
-    /// Number of times an unknown word must be typed before it's learned.
-    /// 2 is the sweet spot: first time could be a typo, second time is intentional.
-    public static let repetitionThreshold = 2
+    /// Number of times an unknown word must be typed/rejected before it's learned.
+    /// 1 = learn immediately. Safe now that autocorrect undo requires an intentional
+    /// tap in the suggestion bar (no more accidental backspace-undo learning).
+    public static let repetitionThreshold = 1
 
     /// Maximum number of learned words. When exceeded, the least-used words
     /// are dropped. 1000 words ≈ 30 KB in UserDefaults — negligible for memory.

--- a/DictusKeyboard/DictusKeyboardBridge.swift
+++ b/DictusKeyboard/DictusKeyboardBridge.swift
@@ -178,10 +178,6 @@ final class DictusKeyboardBridge: NSObject,
     /// then rechecks autocapitalization (e.g., typing "." may prepare shift for next char).
     /// NOTE: Haptic fires in GiellaKeyboardView.touchesBegan() for ALL keys on touchDown.
     private func handleInputKey(_ character: String) {
-        // Invalidate autocorrect undo -- any new character input means the user
-        // accepted the correction. Only immediate backspace should undo.
-        suggestionState?.lastAutocorrect = nil
-
         // Clear rejected words when starting a new word
         if suggestionState?.currentWord.isEmpty == true {
             suggestionState?.rejectedWords.removeAll()
@@ -213,52 +209,25 @@ final class DictusKeyboardBridge: NSObject,
         suggestionState?.updateAsync(context: context)
     }
 
-    /// Handle backspace/delete key with autocorrect undo support.
-    ///
-    /// If the user presses backspace immediately after an autocorrection,
-    /// undo the correction: delete the corrected word + trailing space,
-    /// then re-insert the original word. This matches iOS native behavior
-    /// where backspace after autocorrect restores what the user actually typed.
+    /// Handle backspace/delete key. Always deletes one character.
+    /// Autocorrect undo is handled by tapping the suggestion bar, not backspace.
     private func handleBackspace() {
         AudioServicesPlaySystemSound(KeySound.delete)
 
-        // Check for autocorrect undo: if the last action was an autocorrection,
-        // pressing backspace undoes it instead of deleting a single character.
-        if let autocorrect = suggestionState?.lastAutocorrect {
-            let proxy = controller?.textDocumentProxy
-            // Delete the correction + the trailing space that was auto-inserted
-            let deleteCount = autocorrect.correctedWord.count + (autocorrect.insertedSpace ? 1 : 0)
-            for _ in 0..<deleteCount {
-                proxy?.deleteBackward()
-            }
-            proxy?.insertText(autocorrect.originalWord)
-            // Mark this word as rejected so it won't be re-corrected on next space
-            suggestionState?.rejectedWords.insert(autocorrect.originalWord.lowercased())
-            suggestionState?.lastAutocorrect = nil
-
-            // Record rejection as a usage signal — NOT immediate learning.
-            // A single rejection might mean "wrong correction, let me retype"
-            // (e.g., user typed "doee" meaning to type "dieu", correction was wrong,
-            // user undoes but doesn't actually want "doee" learned).
-            // After 2 rejections of the same word, it's learned (user really means it).
-            // This matches iOS native / Gboard / SwiftKey behavior.
-            if UserDictionary.shared.recordUsage(autocorrect.originalWord) {
-                suggestionState?.learnWord(autocorrect.originalWord)
-            }
-            lastInsertedCharacter = autocorrect.originalWord.last.map(String.init)
-            secondToLastInsertedCharacter = nil
-            updateCapitalization()
-            updateAccentKeyDisplay()
-            // Update suggestions for the restored original word
-            let context = proxy?.documentContextBeforeInput
-            suggestionState?.updateAsync(context: context)
-            return
-        }
-
-        // Normal backspace: delete one character
         controller?.textDocumentProxy.deleteBackward()
         secondToLastInsertedCharacter = nil
         lastInsertedCharacter = nil
+
+        // Check if the corrected word is still intact in the text after deletion.
+        // Keep undo alive if either "correctedWord " or "correctedWord" (without space) is found.
+        // This allows undo even after deleting just the trailing space.
+        if let undo = suggestionState?.pendingUndo {
+            let context = controller?.textDocumentProxy.documentContextBeforeInput ?? ""
+            if !context.contains(undo.correctedWord) {
+                suggestionState?.pendingUndo = nil
+            }
+        }
+
         updateCapitalization()
         updateAccentKeyDisplay()
         let context = controller?.textDocumentProxy.documentContextBeforeInput
@@ -275,6 +244,7 @@ final class DictusKeyboardBridge: NSObject,
     /// delete everything from cursor back to that boundary.
     private func handleWordDelete() {
         AudioServicesPlaySystemSound(KeySound.delete)
+        suggestionState?.pendingUndo = nil
         guard let proxy = controller?.textDocumentProxy,
               let before = proxy.documentContextBeforeInput, !before.isEmpty else {
             // Fallback: single character delete if no text context
@@ -323,6 +293,9 @@ final class DictusKeyboardBridge: NSObject,
         AudioServicesPlaySystemSound(KeySound.modifier)
         secondToLastInsertedCharacter = lastInsertedCharacter
 
+        // Next space after autocorrect = undo window closes
+        suggestionState?.pendingUndo = nil
+
         // Read the current word directly from the text field (synchronous, main thread).
         // WHY not use state.currentWord: it's updated by an async background queue.
         // If the user types fast and hits space before the async update completes,
@@ -350,8 +323,6 @@ final class DictusKeyboardBridge: NSObject,
             // Skip autocorrect — insert space normally
             controller?.textDocumentProxy.insertText(" ")
             lastInsertedCharacter = " "
-            // Clear autocorrect state but still trigger predictions
-            suggestionState?.lastAutocorrect = nil
             suggestionState?.clear()
             suggestionState?.rejectedWords.removeAll()
             let ctx = controller?.textDocumentProxy.documentContextBeforeInput
@@ -391,12 +362,13 @@ final class DictusKeyboardBridge: NSObject,
             proxy?.insertText(" ")
             lastInsertedCharacter = " "
 
-            // Store autocorrect state so backspace can undo it
-            state.lastAutocorrect = AutocorrectState(
+            // Store undo state — user can tap suggestion bar to revert
+            state.pendingUndo = AutocorrectState(
                 originalWord: freshWord,
                 correctedWord: result.correction,
                 insertedSpace: true
             )
+            HapticFeedback.autocorrectApplied()
             // Trigger n-gram predictions after autocorrection too.
             // The corrected word + space is now in the proxy — predict what comes next.
             state.clear()
@@ -426,7 +398,7 @@ final class DictusKeyboardBridge: NSObject,
             // Auto-full-stop changed the text (". " instead of "  ").
             // Invalidate any pending autocorrect undo — the text no longer matches
             // what the undo expects, so backspace should not try to restore.
-            suggestionState?.lastAutocorrect = nil
+            suggestionState?.pendingUndo = nil
             lastInsertedCharacter = " "
         }
 
@@ -450,6 +422,7 @@ final class DictusKeyboardBridge: NSObject,
     /// .sentences autocap which should capitalize after a newline.
     private func handleReturn() {
         AudioServicesPlaySystemSound(KeySound.modifier)
+        suggestionState?.pendingUndo = nil
         controller?.textDocumentProxy.insertText("\n")
         secondToLastInsertedCharacter = lastInsertedCharacter
         lastInsertedCharacter = "\n"
@@ -472,7 +445,7 @@ final class DictusKeyboardBridge: NSObject,
         secondToLastInsertedCharacter = nil
 
         // Chain predictions: query n-gram engine for what comes after this word
-        suggestionState?.lastAutocorrect = nil
+        suggestionState?.pendingUndo = nil
         let context = proxy?.documentContextBeforeInput
         suggestionState?.updatePredictions(context: context)
 

--- a/DictusKeyboard/KeyboardRootView.swift
+++ b/DictusKeyboard/KeyboardRootView.swift
@@ -261,14 +261,25 @@ struct KeyboardRootView: View {
             return
         }
 
+        // Undo mode: tap index 0 = revert autocorrect, tap 1-2 = accept completion/prediction
+        if suggestionState.mode == .undoAvailable {
+            if index == 0, let undo = suggestionState.pendingUndo {
+                performUndo(undo: undo, proxy: proxy)
+                suggestionState.pendingUndo = nil
+                suggestionState.clear()
+            } else {
+                suggestionState.pendingUndo = nil
+                bridge?.handlePredictionTap(word: suggestion)
+            }
+            HapticFeedback.keyTapped()
+            return
+        }
+
         if suggestionState.mode == .corrections {
-            // Tapping the original word (index 0) = user rejects the correction
             if index == 0 {
                 suggestionState.rejectedWords.insert(suggestion.lowercased())
-                // Insert space after original word (user accepted it as-is)
                 proxy.insertText(" ")
             } else {
-                // Apply the correction or alternative
                 replaceCurrentWord(
                     proxy: proxy,
                     currentWord: suggestionState.currentWord,
@@ -276,7 +287,7 @@ struct KeyboardRootView: View {
                     addSpace: true
                 )
             }
-            suggestionState.lastAutocorrect = nil
+            suggestionState.pendingUndo = nil
             suggestionState.clear()
             HapticFeedback.keyTapped()
             return
@@ -290,9 +301,50 @@ struct KeyboardRootView: View {
             addSpace: addSpace
         )
 
-        suggestionState.lastAutocorrect = nil
+        suggestionState.pendingUndo = nil
         suggestionState.clear()
         HapticFeedback.keyTapped()
+    }
+
+    /// Reverts an autocorrection, preserving any characters typed after the correction.
+    private func performUndo(undo: AutocorrectState, proxy: UITextDocumentProxy) {
+        guard let context = proxy.documentContextBeforeInput else { return }
+
+        // Try to find the corrected word with trailing space first, then without
+        // (user may have deleted the space but the word is still intact).
+        let correctedWithSpace = undo.correctedWord + " "
+        let range: Range<String.Index>
+        let matchedWithSpace: Bool
+
+        if undo.insertedSpace, let r = context.range(of: correctedWithSpace, options: .backwards) {
+            range = r
+            matchedWithSpace = true
+        } else if let r = context.range(of: undo.correctedWord, options: .backwards) {
+            range = r
+            matchedWithSpace = false
+        } else {
+            return
+        }
+
+        let afterCorrection = String(context[range.upperBound...])
+        let matchLength = matchedWithSpace ? correctedWithSpace.count : undo.correctedWord.count
+        let deleteCount = matchLength + afterCorrection.count
+
+        for _ in 0..<deleteCount {
+            proxy.deleteBackward()
+        }
+
+        proxy.insertText(undo.originalWord)
+        if matchedWithSpace {
+            proxy.insertText(" ")
+        }
+        proxy.insertText(afterCorrection)
+
+        suggestionState.rejectedWords.insert(undo.originalWord.lowercased())
+
+        if UserDictionary.shared.recordUsage(undo.originalWord) {
+            suggestionState.learnWord(undo.originalWord)
+        }
     }
 
     /// Replaces the word currently being typed with a replacement string.

--- a/DictusKeyboard/KeyboardViewController.swift
+++ b/DictusKeyboard/KeyboardViewController.swift
@@ -401,7 +401,7 @@ class KeyboardViewController: UIInputViewController {
     override func textDidChange(_ textInput: UITextInput?) {
         super.textDidChange(textInput)
         // Invalidate autocorrect undo on external text changes (paste, cursor tap, host autocorrect).
-        bridge?.suggestionState?.lastAutocorrect = nil
+        bridge?.suggestionState?.pendingUndo = nil
         // When text changes externally (paste, cursor move, autocorrect by host app),
         // recheck autocapitalization. This ensures shift state stays correct even when
         // the user moves the cursor to a different position in the text.

--- a/DictusKeyboard/TextPrediction/AOSPTrieEngine.swift
+++ b/DictusKeyboard/TextPrediction/AOSPTrieEngine.swift
@@ -29,11 +29,69 @@ final class AOSPTrieEngine {
 
     /// Per-language hard-coded corrections that the trie can't infer from edit distance alone.
     /// French: "ca" is never valid -- always the unaccented form of "ça".
+    /// English: common contractions typed without apostrophe ("im" → "I'm", "dont" → "don't").
     /// Short words (<=2 chars) are too ambiguous for generic spell correction
     /// (e.g., "ou"/"où", "a"/"à" depend on grammar), so we only correct known cases.
     private static let languageOverrides: [String: [String: String]] = [
-        "fr": ["ca": "\u{00E7}a"],  // "ca" -> "ça"
-        "en": [:],
+        // Common unambiguous accent-missing words. These are NOT valid French without accents.
+        // Excluded: "a"/"à" (both valid), "ou"/"où" (both valid), "meme" (could be English)
+        "fr": [
+            "ca": "\u{00E7}a",            // ca -> ça
+            "tres": "tr\u{00E8}s",        // tres -> très
+            "apres": "apr\u{00E8}s",      // apres -> après
+            "deja": "d\u{00E9}j\u{00E0}", // deja -> déjà
+            "ete": "\u{00E9}t\u{00E9}",   // ete -> été
+            "etre": "\u{00EA}tre",         // etre -> être
+            "voila": "voil\u{00E0}",       // voila -> voilà
+            "bientot": "bient\u{00F4}t",   // bientot -> bientôt
+            "plutot": "plut\u{00F4}t",     // plutot -> plutôt
+            "probleme": "probl\u{00E8}me", // probleme -> problème
+            "systeme": "syst\u{00E8}me",   // systeme -> système
+            "etait": "\u{00E9}tait",       // etait -> était
+            "etaient": "\u{00E9}taient",   // etaient -> étaient
+            "evenement": "\u{00E9}v\u{00E9}nement", // evenement -> événement
+        ],
+        // Only unambiguous contractions — words that are NOT valid English on their own.
+        // Excluded: "were" (we're), "well" (we'll), "wed" (we'd), "ill" (I'll),
+        // "id" (I'd), "hell" (he'll), "hed" (he'd), "shed" (she'd), "shell" (she'll),
+        // "its" (it's), "lets" (let's), "wont" (won't) — all valid standalone words.
+        "en": [
+            "im": "i'm",
+            "ive": "i've",
+            "dont": "don't",
+            "doesnt": "doesn't",
+            "didnt": "didn't",
+            "cant": "can't",
+            "couldnt": "couldn't",
+            "wouldnt": "wouldn't",
+            "shouldnt": "shouldn't",
+            "wasnt": "wasn't",
+            "isnt": "isn't",
+            "arent": "aren't",
+            "werent": "weren't",
+            "hasnt": "hasn't",
+            "havent": "haven't",
+            "hadnt": "hadn't",
+            "youre": "you're",
+            "youve": "you've",
+            "youll": "you'll",
+            "youd": "you'd",
+            "theyre": "they're",
+            "theyve": "they've",
+            "theyll": "they'll",
+            "theyd": "they'd",
+            "weve": "we've",
+            "hes": "he's",
+            "shes": "she's",
+            "itll": "it'll",
+            "thats": "that's",
+            "thatll": "that'll",
+            "whats": "what's",
+            "whos": "who's",
+            "wholl": "who'll",
+            "theres": "there's",
+            "heres": "here's",
+        ],
         "es": [:]
     ]
 
@@ -162,6 +220,153 @@ final class AOSPTrieEngine {
 
     /// Number of words in the loaded dictionary.
     var dictionarySize: Int { wordCount }
+
+    /// Check if a word exists in the trie dictionary.
+    func wordExists(_ word: String) -> Bool {
+        guard bridge.isLoaded() else { return false }
+        return bridge.wordExists(word)
+    }
+
+    /// Get the frequency of a word in the trie (0 if not found).
+    func wordFrequency(_ word: String) -> UInt16 {
+        guard bridge.isLoaded() else { return 0 }
+        return UInt16(bridge.getFrequency(word))
+    }
+
+    /// Try to expand a word into a French contraction with apostrophe.
+    /// "Cest" → "c'est", "lhomme" → "l'homme", "jai" → "j'ai"
+    func contractionExpansion(_ word: String) -> String? {
+        guard bridge.isLoaded() else { return nil }
+        let lowered = word.lowercased()
+        guard lowered.count >= 2 else { return nil }
+
+        let knownPrefixes = ["l'", "d'", "c'", "j'", "n'", "s'", "m'", "t'"]
+        // Try 1-char prefix (l', d', c', j', n', s', m', t')
+        let oneCharPrefix = String(lowered.prefix(1)) + "'"
+        let oneCharSuffix = String(lowered.dropFirst(1))
+        if knownPrefixes.contains(oneCharPrefix),
+           !oneCharSuffix.isEmpty,
+           bridge.wordExists(oneCharSuffix) {
+            return oneCharPrefix + oneCharSuffix
+        }
+
+        // Try 2-char prefix (qu')
+        if lowered.count >= 3 {
+            let twoCharPrefix = String(lowered.prefix(2)) + "'"
+            let twoCharSuffix = String(lowered.dropFirst(2))
+            if twoCharPrefix == "qu'",
+               !twoCharSuffix.isEmpty,
+               bridge.wordExists(twoCharSuffix) {
+                return twoCharPrefix + twoCharSuffix
+            }
+        }
+
+        return nil
+    }
+
+    /// Try adding accents to an unaccented word and check if the result exists.
+    /// "deja" → "déjà", "apres" → "après", "ete" → "été", "tres" → "très"
+    ///
+    /// Users commonly type without accents expecting autocorrect to add them.
+    /// This method generates accent variants and picks the highest-frequency match
+    /// to avoid selecting rare words (e.g., "âpres" over "après").
+    func accentExpansion(_ word: String) -> String? {
+        guard bridge.isLoaded() else { return nil }
+        let lowered = word.lowercased()
+        guard lowered.count >= 2 else { return nil }
+
+        let accentMap: [Character: [Character]]
+        if currentLanguage == "fr" {
+            accentMap = [
+                "e": ["é", "è", "ê", "ë"],
+                "a": ["à", "â"],
+                "i": ["î", "ï"],
+                "o": ["ô"],
+                "u": ["ù", "û", "ü"],
+                "c": ["ç"],
+            ]
+        } else if currentLanguage == "es" {
+            accentMap = [
+                "a": ["á"],
+                "e": ["é"],
+                "i": ["í"],
+                "o": ["ó"],
+                "u": ["ú", "ü"],
+                "n": ["ñ"],
+            ]
+        } else if currentLanguage == "de" {
+            accentMap = [
+                "a": ["ä"],
+                "o": ["ö"],
+                "u": ["ü"],
+                "s": ["ß"],
+            ]
+        } else {
+            return nil
+        }
+
+        var accentablePositions: [(Int, [Character])] = []
+        let chars = Array(lowered)
+        for (i, ch) in chars.enumerated() {
+            if let accents = accentMap[ch] {
+                accentablePositions.append((i, accents))
+            }
+        }
+
+        guard !accentablePositions.isEmpty else { return nil }
+
+        // Collect ALL valid matches with their frequency, then pick the best.
+        // This prevents "apres" → "âpres" (rare) when "après" (common) exists.
+        // Uses getFrequency as primary ranking, wordExists as fallback.
+        var bestMatch: String?
+        var bestFreq: Int = -1
+
+        func checkCandidate(_ candidateWord: String) {
+            let freq = Int(bridge.getFrequency(candidateWord))
+            if freq > 0 && freq > bestFreq {
+                bestMatch = candidateWord
+                bestFreq = freq
+            } else if freq == 0 && bestFreq < 0 && bridge.wordExists(candidateWord) {
+                // Fallback: word exists but getFrequency returns 0 (edge case)
+                bestMatch = candidateWord
+                bestFreq = 0
+            }
+        }
+
+        // Single substitutions
+        for (pos, accents) in accentablePositions {
+            for accent in accents {
+                var candidate = chars
+                candidate[pos] = accent
+                checkCandidate(String(candidate))
+            }
+        }
+
+        // Double substitutions (déjà, après, éléphant, etc.)
+        if accentablePositions.count >= 2 {
+            for i in 0..<accentablePositions.count {
+                for j in (i + 1)..<accentablePositions.count {
+                    let (pos1, accents1) = accentablePositions[i]
+                    let (pos2, accents2) = accentablePositions[j]
+                    for a1 in accents1 {
+                        for a2 in accents2 {
+                            var candidate = chars
+                            candidate[pos1] = a1
+                            candidate[pos2] = a2
+                            checkCandidate(String(candidate))
+                        }
+                    }
+                }
+            }
+        }
+
+        // Only return if an accented version was found with higher frequency than input.
+        let inputFreq = Int(bridge.getFrequency(lowered))
+        if let match = bestMatch, bestFreq > inputFreq {
+            return match
+        }
+        return nil
+    }
 
     // MARK: - N-gram prediction
 

--- a/DictusKeyboard/TextPrediction/SuggestionState.swift
+++ b/DictusKeyboard/TextPrediction/SuggestionState.swift
@@ -15,7 +15,8 @@ enum SuggestionMode {
     case idle
     case completions
     case corrections
-    case predictions  // After space: showing n-gram predicted next words
+    case predictions      // After space: showing n-gram predicted next words
+    case undoAvailable    // After autocorrect: showing undo option for previous correction
 }
 
 /// Tracks the last autocorrection so the user can undo it.
@@ -47,8 +48,9 @@ class SuggestionState: ObservableObject {
     @Published var mode: SuggestionMode = .idle
     @Published var currentWord: String = ""
 
-    /// Tracks the last autocorrection for undo support.
-    var lastAutocorrect: AutocorrectState?
+    /// Tracks an autocorrection that can be undone by tapping the suggestion bar.
+    /// Set when autocorrect fires on space, cleared on next space or undo tap.
+    @Published var pendingUndo: AutocorrectState?
 
     /// Words the user has rejected autocorrection for (undo'd).
     /// After undo, the same word should not be re-corrected on the next space.
@@ -176,7 +178,7 @@ class SuggestionState: ObservableObject {
         // triggered updatePredictions(), and clearing here would race with the
         // async prediction result. Predictions are the correct state after space.
         if let lastChar = context.last, lastChar.isWhitespace || lastChar.isNewline {
-            if mode != .predictions {
+            if mode != .predictions && mode != .undoAvailable {
                 clear()
             }
             return
@@ -232,9 +234,15 @@ class SuggestionState: ObservableObject {
 
                 self.currentWord = partial
 
-                // Spell correction takes priority (standard mobile layout)
-                if let result = spellResult,
+                // Undo available: show original word as first slot, fill remaining with completions
+                if let undo = self.pendingUndo {
+                    var undoSuggestions = [undo.originalWord]
+                    undoSuggestions.append(contentsOf: completions.prefix(2))
+                    self.suggestions = undoSuggestions
+                    self.mode = .undoAvailable
+                } else if let result = spellResult,
                    result.correction.lowercased() != partial.lowercased() {
+                    // Spell correction (standard mobile layout)
                     var correctionSuggestions = [partial, result.correction]
                     if let firstAlt = result.alternatives.first {
                         correctionSuggestions.append(firstAlt)
@@ -319,8 +327,12 @@ class SuggestionState: ObservableObject {
                 guard let self = self else { return }
                 guard !(self.currentSuggestionWork?.isCancelled ?? true) else { return }
 
-                if predictions.isEmpty {
-                    // No predictions available -- stay idle (don't show stale completions)
+                if let undo = self.pendingUndo {
+                    var undoSuggestions = [undo.originalWord]
+                    undoSuggestions.append(contentsOf: predictions.prefix(2))
+                    self.suggestions = undoSuggestions
+                    self.mode = .undoAvailable
+                } else if predictions.isEmpty {
                     self.suggestions = []
                     self.mode = .idle
                 } else {

--- a/DictusKeyboard/TextPrediction/TextPredictionEngine.swift
+++ b/DictusKeyboard/TextPrediction/TextPredictionEngine.swift
@@ -114,7 +114,29 @@ class TextPredictionEngine {
             return nil  // User-learned word: no correction needed
         }
 
-        // Pass 2: trie spell check (proximity-weighted, accent-aware)
+        // Accent expansion runs BEFORE wordExists check.
+        // "tres" may exist in the trie as a low-frequency word, but "très" is far
+        // more common. The accent expansion uses frequency comparison to decide.
+        // "deja" → "déjà", "apres" → "après", "tres" → "très"
+        if let accented = aospTrieEngine.accentExpansion(wordToCheck) {
+            let isCapitalized = word.first?.isUppercase == true
+            return (isCapitalized ? accented.capitalized : accented, [])
+        }
+
+        // Valid word guard: if the word exists in the trie dictionary, it's correct.
+        // This prevents aggressive corrections like "fais" → "vais".
+        // Runs AFTER accent expansion so "tres" → "très" still works.
+        if aospTrieEngine.wordExists(wordToCheck) {
+            return nil
+        }
+
+        // Contraction expansion: "Cest" → "C'est", "jai" → "j'ai"
+        if let expanded = aospTrieEngine.contractionExpansion(word) {
+            let isCapitalized = word.first?.isUppercase == true
+            return (isCapitalized ? expanded.capitalized : expanded, [])
+        }
+
+        // Pass 4: trie spell check (proximity-weighted, accent-aware)
         return aospTrieEngine.spellCheck(word)
     }
 
@@ -214,30 +236,9 @@ class TextPredictionEngine {
             return (newCorrection, Array(newAlternatives.prefix(2)))
         }
 
-        // Word is valid (spellCheck returned nil). Check if any n-gram prediction
-        // is close to the typed word. Example: "je sui" → prediction "suis" at
-        // edit distance 1, with high bigram score → suggest as correction.
-        guard !closePredictions.isEmpty else { return nil }
-
-        let inputScore = aospTrieEngine.bigramScore(for: wordToCheck, after: prevLower)
-
-        guard let best = closePredictions.max(by: { $0.1 < $1.1 }), best.1 > inputScore else {
-            return nil
-        }
-
-        let isCapitalized = word.first?.isUppercase == true
-        let fullCorrection = prefix != nil ? (prefix! + best.0) : best.0
-        let correction = isCapitalized ? fullCorrection.capitalized : fullCorrection
-
-        let alternatives = closePredictions.filter { $0.0 != best.0 }
-            .sorted { $0.1 > $1.1 }
-            .prefix(2)
-            .map { candidate -> String in
-                let full = prefix != nil ? (prefix! + candidate.0) : candidate.0
-                return isCapitalized ? full.capitalized : full
-            }
-
-        return (correction, Array(alternatives))
+        // Word is valid (spellCheck returned nil) — do not override with n-gram
+        // predictions. This prevents "je fais" → "je vais" when "fais" is valid.
+        return nil
     }
 
     /// Levenshtein edit distance between two strings. O(n*m) but strings are

--- a/DictusKeyboard/Views/SuggestionBarView.swift
+++ b/DictusKeyboard/Views/SuggestionBarView.swift
@@ -46,7 +46,7 @@ struct SuggestionBarView: View {
                         // This matches standard iOS keyboard suggestion bar behavior.
                         Text(displayText(suggestion, at: index))
                             .font(.system(size: 15))
-                            .fontWeight(mode == .predictions ? .regular : (index == 1 ? .semibold : .regular))
+                            .fontWeight(fontWeight(at: index))
                             .foregroundColor(Color(.label))
                             .frame(maxWidth: .infinity)
                             .frame(height: 36)
@@ -63,9 +63,23 @@ struct SuggestionBarView: View {
     /// In correction mode, the original word (index 0) is shown in quotes
     /// to indicate it's the "as-typed" option. Matches iOS native behavior
     /// where the unquoted bold center word is the one that gets auto-applied.
+    private func fontWeight(at index: Int) -> Font.Weight {
+        switch mode {
+        case .predictions:
+            return .regular
+        case .undoAvailable:
+            return index == 0 ? .semibold : .regular
+        default:
+            return index == 1 ? .semibold : .regular
+        }
+    }
+
     private func displayText(_ suggestion: String, at index: Int) -> String {
         if mode == .corrections && index == 0 {
             return "\u{201C}\(suggestion)\u{201D}"
+        }
+        if mode == .undoAvailable && index == 0 {
+            return suggestion + " \u{21A9}"
         }
         return suggestion
     }


### PR DESCRIPTION
## Summary

- **Softer haptics**: key taps use `UISelectionFeedbackGenerator` (subtler), distinct haptic on autocorrect to signal "something changed"
- **Autocorrect safety**: never correct valid dictionary words, accent expansion for French/Spanish/German, English contraction overrides (~30), French contraction expansion
- **New undo UX**: suggestion bar shows "original ↩" after autocorrect (persists until next space), backspace is always normal delete
- **Faster learning**: `repetitionThreshold` lowered from 2 to 1 since undo is now always intentional

## Issues

- Closes #107 — autocorrection too aggressive + haptics too strong
- Closes #75 — replaces backspace undo with suggestion bar undo
- Closes #67 — autocorrect undo no longer triggers after typing new characters

## Test plan

- [ ] Type on keyboard → haptic feels lighter than before
- [ ] Type misspelled word + space → slightly stronger haptic on correction
- [ ] "je fais" + space → stays "je fais" (not "je vais")
- [ ] "C'est" + space → stays "C'est" (not "C'et")
- [ ] "Cest" + space → corrected to "C'est"
- [ ] "tres" + space → "très", "apres" → "après", "deja" → "déjà"
- [ ] English: "im" → "i'm", "dont" → "don't", "doesnt" → "doesn't"
- [ ] Type misspelled word + space + type chars → suggestion bar shows "original ↩"
- [ ] Tap "original ↩" → reverts correction, preserves typed text
- [ ] Backspace after autocorrect → deletes character normally (no undo)
- [ ] Next space after correction → undo expires

🤖 Generated with [Claude Code](https://claude.com/claude-code)