### PR TITLE
fix(#142): cold-start keyboard layout glitch (toolbar centred)

### DIFF
--- a/DictusKeyboard/KeyboardRootView.swift
+++ b/DictusKeyboard/KeyboardRootView.swift
@@ -151,6 +151,13 @@ struct KeyboardRootView: View {
                 // No bottom spacer -- the UIKit keyboard handles its own height
             }
         }
+        // Issue #142: force the body to fill its hosting frame top-aligned.
+        // Without this, when the hosting view expands from 52→276pt on mic
+        // tap but SwiftUI hasn't yet re-rendered ToolbarView→RecordingOverlay
+        // (1-frame async lag), UIHostingController centres the 52pt toolbar
+        // intrinsic content inside its 276pt frame — and iOS's keyboard-down
+        // animation snapshot freezes that centred-toolbar layout on screen.
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(Color.clear)
         .onChange(of: showsOverlay) { _, isShowing in
             let usedFallback = isShowing && state.activeControllerID == nil

--- a/DictusKeyboard/KeyboardViewController.swift
+++ b/DictusKeyboard/KeyboardViewController.swift
@@ -497,13 +497,6 @@ class KeyboardViewController: UIInputViewController {
             details: "animated=\(animated) memMB=\(MemoryFootprint.residentMB())"
         ))
         PersistentLog.log(.keyboardDidDisappear)
-        KeyboardState.shared.registerControllerDisappearance(controllerID: controllerID)
-        PersistentLog.log(.diagnosticProbe(
-            component: "KeyboardViewController",
-            instanceID: controllerID,
-            action: "registeredDisappearance",
-            details: ""
-        ))
 
         // Tear down the dictation status subscription so this (now-detached)
         // controller no longer reacts when KeyboardState publishes. iOS caches
@@ -512,6 +505,41 @@ class KeyboardViewController: UIInputViewController {
         // viewWillAppear re-subscribes on reattach.
         dictationStatusCancellable?.cancel()
         dictationStatusCancellable = nil
+
+        // Issue #142: skip registerControllerDisappearance during an active
+        // dictation session. iOS calls viewDidDisappear on the keyboard right
+        // before bringing DictusApp foreground for cold-start; an immediate
+        // unregister would flip activeControllerID→nil and isKeyboardVisible
+        // →false, making KeyboardRootView.showsOverlay recompute to false and
+        // SwiftUI swap RecordingOverlay→ToolbarView while hostingConst is still
+        // 276pt. iOS's keyboard-down animation snapshot then captures that
+        // inconsistent layout (toolbar centred in expanded hosting), freezing
+        // it on screen for the duration of the transition.
+        //
+        // The successor controller's registerControllerAppearance overwrites
+        // activeControllerID, so a clean handoff happens automatically. If
+        // the keyboard is truly dismissed during recording (no successor), the
+        // synchronous deinit safety net below catches it.
+        let status = KeyboardState.shared.dictationStatus
+        let isActiveSession = status == .requested
+            || status == .recording
+            || status == .transcribing
+        if isActiveSession {
+            PersistentLog.log(.diagnosticProbe(
+                component: "KeyboardViewController",
+                instanceID: controllerID,
+                action: "skippedUnregister_activeSession",
+                details: "status=\(status.rawValue) activeID=\(KeyboardState.shared.activeControllerID ?? "none")"
+            ))
+        } else {
+            KeyboardState.shared.registerControllerDisappearance(controllerID: controllerID)
+            PersistentLog.log(.diagnosticProbe(
+                component: "KeyboardViewController",
+                instanceID: controllerID,
+                action: "registeredDisappearance",
+                details: ""
+            ))
+        }
 
         // Darwin observers cleaned up by KeyboardState deinit
     }
@@ -546,6 +574,17 @@ class KeyboardViewController: UIInputViewController {
     }
 
     deinit {
+        // Issue #142 safety net: viewDidDisappear skips unregistration during
+        // an active dictation session to avoid a SwiftUI race that produces a
+        // centred-toolbar visual artefact during cold-start handoff. If iOS
+        // deallocates us while we still own activeControllerID (no successor
+        // controller registered, e.g. a truly dismissed keyboard during
+        // recording), unregister now — synchronous deinit is past any SwiftUI
+        // race window so it's safe.
+        if KeyboardState.shared.activeControllerID == controllerID {
+            KeyboardState.shared.registerControllerDisappearance(controllerID: controllerID)
+        }
+
         // Symmetric tear-down for the addChild()/didMove(toParent:) we did in viewDidLoad.
         // Without this, UIKit holds the hosting controller in `children` and SwiftUI may
         // keep its observation graph alive past our own deinit, perpetuating the


### PR DESCRIPTION
## Summary
- Fixes #142: during cold-start dictation, the keyboard toolbar briefly appeared visually centred in the keyboard area before iOS animated the keyboard down for the DictusApp handoff.
- Two surgical changes — one resolves the SwiftUI state-machine race, the other prevents `UIHostingController` from centring transient content during a 1-frame async lag.

## Diagnosis (per `/diagnose` skill)

The bug had two layers:

**H1 — single-handoff race.** `viewDidDisappear` on the outgoing controller fires right before iOS brings DictusApp foreground. The pre-existing code immediately called `registerControllerDisappearance`, flipping `activeControllerID` → `nil` and `isKeyboardVisible` → `false`. `KeyboardRootView.showsOverlay` recomputed `false`, SwiftUI swapped `RecordingOverlay` → `ToolbarView`, all while `hostingHeightConstraint` was still 276pt (expanded recording state).

**H3 — inconsistent SwiftUI/UIKit frame.** Even without the unregistration race, there is a 1-frame window between `hostingHeightConstraint = 276` (synchronous, applied via Combine sink) and SwiftUI re-rendering `ToolbarView` → `RecordingOverlay` (next runloop). During that window, `UIHostingController` centred the 52pt toolbar intrinsic content vertically inside its 276pt frame. iOS's keyboard-down animation snapshotted that layout and froze it on screen for ~500ms.

## Changes

**`KeyboardViewController.viewDidDisappear`** — skip `registerControllerDisappearance` while `dictationStatus` is `.requested` / `.recording` / `.transcribing`. The successor controller's `registerControllerAppearance` overwrites `activeControllerID` automatically. `deinit` keeps a synchronous safety net for the no-successor edge case.

**`KeyboardRootView.body`** — `.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)`. Forces the body to fill its hosting frame top-aligned, so transient toolbar content cannot get centred by the hosting controller during the async re-render window.

## Test plan

- [x] Simulator (iPhone 17 Pro Max, iOS 26.3.1): 5 consecutive cold starts, all clean. Logs show `skippedUnregister_activeSession` firing on every cold-start `viewDidDisappear`, no `showsOverlayChanged isShowing=false` events with active status during the handoff window.
- [x] Physical device (iPhone 17 Pro): user-validated across multiple cold starts — toolbar stays at top, no centred-toolbar artefact.
- [x] Warm starts unaffected (normal `idle → requested → recording → ready` lifecycle preserved).
- [x] Idle dismissal (globe key, field switch) still unregisters cleanly via the original branch.

## Notes

No automated regression test: iOS keyboard-extension cold-start races have no testable seam. Future regressions would manifest visibly on cold-start handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)