### PR TITLE
fix: show build number in Settings → About

### DIFF
--- a/DictusApp/Views/SettingsView.swift
+++ b/DictusApp/Views/SettingsView.swift
@@ -230,14 +230,14 @@ struct SettingsView: View {
         }
     }
 
-    /// App version string from Info.plist.
+    /// App version string from Info.plist — marketing version + build number.
     ///
-    /// WHY Bundle.main.infoDictionary:
-    /// This reads CFBundleShortVersionString (marketing version like "1.0")
-    /// directly from the compiled Info.plist. It updates automatically when
-    /// the version is bumped in Xcode project settings.
+    /// Format: "1.6.0 (10)" — lets testers report bugs against a specific build,
+    /// since TestFlight ships multiple builds under the same marketing version.
     private var appVersion: String {
-        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
+        let marketing = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+        return "\(marketing) (\(build))"
     }
 
     /// Diagnostic detail view showing App Group health.


### PR DESCRIPTION
## Summary

Display format in Settings → About changes from `1.6.0` to `1.6.0 (10)`.

## Why

Multiple TestFlight builds ship under the same marketing version (e.g., 1.6.0 beta builds 9, 10, 11...). Without the build number visible in-app, testers can't tell the team which exact build they hit a bug on.

The log export header already includes the build number — this aligns the Settings UI with that convention.

## Changes

- `DictusApp/Views/SettingsView.swift` — `appVersion` computed property now concatenates `CFBundleShortVersionString` and `CFBundleVersion`.

## Test plan

- [ ] Launch DictusApp, go to Settings → About
- [ ] Verify version row shows `1.6.0 (10)` (or current build)
- [ ] No regression on other About rows (GitHub, Licenses, Diagnostic, Debug Logs, Export logs)

## Follow-up

After merge to main, back-merge main → develop to keep branches aligned.