### PR TITLE
chore: bump to 1.6.1 (build 14)

### DIFF
--- a/DictusApp/Info.plist
+++ b/DictusApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>14</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusKeyboard/Info.plist
+++ b/DictusKeyboard/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>14</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusWidgets/Info.plist
+++ b/DictusWidgets/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>14</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
Bump version to 1.6.1 and CFBundleVersion to 14 across all three targets (App / Keyboard / Widgets) ahead of TestFlight upload.

## Why 1.6.1

Patch-only release per `docs/VERSIONING.md` heuristic — develop has accumulated bug fixes since v1.6.0-beta.4 with no new user-facing features.

Includes:
- #134 — keyboard extension retain cycle + memory hardening (PR #135)
- #92  — keyboard load flash partial fix (PR #139)
- #106 — background lifecycle + idle warm-state release + drain throttle (PR #140)
- #142 — cold-start keyboard layout glitch (PR #143)
- CI workflow (PR #145)

🤖 Generated with [Claude Code](https://claude.com/claude-code)