### PR TITLE
chore(ci): add GitHub Actions workflow for build + SwiftLint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,13 @@ jobs:
 
   build:
     name: Build (iOS Simulator)
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
+
+      - name: Select Xcode 26.3
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app
 
       - name: Show Xcode version
         run: xcodebuild -version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop, main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: SwiftLint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run SwiftLint
+        uses: norio-nomura/action-swiftlint@3.2.1
+        env:
+          DIFF_BASE: ${{ github.base_ref }}
+        with:
+          args: lint --reporter github-actions-logging
+
+  build:
+    name: Build (iOS Simulator)
+    runs-on: macos-15
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: Install xcbeautify (if missing)
+        run: |
+          if ! command -v xcbeautify >/dev/null 2>&1; then
+            brew install xcbeautify
+          fi
+
+      - name: Cache SwiftPM
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
+            ~/Library/Caches/org.swift.swiftpm
+          key: spm-${{ runner.os }}-${{ hashFiles('Dictus.xcodeproj/project.pbxproj', 'DictusCore/Package.swift') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
+
+      - name: Resolve SwiftPM dependencies
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project Dictus.xcodeproj \
+            -scheme DictusApp
+
+      - name: Build DictusApp (and embedded Keyboard, Widgets, Core)
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -project Dictus.xcodeproj \
+            -scheme DictusApp \
+            -configuration Debug \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath build/DerivedData \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_IDENTITY="" \
+            | xcbeautify --renderer github-actions
+
+      - name: Upload build logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: xcodebuild-logs
+          path: |
+            build/DerivedData/Logs/Build
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,61 @@
+included:
+  - DictusApp
+  - DictusKeyboard
+  - DictusCore/Sources
+  - DictusWidgets
+
+excluded:
+  - build
+  - .build
+  - Library
+  - scripts
+  - designs
+  - DictusCore/.build
+  - DictusKeyboard/Vendored      # vendored giellakbd-ios — keep as-is (see CLAUDE.md)
+  - "**/*.generated.swift"
+
+disabled_rules:
+  - line_length
+  - trailing_whitespace
+  - todo
+  - identifier_name
+  - type_name
+
+opt_in_rules:
+  - empty_count
+  - empty_string
+  - first_where
+  - last_where
+  - explicit_init
+  - closure_spacing
+  - contains_over_first_not_nil
+  - redundant_nil_coalescing
+  - sorted_first_last
+  - unneeded_parentheses_in_closure_argument
+  - vertical_parameter_alignment_on_call
+  - yoda_condition
+
+force_cast: warning
+force_try: warning
+
+force_unwrapping:
+  severity: warning
+
+cyclomatic_complexity:
+  warning: 15
+  error: 25
+
+function_body_length:
+  warning: 80
+  error: 200
+
+type_body_length:
+  warning: 400
+  error: 600
+
+file_length:
+  warning: 600
+  error: 1000
+  ignore_comment_only_lines: true
+
+reporter: "xcode"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,12 +44,29 @@ cd DictusCore
 swift test
 ```
 
+## Continuous Integration
+
+Every pull request runs through GitHub Actions. Two checks must pass before a PR can be merged:
+
+- **SwiftLint** -- enforces style rules defined in `.swiftlint.yml`. Runs on Linux, completes in under a minute.
+- **Build** -- compiles the `DictusApp` scheme (which embeds `DictusKeyboard`, `DictusWidgets`, and depends on `DictusCore`) for iOS Simulator. Runs on macOS, takes 5-10 minutes.
+
+To check locally before pushing:
+
+```bash
+brew install swiftlint
+swiftlint lint
+```
+
+The CI does **not** sign builds, run tests, or upload to TestFlight. Its only job is to catch broken compilations and obvious style regressions.
+
 ## Pull Request Guidelines
 
 - Use a **descriptive title** (e.g., "Fix waveform animation on cold start").
 - **Explain what and why** in the PR description, not just what changed.
 - Keep PRs **focused** -- one feature or fix per PR.
 - Make sure the project builds without warnings before submitting.
+- Verify CI is green before requesting review.
 
 ## No CLA Required
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/getdictus/dictus-ios/actions/workflows/ci.yml"><img src="https://github.com/getdictus/dictus-ios/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
   <img src="https://img.shields.io/badge/platform-iOS%2017%2B-lightgrey.svg" alt="Platform: iOS 17+" />
   <img src="https://img.shields.io/badge/swift-5.9%2B-orange.svg" alt="Swift 5.9+" />


### PR DESCRIPTION
## Summary

Foundation CI pipeline for Dictus. Two checks gate every PR to `develop` / `main`:

- **SwiftLint** (Ubuntu, ~30s) — style rules from `.swiftlint.yml`
- **Build** (macOS, ~5-10 min) — `xcodebuild build` of `DictusApp` scheme with `CODE_SIGNING_ALLOWED=NO`. Covers Keyboard, Widgets, and Core via embedded targets and SPM deps. Caches SwiftPM packages keyed on `project.pbxproj` + `Package.swift` hashes.

## What this is *not*

- ❌ No tests (issue #22 is the next chapter — a `test` job will graft onto this workflow)
- ❌ No signing, no archive, no IPA, no TestFlight upload (manual TestFlight remains the release path)
- ❌ No code refactor — SwiftLint is intentionally lenient at first (no `--strict`, most rules at warning severity, vendored giellakbd-ios excluded)

Local validation done before pushing:
- `swiftlint lint` → 123 violations, 0 errors → lint passes
- `xcodebuild build … CODE_SIGNING_ALLOWED=NO` → `BUILD SUCCEEDED`

## Why now

Project has no automated build verification. Recent PRs have shipped with regressions (cold-start glitch, audio session issues) that a simple compile-check + style baseline would not have caught alone — but they would have caught any of the *other* breaks we narrowly avoided. This is the cheapest, highest-leverage piece of CI to put in place first.

## Tradeoffs / decisions

- **Single build instead of three** — building the `DictusApp` scheme already pulls in Keyboard (extension), Widgets (extension), and Core (SPM dep), so one job covers compilation of the whole app bundle.
- **SwiftLint on Linux** — saves macOS minutes and gives lint feedback in 30s instead of 3 min. SwiftLint runs identically on Linux for this codebase.
- **Lenient lint** — config tuned so the current codebase passes with 0 errors. Warnings serve as a cleanup backlog. Tighten over time.
- **Vendored dir excluded** — `DictusKeyboard/Vendored/` is third-party giellakbd-ios per CLAUDE.md "minimal vendoring" rule.

## Test plan

- [ ] CI workflow triggers on this PR
- [ ] `lint` job passes (exit 0, no errors in `.swiftlint.yml`-configured rules)
- [ ] `build` job passes (`BUILD SUCCEEDED` on macos-15)
- [ ] After merge, badge in README shows green
- [ ] Optional: configure branch protection in GitHub Settings to require these checks before merging

## Follow-ups (separate PRs)

- Branch protection rules on `develop` and `main` (UI-only, Pierre's hand)
- Issue #22 — Xcode test targets and `xcodebuild test` job
- Tighten SwiftLint to `--strict` once warning backlog is cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)