### PR TITLE
Release v1.6.1 (build 14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,13 @@ jobs:
 
   build:
     name: Build (iOS Simulator)
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
+
+      - name: Select Xcode 26.3
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app
 
       - name: Show Xcode version
         run: xcodebuild -version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop, main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: SwiftLint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run SwiftLint
+        uses: norio-nomura/action-swiftlint@3.2.1
+        env:
+          DIFF_BASE: ${{ github.base_ref }}
+        with:
+          args: lint --reporter github-actions-logging
+
+  build:
+    name: Build (iOS Simulator)
+    runs-on: macos-15
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: Install xcbeautify (if missing)
+        run: |
+          if ! command -v xcbeautify >/dev/null 2>&1; then
+            brew install xcbeautify
+          fi
+
+      - name: Cache SwiftPM
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
+            ~/Library/Caches/org.swift.swiftpm
+          key: spm-${{ runner.os }}-${{ hashFiles('Dictus.xcodeproj/project.pbxproj', 'DictusCore/Package.swift') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
+
+      - name: Resolve SwiftPM dependencies
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project Dictus.xcodeproj \
+            -scheme DictusApp
+
+      - name: Build DictusApp (and embedded Keyboard, Widgets, Core)
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -project Dictus.xcodeproj \
+            -scheme DictusApp \
+            -configuration Debug \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath build/DerivedData \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_IDENTITY="" \
+            | xcbeautify --renderer github-actions
+
+      - name: Upload build logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: xcodebuild-logs
+          path: |
+            build/DerivedData/Logs/Build
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.planning/debug/issue-92-approach-b-handoff.md
+++ b/.planning/debug/issue-92-approach-b-handoff.md
@@ -1,0 +1,365 @@
+# Issue #92 — Approche B handoff (refactor self.inputView)
+
+**Branche** : `fix/92-approach-b` (depuis `develop`)
+**Date du handoff** : 2026-04-29
+**Auteur du handoff** : conversation précédente, Claude Opus 4.7
+**Mission** : éliminer DEFINITIVEMENT le flash visuel de chargement du clavier
+
+---
+
+## TL;DR pour la prochaine IA
+
+Le bug #92 : à chaque apparition du clavier Dictus, un rectangle gris de 228pt apparaît visuellement pendant ~500ms. La cause racine est **structurelle** : `self.inputView = kbInputView` déclenche `UIView-Encapsulated-Layout-Height = ~504pt @ priorité 1000` par iOS pendant l'animation d'entrée. Aucune contrainte priorité ≤ 999 ne peut gagner contre 1000.
+
+**Toutes les approches non-invasives ont été épuisées** sur la branche `fix/92-keyboard-load-flash` (déjà commit). L'approche B est le seul vrai fix structurel : retirer `self.inputView = kbInputView` et migrer le layout sur `self.view`, pattern upstream giellakbd-ios. Régression audio à gérer : créer un `KeyboardInputView` 1×1pt invisible juste pour conformer à `UIInputViewAudioFeedback`.
+
+**Effort estimé** : ~80-150 LOC, refactor focalisé dans `DictusKeyboard/KeyboardViewController.swift`. 1-2h de travail + tests device.
+
+---
+
+## Contexte complet
+
+### Le bug
+
+À chaque apparition du clavier Dictus (tap dans Notes, Spotlight pull-down, retour d'app, etc.), pendant ~500ms :
+- iOS impose `UIView-Encapsulated-Layout-Height = 504pt @ priorité 1000` sur `self.inputView`
+- Pendant ce transient, kbInputView est 504pt mais le contenu utile (toolbar 52pt + clavier 224pt = 276pt) ne fait que 276pt
+- Les 228pt restants exposent le chrome gris de UIInputView, créant un flash visuel jarrant
+
+### Architecture actuelle (sur develop)
+
+```
+UIInputViewController (KeyboardViewController)
+└── self.inputView = kbInputView: KeyboardInputView (UIInputView)  ← ICI le bug
+    ├── hosting.view: UIView (UIHostingController contenu SwiftUI)
+    │   └── KeyboardRootView (toolbar FR/mic + recording overlay + emoji picker)
+    └── giellaKeyboard: GiellaKeyboardView (UICollectionView)
+        └── 224pt key grid
+```
+
+Contraintes actuelles sur develop (avant approche B) :
+- `kbInputView.heightAnchor = 276 @ 999` (cassé pendant transient car 1000 > 999)
+- `hosting.top = kbInputView.top @ required`, `hosting.height = 52 @ 999`
+- `keyboard.top = hosting.bottom @ required`, `keyboard.height = 224 @ 999`
+- Pas de `keyboard.bottom`, pas de `hosting.bottom`
+
+### Pattern upstream giellakbd-ios (référence pour approche B)
+
+**Fichier** : `/Users/pierreviviere/dev/giellakbd-ios/Keyboard/Controllers/KeyboardViewController.swift`
+
+Lignes 262-274 (`setupKeyboardContainer`) :
+```swift
+keyboardContainer = UIView()
+keyboardContainer.translatesAutoresizingMaskIntoConstraints = false
+view.addSubview(keyboardContainer)
+keyboardContainer.topAnchor.constraint(equalTo: view.topAnchor).enable(priority: .defaultHigh)
+keyboardContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor).enable(priority: .required)
+keyboardContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor).enable(priority: .required)
+keyboardContainer.bottomAnchor.constraint(equalTo: view.bottomAnchor).enable(priority: .required)
+```
+
+Lignes 98-105 (`initHeightConstraint`) :
+```swift
+private func initHeightConstraint() {
+    // If this is removed, iPhone 5s glitches before finding the correct height.
+    DispatchQueue.main.async {
+        self.heightConstraint = self.keyboardContainer.heightAnchor
+            .constraint(equalToConstant: self.preferredHeight)
+            .enable(priority: UILayoutPriority(999))
+    }
+}
+```
+
+Lignes 360-368 (`viewDidLayoutSubviews`) :
+```swift
+private var isFirstRun = true
+open override func viewDidLayoutSubviews() {
+    if isFirstRun {
+        isFirstRun = false
+        initHeightConstraint()
+    }
+    super.viewDidLayoutSubviews()
+}
+```
+
+**Pourquoi upstream n'a pas le bug** :
+1. `self.inputView` n'est jamais assigné. iOS ne décore pas `self.view` avec la contrainte 1000.
+2. `keyboardContainer` est subview directe de `self.view` avec `top=.defaultHigh`, `bottom=.required`, `leading/trailing=.required`. Pendant le transient, `self.view` est 504pt mais `keyboardContainer` reste 224pt collé en bas.
+3. `heightConstraint` installé en `viewDidLayoutSubviews` first-run via `DispatchQueue.main.async` (commentaire upstream : "If this is removed, iPhone 5s glitches before finding the correct height").
+
+### Régression audio à gérer
+
+`UIDevice.current.playInputClick()` (clic des touches Apple natif) ne marche QUE si `self.inputView` est un `UIView` conforme à `UIInputViewAudioFeedback`. Si on supprime `self.inputView = kbInputView`, le clic des touches devient silencieux.
+
+**Solution proposée** : créer un mini `KeyboardInputView` de 1×1pt, alpha=0 ou hidden=true, assigné à `self.inputView` UNIQUEMENT pour conformer au protocole audio. Tout le layout réel se fait sur `self.view` via `keyboardContainer`. Ce pattern est documenté dans le doc d'analyse comme alternative valide.
+
+`KeyboardInputView` (DictusKeyboard/InputView.swift) est déjà conforme :
+```swift
+class KeyboardInputView: UIInputView, UIInputViewAudioFeedback {
+    var enableInputClicksWhenVisible: Bool { true }
+    convenience init() { self.init(frame: .zero, inputViewStyle: .keyboard) }
+}
+```
+
+### États du clavier à préserver
+
+L'architecture actuelle gère **5 états** via `hostingHeightConstraint` et `giellaKeyboard.isHidden` :
+
+1. **Toolbar mode (idle)** : `hostingHeight = 52pt`, `giellaKeyboard` visible. UI = toolbar(52) + keys(224) = 276pt
+2. **Recording mode** : `hostingHeight = 276pt` (full keyboard area), `giellaKeyboard` visible derrière (recording overlay opaque le couvre)
+3. **Emoji picker mode** : `hostingHeight = 276pt`, `giellaKeyboard.isHidden = true`
+4. **Language switch** : reload du `giellaKeyboard` (destroy + recreate avec nouveau layout/locale)
+5. **Cold start** : `hosting.view.isHidden = true` initialement, dévoilé après `viewWillAppear`
+
+**Tous ces états doivent continuer à fonctionner après l'approche B**.
+
+### Tests de non-régression critiques
+
+Issues à ne PAS régresser (mémoire institutionnelle) :
+
+| Issue | Description | Fichier de test |
+|---|---|---|
+| #56 | Dead zones edge keys | Pas de touches mortes sur les bords |
+| #69 | Top-row key popups clipping | Popups au-dessus du clavier visibles |
+| #99 | Toolbar displacement cold start | Toolbar pas déplacée au démarrage |
+| #116 | Stretched keys on app switch | Pas de touches étirées au retour d'app |
+| #128 | Stale controllers / memory leak | activeControllerID gating |
+| #134 | Retain cycle / grey overlay freeze | Pas de gris non-cliquable après 10 switches |
+| audio | `playInputClick()` actif | Clic Apple sur appui touches |
+| recording overlay | Stretches/contracts smoothly | Pas de flash, transition fluide |
+| emoji picker | Toggle smooth | Pas de flash |
+| language switch | Globe key behavior | Pas de flash, layout correct |
+
+---
+
+## Spec d'implémentation approche B
+
+### Étape 1 — restructurer le layout sur `self.view`
+
+Dans `viewDidLoad` de `KeyboardViewController.swift` :
+
+1. **Créer `kbInputView` minuscule** pour audio uniquement :
+   ```swift
+   let audioInputView = KeyboardInputView(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+   audioInputView.alpha = 0
+   self.inputView = audioInputView
+   ```
+
+2. **Créer `keyboardContainer = UIView()`** comme subview directe de `self.view` :
+   ```swift
+   let container = UIView()
+   container.translatesAutoresizingMaskIntoConstraints = false
+   container.backgroundColor = .clear
+   self.view.addSubview(container)
+   self.keyboardContainer = container
+   ```
+
+3. **Pinner keyboardContainer au pattern upstream** :
+   ```swift
+   let containerTop = container.topAnchor.constraint(equalTo: self.view.topAnchor)
+   containerTop.priority = .defaultHigh  // yields under transient
+   NSLayoutConstraint.activate([
+       containerTop,
+       container.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+       container.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+       container.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+   ])
+   ```
+
+4. **Ajouter hosting.view + giellaKeyboard à `keyboardContainer`** (pas à `kbInputView`) :
+   ```swift
+   container.addSubview(hosting.view)
+   container.addSubview(keyboard)
+   ```
+
+5. **Pinner hosting + keyboard à `keyboardContainer`** (logique actuelle adaptée) :
+   ```swift
+   // hosting top, leading, trailing pinned to container; height as before
+   hosting.view.topAnchor.constraint(equalTo: container.topAnchor)
+   hosting.view.leadingAnchor.constraint(equalTo: container.leadingAnchor)
+   hosting.view.trailingAnchor.constraint(equalTo: container.trailingAnchor)
+   hostingHeight  // 52 @ 999
+   // keyboard top to hosting bottom; bottom to container bottom; height 224 @ 999
+   keyboard.topAnchor.constraint(equalTo: hosting.view.bottomAnchor)
+   keyboard.leadingAnchor.constraint(equalTo: container.leadingAnchor)
+   keyboard.trailingAnchor.constraint(equalTo: container.trailingAnchor)
+   keyboard.bottomAnchor.constraint(equalTo: container.bottomAnchor)
+   keyboardHeight  // 224 @ 999
+   ```
+
+### Étape 2 — installer la heightConstraint via `viewDidLayoutSubviews` first-run
+
+Pattern upstream :
+```swift
+private var hasInstalledHeightConstraint = false
+override func viewDidLayoutSubviews() {
+    if !hasInstalledHeightConstraint {
+        hasInstalledHeightConstraint = true
+        installContainerHeight()
+    }
+    super.viewDidLayoutSubviews()
+}
+
+private func installContainerHeight() {
+    DispatchQueue.main.async {
+        guard let container = self.keyboardContainer else { return }
+        let constraint = container.heightAnchor.constraint(equalToConstant: self.computeKeyboardHeight())
+        constraint.priority = UILayoutPriority(999)
+        constraint.isActive = true
+        self.containerHeightConstraint = constraint
+    }
+}
+```
+
+### Étape 3 — migrer toutes les références `kbInputView` vers `keyboardContainer`
+
+Sites concernés (sur la branche develop actuelle) :
+- `viewDidLoad` : addSubview, constraint setup, heightConstraint sur kbInputView
+- `viewWillAppear` : `disableWindowGestureDelay()`, snapshots
+- `viewDidAppear` : `logLayoutSnapshot()`
+- `handleDictationStatusChange` : `inputView?.setNeedsLayout(); inputView?.layoutIfNeeded()` → utiliser `self.view` ou `keyboardContainer`
+- `reloadKeyboardLayout` : guard `inputView` → guard sur `keyboardContainer`, addSubview/constraint, setNeedsLayout
+- `toggleEmojiPicker` : `inputView?.setNeedsLayout()` → `self.view` ou `keyboardContainer`
+
+### Étape 4 — gestion `hostingHeightConstraint`
+
+Le toggle entre 52pt (toolbar) et 276pt (recording/emoji) reste identique, juste sur `keyboardContainer` au lieu de `kbInputView`. **Important** : pendant recording overlay, hosting.height = container.height (276pt). Hosting overlay couvre le keyboard. Pas besoin de toggle bottom anchor (la solution option E sur fix/92-keyboard-load-flash devient obsolète car le 504pt transient n'existe plus).
+
+### Étape 5 — tests sur device
+
+Build et tester chaque état :
+1. Apparition normale (tap Notes) → flash supprimé ?
+2. Spotlight pull-down → flash supprimé ?
+3. Retour d'app → flash supprimé ?
+4. Cold start → toolbar bien positionnée, pas de displacement ?
+5. Recording overlay → s'étire/contracte sans flash ?
+6. Emoji picker → toggle sans flash ?
+7. Language switch (globe) → reload sans flash ?
+8. Audio click → `playInputClick()` toujours actif sur tap touches ?
+9. Top-row popups → pas clippés ?
+10. Edge keys → réactifs (pas de dead zones bord écran) ?
+11. Switch rapide d'apps (10x) → pas de gris non-cliquable, pas de leak ?
+
+### Étape 6 — bumper le build
+
+Build 14 → 15 dans 3 plists :
+- `DictusApp/Info.plist`
+- `DictusKeyboard/Info.plist`
+- `DictusWidgets/Info.plist`
+
+---
+
+## Risques et gotchas
+
+### Risque 1 : Audio feedback ne marche pas
+
+`playInputClick()` exige que `self.inputView` soit le UIInputView **visible** (selon Apple docs informels). Notre 1×1pt invisible pourrait ne pas suffire.
+
+**Mitigation** : tester en priorité. Si ça ne marche pas, alternatives :
+- `UIDevice.current.playInputClick()` peut être remplacé par `AudioServicesPlaySystemSound(1104)` (clic Apple ID 1104) en fallback
+- Ou rendre l'input view de 1pt mais visible (alpha=1) hors écran (e.g., y=-10)
+
+### Risque 2 : `disableWindowGestureDelay()` ne marche plus
+
+Méthode lit `view.window?.gestureRecognizers` — elle dépend de la window de l'inputView/view. Vérifier que `self.view.window` est toujours accessible avec self.inputView en 1×1pt invisible.
+
+### Risque 3 : `viewDidLayoutSubviews` se déclenche trop souvent
+
+Le first-run guard est important. Sans lui, on réinstalle la heightConstraint à chaque layout pass → fuite de constraints.
+
+### Risque 4 : Recording overlay positionnement vertical
+
+Hosting.view a actuellement `top = kbInputView.top`. Avec keyboardContainer, hosting.view sera `top = keyboardContainer.top`. Comportement identique attendu, mais à vérifier en device : pendant recording, le waveform doit s'afficher centré dans les 276pt du container, pas plus haut que prévu.
+
+### Risque 5 : compute `preferredHeight` / `computeKeyboardHeight()`
+
+La fonction existe déjà dans le code (dans `KeyboardViewController.swift` ou un helper). Elle retourne 276pt. Vérifier qu'elle est appelée au bon moment (après que `traitCollection` est initialisé). Pattern upstream l'appelle dans `installContainerHeight` via `DispatchQueue.main.async` pour différer après la première passe layout.
+
+### Risque 6 : Cold start regression #99
+
+`hosting.view.isHidden = true` initialement, dévoilé en `viewWillAppear`. À préserver tel quel. Aucune raison que keyboardContainer change ça.
+
+### Risque 7 : self.view background color
+
+`self.view` (UIInputViewController.view) a un background par défaut clear. Pendant le transient 504pt (avant que keyboardContainer ne se cale en bas), le top de self.view sera visible si transparent → on voit ce qui est derrière (host app). C'est le comportement upstream et c'est OK. À vérifier que self.view.backgroundColor est bien `.clear`.
+
+---
+
+## Fichiers à modifier
+
+### Modifs principales
+- `/Users/pierreviviere/dev/dictus/DictusKeyboard/KeyboardViewController.swift` — refactor layout
+
+### Modifs build version
+- `/Users/pierreviviere/dev/dictus/DictusApp/Info.plist` — build 14 → 15
+- `/Users/pierreviviere/dev/dictus/DictusKeyboard/Info.plist` — build 14 → 15
+- `/Users/pierreviviere/dev/dictus/DictusWidgets/Info.plist` — build 14 → 15
+
+### Fichiers de référence (lecture seule)
+- `/Users/pierreviviere/dev/dictus/.planning/debug/issue-92-keyboard-flash-analysis.md` — analyse 10-agents, régressions
+- `/Users/pierreviviere/dev/giellakbd-ios/Keyboard/Controllers/KeyboardViewController.swift` — pattern upstream
+  - Lignes 98-110 : `initHeightConstraint`
+  - Lignes 262-274 : `setupKeyboardContainer`
+  - Lignes 360-368 : `viewDidLayoutSubviews` first-run
+- `/Users/pierreviviere/dev/giellakbd-ios/Keyboard/Utility/Utils.swift:217-226` — helper `enable(priority:)`
+
+---
+
+## État actuel des branches au moment du handoff
+
+```
+develop                          ← branche stable, target des PRs
+  └── fix/92-approach-b           ← TU ES ICI, branche de travail
+      (depuis 9437ff0 = dernier commit de develop)
+
+fix/92-keyboard-load-flash       ← approche A + option E commitées
+                                    (a27a980, partial fix)
+                                    Build 14 testé, flash résiduel 228pt
+```
+
+**Ne PAS merger fix/92-keyboard-load-flash dans la nouvelle branche** — l'approche B remplace complètement ces tentatives. Si l'approche B échoue, on pourra toujours revenir à approche A via cherry-pick ou merge.
+
+---
+
+## Critères de succès
+
+L'approche B sera considérée comme un succès si, sur device :
+
+1. ✅ **Le flash 228pt gris a disparu** lors de l'apparition du clavier (Spotlight, Notes, retour d'app)
+2. ✅ Audio click `playInputClick()` toujours actif
+3. ✅ Recording overlay s'étire et se contracte sans flash
+4. ✅ Emoji picker bascule sans flash
+5. ✅ Language switch (globe) sans flash
+6. ✅ Toutes les non-régressions (#56, #69, #99, #116, #128, #134) tiennent
+
+Si tout est OK : commit + push + ouvrir PR vers develop pour merge.
+
+Si flash résiduel inattendu : logger les frame.minY de keyboardContainer, hosting, keyboard via `logLayoutSnapshot` (sonde déjà étendue sur fix/92-keyboard-load-flash) et adapter.
+
+Si régression audio : voir Risque 1, fallback `AudioServicesPlaySystemSound(1104)`.
+
+---
+
+## Mode de travail recommandé
+
+1. **Démarrer en mode plan** (`shift+tab` au début) pour proposer le plan détaillé avant d'écrire du code
+2. **Lire les fichiers de référence** avant de planifier (analysis doc + upstream)
+3. **Build après chaque étape majeure** (`xcodebuild -project Dictus.xcodeproj -scheme DictusKeyboard -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`)
+4. **Demander à Pierre de tester sur device** avant de commit. Pierre teste sur iPhone 17 Pro / iOS 26.3.1 via TestFlight ou run direct
+5. **Ne PAS push avant retour positif de Pierre**
+6. **Commit message** : `fix(#92): refactor self.inputView to eliminate 504pt transient flash` + body détaillé
+
+---
+
+## Glossaire
+
+- **Transient** : la fenêtre de ~500ms pendant laquelle iOS impose `UIView-Encapsulated-Layout-Height = 504pt @ priority 1000` sur `self.inputView`
+- **kbInputView** : l'instance actuelle de `KeyboardInputView` assignée à `self.inputView` (à RETIRER ou réduire à 1×1pt)
+- **keyboardContainer** : nouveau UIView, subview directe de `self.view`, qui hébergera hosting + giellaKeyboard
+- **giellaKeyboard** : la `GiellaKeyboardView` qui contient les touches AZERTY (UICollectionView)
+- **hosting** : le `UIHostingController<KeyboardRootView>` qui contient toolbar SwiftUI + recording overlay + emoji picker
+- **bridge** : `DictusKeyboardBridge`, adaptateur giellakbd-ios delegate → Dictus actions
+
+---
+
+Bonne chance. La doc d'analyse `.planning/debug/issue-92-keyboard-flash-analysis.md` est ta meilleure amie pour les régressions à éviter et les hypothèses déjà testées.

--- a/.planning/debug/issue-92-fresh-start-handoff.md
+++ b/.planning/debug/issue-92-fresh-start-handoff.md
@@ -1,0 +1,183 @@
+# Issue #92 — Fresh start handoff (2026-04-30)
+
+**Branche actuelle** : `fix/92-approach-b`
+**Repartir de** : commit `9437ff0` (HEAD de develop)
+**État au moment du handoff** : 4 itérations testées sur cette branche, aucune n'a résolu le bug visuel. Toutes en WIP non commitées (peuvent être reset proprement).
+
+---
+
+## Le bug, sans interpretation
+
+À chaque apparition du clavier Dictus, pendant ~500ms après `viewDidAppear`, l'utilisateur perçoit une transition visible : **le clavier semble "grandir" / s'ajuster en taille avant d'arriver à sa position finale**. Une zone d'environ **228pt de hauteur** apparaît AU-DESSUS de la zone clavier utile (au-dessus de la barre toolbar Dictus FR+mic), et disparaît après ~500ms.
+
+**Reproduction la plus dramatique** :
+1. iPhone 17 Pro / iOS 26.3.1
+2. Spotlight pull-down depuis l'écran d'accueil → tap dans la barre de recherche
+3. Le clavier apparaît avec ~228pt de zone supplémentaire au-dessus pendant ~500ms
+
+Reproductible aussi : tap dans Notes, retour d'app après dictation, cold start.
+
+---
+
+## Diagnostic structurel confirmé (logs)
+
+iOS impose `UIView-Encapsulated-Layout-Height ≈ 504pt @ priorité 1000` sur `self.inputView` (ou `self.view` si pas d'inputView assigné) pendant l'animation d'entrée. Notre clavier utile fait 276pt (toolbar 52pt + key grid 224pt). Différence = 228pt exposés.
+
+Logs caractéristiques (toutes itérations) :
+```
+viewDidAppear_settled:  viewBounds=430x504  containerFrame=430x276@y=228  status=ready
+layoutSnapshot_500ms:   viewBounds=430x276  containerFrame=430x276@y=0    status=ready
+```
+
+Notre `keyboardContainer` est correctement positionné (276pt collé en bas pendant le transient, puis 276pt au top après settlement). C'est la zone des **228pt qui restent au-dessus** qui pose problème — elle est visible (gris translucide), pas transparente.
+
+---
+
+## Architecture actuelle (état après les 4 itérations WIP)
+
+```
+UIInputViewController (KeyboardViewController)
+└── self.view (UIView vanille, backgroundColor=.clear)  ← itération 4
+    └── keyboardContainer: UIView (subview de self.view)
+        ├── hosting.view (UIHostingController<KeyboardRootView>) — toolbar + recording overlay
+        └── giellaKeyboard: GiellaKeyboardView (UICollectionView) — touches AZERTY
+```
+
+**Contraintes container** (pattern upstream giellakbd-ios) :
+- `top = self.view.top` @ `.defaultHigh` (yields)
+- `leading/trailing/bottom = self.view` @ `.required`
+- `height = 276pt` @ `999` — installé en `viewDidLayoutSubviews` first-run via `DispatchQueue.main.async`
+
+**Audio click** : géré dans `DictusKeyboardBridge.swift` via `AudioServicesPlaySystemSound(1104)` etc. (3 sons distincts via `KeySound.letter/delete/modifier`). **Aucune dépendance à `UIInputViewAudioFeedback`** ou `playInputClick()`.
+
+---
+
+## Les 4 hypothèses testées et leur résultat
+
+| # | Hypothèse | Modif | Résultat | Pourquoi |
+|---|-----------|-------|----------|----------|
+| 1 | "Self.view + 1×1 audio inputView fonctionne" | `keyboardContainer` subview de `self.view` + `self.inputView = KeyboardInputView(1×1, alpha=0)` | ❌ KO total — clavier invisible, écran blanc | Setting `self.inputView` détache `self.view` de la window. Container width=0, hors hiérarchie. |
+| 2 | "Override loadView pour faire de self.view un UIInputView" | `loadView()` → `self.view = KeyboardInputView` | ⚠️ Partiel — le clavier marche, container correctement positionné, mais flash gris persiste | UIInputView a un visual-effect chrome interne (frosted-glass system blur) non-désactivable via API publique |
+| 3 | "Setter `.clear` sur l'UIInputView neutralise son chrome" | `inputView.backgroundColor = .clear` dans loadView | ❌ KO — chrome blur reste visible | Le visual effect interne n'est pas affecté par backgroundColor |
+| 4 | "Drop UIInputView entièrement, UIView vanille .clear" | Drop `loadView()`, `self.view.backgroundColor = .clear` dans viewDidLoad, supprime `InputView.swift` (code mort, bridge utilise déjà AudioServicesPlaySystemSound) | ❌ KO — flash gris toujours présent | self.view est bien transparent, mais une vue PARENTE système iOS (`UIInputSetHostView` ou `UIInputSetContainerView`) reste grise et est visible à travers |
+
+---
+
+## Conclusion sur ce qui n'a pas marché
+
+Toutes les hypothèses tournaient autour de "neutraliser self.view ou son équivalent". La conclusion forte de la 4e itération est que **le gris ne vient PAS de self.view** (qui est maintenant transparent confirmé). Il vient probablement d'une vue système iOS au-dessus de self.view dans la hiérarchie de la keyboard window :
+- `UITextEffectsWindow` (la keyboard window)
+- `UIInputSetContainerView` (vue parente système)
+- `UIInputSetHostView` (vue parente système)
+- `self.view` (notre UIView, transparent maintenant)
+
+Aucune API publique ne permet de modifier ces vues système. C'est probablement pour ça qu'il faudrait inspecter via Xcode View Debugger / Reveal sur device pendant le transient pour comprendre quelle vue précise est grise.
+
+---
+
+## Pourquoi giellakbd-ios upstream n'a pas le bug (mystère non résolu)
+
+L'agent de recherche a confirmé :
+- Upstream n'override pas `loadView` → self.view est UIView vanille
+- Upstream a `self.view.backgroundColor = .clear` (theme.backgroundColor en mode light)
+- Upstream a la même structure container : top=defaultHigh, bottom=required, height=999
+
+**On a fait exactement la même chose maintenant**. Et notre flash persiste. Donc soit :
+- (a) Upstream a aussi le flash mais c'est moins visible/perceptible (différence subtile de timing, animation, ou couleur)
+- (b) Il y a un trick quelque part qu'on n'a pas trouvé (build settings, plist key, deployment target différent)
+- (c) iOS 26 traite différemment les keyboard extensions selon un facteur qu'on n'a pas identifié
+
+**Cette question reste ouverte et est probablement la clé.**
+
+---
+
+## Pistes non explorées (pour le fresh start)
+
+1. **Xcode View Debugger / Reveal sur device pendant le transient** : la SEULE façon fiable de voir QUELLE vue est grise dans la hiérarchie. Probablement nécessite de pause au bon moment (breakpoint dans viewDidAppear).
+2. **Comparer les Info.plist** : Dictus vs giellakbd-ios. Y a-t-il une clé qui change le comportement de l'inputView ? `RequestsOpenAccess`, `IsASCIICapable`, `PrefersRightToLeft`, `KeyboardName`, etc.
+3. **`UIInputViewController.preferredContentSize`** : pas testé. Peut signaler à iOS la taille préférée.
+4. **`self.view.window.rootViewController?.view.backgroundColor = .clear`** : remonter la hiérarchie et clear toutes les parentes possibles.
+5. **Override `viewWillAppear` pour chercher les superviews** : remonter la chaîne `view.superview?.superview?...` et logger leur backgroundColor + class. Peut-être qu'on peut neutraliser un parent.
+6. **Tester sur simulator vs device** : si comportement différent, ça peut indiquer une animation iOS spécifique au hardware.
+7. **`disablesAutomaticKeyboardDismissal`** : explorer toutes les properties de UIInputViewController pour voir s'il y a un toggle qu'on a raté.
+8. **Recording d'écran 60fps + analyse frame par frame** : voir EXACTEMENT à quel moment le gris apparaît et disparaît, et si la couleur évolue (animation alpha ?).
+9. **Récupérer/installer giellakbd-ios sur un device et comparer côte à côte avec un screen recording** : confirmer que upstream n'a vraiment PAS le bug, ou qu'il l'a aussi mais différemment.
+10. **Tenter un nouvel angle : ne pas faire un container 276pt, mais un container 504pt avec contenu rendered uniquement dans les 276pt du bas** (sorte de "mask" ou clip). Le slot reste 504pt visuellement mais transparent au-dessus de notre contenu.
+
+---
+
+## Outils / skills suggérés pour le fresh start
+
+- **Xcode View Debugger** : indispensable. Lancer Dictus sur device, déclencher le bug, capture la hiérarchie pendant le transient.
+- **Reveal app** : alternative pro pour debug de view hierarchy live.
+- **Screen recording 60fps** sur device (`xcrun simctl io booted recordVideo` pour simulator, ou Voice Memos + screen recording iOS pour device) puis analyse frame par frame.
+- **`po self.view.recursiveDescription()`** dans LLDB pendant le transient pour dump la hiérarchie.
+- **Agent de recherche dédié à la doc Apple privée / OpenRadar / forums Apple Dev** : chercher "third-party keyboard 504pt transient flash" ou "UIInputSetHostView background".
+- **MCP Serena** : si disponible, pour explorer plus efficacement le codebase et naviguer.
+
+---
+
+## Pour repartir proprement
+
+### Option recommandée : reset hard à develop
+
+```bash
+git reset --hard 9437ff0
+```
+
+Garde les 2 commits de doc (`615edd9` et `1ca9a79`), supprime toutes les modifs WIP des 4 itérations. Branche reste `fix/92-approach-b`. Repart de zéro côté code.
+
+### Option : garder la suppression code mort uniquement
+
+```bash
+# Reset code mais garde la suppression InputView.swift et la simplification audio mention
+git reset --hard 9437ff0
+# Puis re-supprimer InputView.swift proprement dans une nouvelle commit
+```
+
+### Option : garder l'architecture container mais reset le reste
+
+Pas recommandé — l'architecture container ne résout pas le bug et ajoute de la complexité sans bénéfice clair.
+
+---
+
+## Fichiers de référence à consulter avant de commencer
+
+- `.planning/debug/issue-92-keyboard-flash-analysis.md` — analyse 10-agents originale (synthèse causes/régressions)
+- `.planning/debug/issue-92-approach-b-handoff.md` — handoff de l'approche B (à considérer comme historique maintenant)
+- `DictusKeyboard/KeyboardViewController.swift` — état actuel WIP (à reset)
+- `DictusKeyboard/DictusKeyboardBridge.swift` — bridge avec audio implémentation (12 call sites `AudioServicesPlaySystemSound`)
+- `/Users/pierreviviere/dev/giellakbd-ios/Keyboard/Controllers/KeyboardViewController.swift` — référence upstream
+- `/Users/pierreviviere/dev/giellakbd-ios/Keyboard/Utility/Audio.swift` — référence audio upstream
+
+---
+
+## Prompt suggéré pour la nouvelle session
+
+```
+Je travaille sur l'issue #92 du repo Dictus (clavier iOS) : à chaque apparition
+du clavier, pendant ~500ms, une zone de 228pt apparaît au-dessus de la zone
+utile, donnant la sensation que le clavier "grandit". Cause structurelle :
+iOS impose UIView-Encapsulated-Layout-Height = 504pt @ priorité 1000 sur
+self.view pendant l'animation d'entrée, notre keyboard utile = 276pt.
+
+Une session précédente a tenté 4 approches (refactor self.inputView, pattern
+upstream giellakbd-ios, etc.). AUCUNE n'a résolu le bug. Tout le contexte
+exhaustif est dans .planning/debug/issue-92-fresh-start-handoff.md — LIS-LE
+EN ENTIER avant toute action.
+
+Le travail WIP a été reset à develop, on repart de zéro côté code, mais on
+garde la branche fix/92-approach-b active pour ne pas perdre le contexte.
+
+Mission : tenter une NOUVELLE approche. Le handoff liste 10 pistes non explorées
+(section "Pistes non explorées"). Le plus prometteur selon moi : utiliser le
+Xcode View Debugger ou faire un dump LLDB de view.recursiveDescription pendant
+le transient pour identifier QUI est gris. Sans cette info, on continue à tirer
+à l'aveugle.
+
+Mode plan obligatoire (shift+tab) avant toute action. Lis le handoff,
+analyse les pistes, propose-moi un plan détaillé qui commence par DIAGNOSTIC
+PRÉCIS (pas par code).
+
+Pas de commit ni push avant retour positif de Pierre sur device.
+```

--- a/.planning/debug/issue-92-keyboard-flash-analysis.md
+++ b/.planning/debug/issue-92-keyboard-flash-analysis.md
@@ -1,0 +1,156 @@
+# Issue #92 — Keyboard load flash : analyse approfondie (2026-04-29)
+
+## TL;DR
+
+À chaque apparition du clavier Dictus, `inputView.bounds` est forcé à **504pt** par iOS pendant ~500ms avant de retomber à 276pt. Cause : iOS impose `UIView-Encapsulated-Layout-Height` à priorité **1000** sur tout view assigné à `self.inputView` pendant l'animation d'entrée. Aucune contrainte 999 ne peut gagner contre 1000.
+
+L'upstream giellakbd-ios n'a PAS ce bug parce qu'il :
+1. N'assigne **jamais** `self.inputView` (utilise `self.view` directement, qui n'est pas décoré par cette contrainte 1000)
+2. Bottom-anchor son `keyboardContainer` (top yield, bottom required, height=999) → pendant le transient le clavier reste 276pt collé en bas, pas de flash visible
+
+## Reproduction confirmée
+
+- iPhone 17 Pro / iOS 26.3.1
+- TestFlight build 13 (commit `49e23d7@develop`)
+- Captures et logs : `/Users/pierreviviere/Downloads/dictus-logs 12.txt`, `dictus-logs 13.txt`, screenshots du 2026-04-29 09:03 et 09:53
+- Reproduction la plus dramatique : pull-down Spotlight depuis l'écran d'accueil
+
+## Logs caractéristiques (build 14, après tentative self-sizing)
+
+```
+viewWillAppear_entry:    inputBounds=430x932 hostingConst=52 preferredH=276
+viewDidAppear_settled:   inputBounds=430x504 viewBounds=430x504 keyboardFrame=430x224 hostingFrame=430x52
+layoutSnapshot_500ms:    inputBounds=430x276 viewBounds=430x276 keyboardFrame=430x224 hostingFrame=430x52
+```
+
+Pattern identique sur 7 sessions consécutives. Self-sizing (`allowsSelfSizing=true` + `intrinsicContentSize`) **n'a pas** réduit le transient.
+
+## Synthèse des 6 + 4 agents lancés
+
+### Agents 1-6 (analyse initiale, 2026-04-29 matin)
+
+1. **Apple official APIs** — Identifie `UIView-Encapsulated-Layout-Height` priorité 1000 comme contrainte gagnante. Recommande `allowsSelfSizing` + `intrinsicContentSize`. **Tenté → n'a pas marché.**
+2. **Constraint priority forensics** — Confirme l'asymétrie hosting@999 OK / giellaKeyboard@999 KO via topologie : hosting top-anchored converge instantanément, giellaKeyboard bottom-anchored sur build 13 stretchait à 452pt.
+3. **Open-source keyboards reference** — giellakbd upstream n'a pas le bug. Leur fix : installer heightConstraint dans `viewDidLayoutSubviews` first-run via `DispatchQueue.main.async`. Commentaire upstream explicite : *"If this is removed, iPhone 5s glitches before finding the correct height"*.
+4. **Visual masking strategies** — Background opaque sur `kbInputView`. **Tenté → a aggravé le visuel** (rectangle gris très visible au lieu d'un fond système moins distinct).
+5. **Git history regression hunt** — Confirme que ba12a69 (déjà sur develop) corrige la stretch des touches. Commit 6add300 (sondes mémoire) a rendu le transient visible en chargeant le main thread.
+6. **View hierarchy analysis** — Mécanisme : `GiellaKeyboardView.bounds.didSet` → `reloadData()` → cellules à `bounds.height/4`. Sur build 13 (avec bottomAnchor), bounds=452 → cellules 113pt = touches doublées. Sur build avec ba12a69 : cellules restent 56pt mais 228pt vide visible.
+
+### Agents 7-10 (comparaison upstream, 2026-04-29 fin)
+
+7. **KeyboardViewController structural diff** — Diff complet. 3 différences cumulées causent le bug : (a) `self.inputView = kbInputView`, (b) absence de bottom-pin sur enfants de kbInputView, (c) UIHostingController ajouté.
+8. **UIInputView lifecycle deep dive** — Confirme H1+H2+H3 TRUE. `self.inputView` opt-in dans pathway "self-sizing UIInputView" qui n'est honoré qu'**après** l'animation. Recommande retrait de `self.inputView`.
+9. **Build settings/plist diff** — `IPHONEOS_DEPLOYMENT_TARGET 17.0` (nous) vs `13.0` (upstream). Plausible que iOS 14+ ait introduit la pathway "système → autolayout" en 2 temps. Test diagnostique secondaire.
+10. **UIHostingController analysis** — INCONCLUSIVE leaning FALSE. Hosting est neutralisé par `compressionResistance=.defaultLow` + heightAnchor 999. Cause réelle = `UIView-Encapsulated-Layout-Height`. Hosting est incidental.
+
+## Cause racine définitive
+
+`self.inputView = kbInputView` (KeyboardViewController.swift, ligne ~213) déclenche l'application par iOS de `UIView-Encapsulated-Layout-Height = ~504pt` priorité 1000 pendant l'animation d'entrée. Combiné avec une absence de bottom-pin, le 228pt vide est exposé au-dessous des touches avec le fond gris par défaut de UIInputView.
+
+## Approches recommandées (du moins invasif au plus complet)
+
+### Approche A — Bottom-anchor minimal (recommandée pour tester)
+
+**Modification** : 4 lignes dans `KeyboardViewController.swift` (et le miroir dans `reloadKeyboardLayout`).
+
+```swift
+// Lignes ~187-191 : ajouter bottomAnchor à priorité defaultHigh
+keyboard.topAnchor.constraint(equalTo: hosting.view.bottomAnchor),  // garder
+keyboard.leadingAnchor.constraint(equalTo: kbInputView.leadingAnchor),
+keyboard.trailingAnchor.constraint(equalTo: kbInputView.trailingAnchor),
+keyboard.bottomAnchor.constraint(equalTo: kbInputView.bottomAnchor),  // NOUVEAU, priorité par défaut required
+keyboardHeight,  // garder priorité 999
+```
+
+Wait — il faut baisser la priorité du topAnchor pour que ça yield :
+
+```swift
+let topPin = keyboard.topAnchor.constraint(equalTo: hosting.view.bottomAnchor)
+topPin.priority = .defaultHigh  // 750 — yield au transient
+let bottomPin = keyboard.bottomAnchor.constraint(equalTo: kbInputView.bottomAnchor)
+// bottomPin priority = .required par défaut
+NSLayoutConstraint.activate([topPin, bottomPin, /* leading, trailing, heightAnchor 999 */])
+```
+
+**Pendant le transient 504pt** : top yield, bottom required gagne, height=999 fixe à 224pt → keyboard collé en bas du kbInputView, 228pt vide AU-DESSUS du toolbar (zone host app, transparente).
+
+**Préserve** :
+- `self.inputView = kbInputView` (audio feedback Apple intact)
+- ba12a69 (heightAnchor=224 priorité 999)
+- Toute la logique recording overlay / emoji picker / language switch
+
+**Risque** : faible. C'est exactement le pattern upstream.
+
+**Test diagnostique** : si l'utilisateur ne voit plus le rectangle gris au-dessus du clavier après cette modif, la cause structurelle est confirmée et on peut s'arrêter là.
+
+### Approche B — Alignement complet upstream (refactor)
+
+À tenter UNIQUEMENT si A laisse un visuel résiduel.
+
+1. Retirer `self.inputView = kbInputView`
+2. Renommer `kbInputView` en `keyboardContainer` et l'ajouter comme subview de `self.view`
+3. Pinner `keyboardContainer` : `top=.defaultHigh`, `leading/trailing/bottom=.required`
+4. Installer `heightAnchor=computeKeyboardHeight() priority 999` dans `viewDidLayoutSubviews` first-run via `DispatchQueue.main.async` (pattern upstream lignes 98-105 + 361-368)
+5. **Régression audio à gérer** : `playInputClick()` ne marche que si `self.inputView` est un `UIInputView`. Workaround : créer un tiny `KeyboardInputView` (1x1pt, alpha=0) assigné à `self.inputView` juste pour conformer au protocole audio, et router le layout via `keyboardContainer` sur `self.view`.
+
+## Régressions à éviter (mémoire institutionnelle de l'enquête)
+
+| Tentative | Régression | Source |
+|---|---|---|
+| Désactiver autoresizing masks sur `kbInputView` | Clavier collapse à zéro largeur | commit `a2d847d` |
+| Re-pinner `keyboard.bottomAnchor` SANS bottom-pin priorité required | Recrée stretch des touches | commit `ba12a69` |
+| Contrainte sur `self.view.heightAnchor` | No-op | commits `d2b9024`/`2ccc528` |
+| `alpha=0` sur tout `kbInputView` | Expose le gris système | tentative pré-2026-04-09 |
+| `clipsToBounds=true` sur kbInputView | Casse popups top-row | issue #69 |
+| `window.layer.speed = 0` | App Review rejection | hypothèse rejetée |
+| Override `layoutSubviews` clamping bounds | Risque de freeze layout | hypothèse rejetée |
+| `allowsSelfSizing=true` + `intrinsicContentSize` | Honoré post-animation seulement, ne supprime pas le 504pt transient | tentative 2026-04-29 build 14 |
+| `self.preferredContentSize` | Pas la bonne API pour keyboards (Apple docs : popovers/sheets) | tentative 2026-04-29 build 14 |
+| Background opaque sur `KeyboardInputView` | Aggrave visuel — rectangle gris très visible au lieu d'un fond système discret | tentative 2026-04-29 build 14 |
+
+## Critères de validation
+
+Sur device, après modif :
+
+**Visuel** :
+- [ ] Plus de touches doublées en taille pendant l'apparition
+- [ ] Plus de rectangle gris au-dessus du clavier
+- [ ] Apparition fluide en dark + light mode
+- [ ] Cas Spotlight pull-down OK
+- [ ] Cas tap dans Notes OK
+- [ ] Cas retour d'app OK
+
+**Logs** :
+- [ ] `viewDidAppear_settled keyboardFrame=430x224` à toutes les sessions
+- [ ] `keyboard.frame.minY` = `kbInputView.bounds.height - 224` pendant le transient (clavier en bas)
+- [ ] `inputBounds=430x504` peut persister à viewDidAppear (acceptable si le visuel est OK)
+
+## Tests de non-régression
+
+- [ ] #69 — popups top-row pas clippés
+- [ ] #99 — pas de toolbar déplacé en cold start
+- [ ] #116 — pas de stretched keys au switch d'app
+- [ ] #128 — pas de zombies controller
+- [ ] #134 — pas de retain cycle ni de gris non-cliquable après 10 switches rapides
+- [ ] Audio feedback Apple `playInputClick()` toujours actif
+- [ ] Recording overlay s'étire et se contracte sans flash
+- [ ] Emoji picker bascule sans flash
+- [ ] Language switch (globe) sans flash
+
+## Fichiers de référence
+
+### Côté Dictus (à modifier)
+- `/Users/pierreviviere/dev/dictus/DictusKeyboard/KeyboardViewController.swift`
+- `/Users/pierreviviere/dev/dictus/DictusKeyboard/InputView.swift`
+
+### Côté upstream (référence)
+- `/Users/pierreviviere/dev/giellakbd-ios/Keyboard/Controllers/KeyboardViewController.swift` (lignes 98-110, 262-274, 361-368)
+- `/Users/pierreviviere/dev/giellakbd-ios/Keyboard/Utility/Utils.swift:217-226` (helper `enable(priority:)`)
+
+## Historique des modifications déjà revertées
+
+Sur la branche `fix/92-keyboard-load-flash`, j'avais tenté avant ce reset :
+- `InputView.swift` : ajout `allowsSelfSizing`, `intrinsicContentSize`, `preferredHeight`, `applyChromeBackground` (background opaque), `layoutSubviews` probe
+- `KeyboardViewController.swift` : suppression `heightConstraint`, ajout `preferredContentSize`, helpers `preferredHeightOfInput()`/`setInputPreferredHeight()`, sondes diagnostiques `preferredH=`
+
+**Toutes ces modifs ont été revertées** au reset (`git checkout develop -- ...`), seul le bump build 13→14 est conservé. La branche est maintenant prête pour appliquer l'approche A.

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,61 @@
+included:
+  - DictusApp
+  - DictusKeyboard
+  - DictusCore/Sources
+  - DictusWidgets
+
+excluded:
+  - build
+  - .build
+  - Library
+  - scripts
+  - designs
+  - DictusCore/.build
+  - DictusKeyboard/Vendored      # vendored giellakbd-ios — keep as-is (see CLAUDE.md)
+  - "**/*.generated.swift"
+
+disabled_rules:
+  - line_length
+  - trailing_whitespace
+  - todo
+  - identifier_name
+  - type_name
+
+opt_in_rules:
+  - empty_count
+  - empty_string
+  - first_where
+  - last_where
+  - explicit_init
+  - closure_spacing
+  - contains_over_first_not_nil
+  - redundant_nil_coalescing
+  - sorted_first_last
+  - unneeded_parentheses_in_closure_argument
+  - vertical_parameter_alignment_on_call
+  - yoda_condition
+
+force_cast: warning
+force_try: warning
+
+force_unwrapping:
+  severity: warning
+
+cyclomatic_complexity:
+  warning: 15
+  error: 25
+
+function_body_length:
+  warning: 80
+  error: 200
+
+type_body_length:
+  warning: 400
+  error: 600
+
+file_length:
+  warning: 600
+  error: 1000
+  ignore_comment_only_lines: true
+
+reporter: "xcode"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,3 +69,17 @@ Barre centrale = dégradé #6BA3FF → #2563EB
 Barres latérales = blanc à 45% et 65% d'opacité
 Fond icône = dégradé #0D2040 → #071020 à 135°
 Border radius barres = 4.5pt
+
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs live as GitHub issues in `getdictus/dictus-ios`, managed via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default canonical labels: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context — `CONTEXT.md` + `docs/adr/` at the repo root (created lazily by `/grill-with-docs`). See `docs/agents/domain.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,12 +44,29 @@ cd DictusCore
 swift test
 ```
 
+## Continuous Integration
+
+Every pull request runs through GitHub Actions. Two checks must pass before a PR can be merged:
+
+- **SwiftLint** -- enforces style rules defined in `.swiftlint.yml`. Runs on Linux, completes in under a minute.
+- **Build** -- compiles the `DictusApp` scheme (which embeds `DictusKeyboard`, `DictusWidgets`, and depends on `DictusCore`) for iOS Simulator. Runs on macOS, takes 5-10 minutes.
+
+To check locally before pushing:
+
+```bash
+brew install swiftlint
+swiftlint lint
+```
+
+The CI does **not** sign builds, run tests, or upload to TestFlight. Its only job is to catch broken compilations and obvious style regressions.
+
 ## Pull Request Guidelines
 
 - Use a **descriptive title** (e.g., "Fix waveform animation on cold start").
 - **Explain what and why** in the PR description, not just what changed.
 - Keep PRs **focused** -- one feature or fix per PR.
 - Make sure the project builds without warnings before submitting.
+- Verify CI is green before requesting review.
 
 ## No CLA Required
 

--- a/DictusApp/Audio/UnifiedAudioEngine.swift
+++ b/DictusApp/Audio/UnifiedAudioEngine.swift
@@ -6,6 +6,19 @@ import Foundation
 @preconcurrency import AVFoundation
 import DictusCore
 
+extension Notification.Name {
+    /// In-process signal that the AVAudioSession was interrupted or the media
+    /// services stack was reset. Consumers (LiveActivityManager, DictationCoordinator)
+    /// must treat the audio engine as dead until a successful `warmUp()` returns.
+    /// Mirrors the cross-process Darwin notification of the same name (issue #106).
+    static let dictusAudioSessionInterrupted = Notification.Name("DictusAudioSessionInterrupted")
+
+    /// In-process signal that the warm-state engine was released after the idle
+    /// timeout. Consumers should dismiss the Dynamic Island standby indicator —
+    /// the next dictation will be a cold start (issue #106 Phase B).
+    static let dictusWarmStateReleased = Notification.Name("DictusWarmStateReleased")
+}
+
 /// Errors that can occur during audio engine operations.
 enum AudioEngineError: Error, LocalizedError {
     case permissionDenied
@@ -63,12 +76,20 @@ class UnifiedAudioEngine: ObservableObject {
     /// COMPUTED from engine.isRunning — always accurate, fixes #38.
     var isEngineRunning: Bool { engine.isRunning }
 
+    /// Whether the engine is in a healthy state for warm-start recording.
+    ///
+    /// WHY both gates: `engine.isRunning` returns true even after an interruption
+    /// began, until we explicitly stop it. `isInterrupted` reflects whether the
+    /// AVAudioSession is actually usable. The Live Activity layer queries this to
+    /// avoid showing "ready to dictate" while the audio system is dead (issue #106).
+    var isHealthy: Bool { engine.isRunning && !isInterrupted }
+
     /// Current accumulated sample count (for zombie engine health check).
     var currentSampleCount: Int { audioSamples.count }
 
     // MARK: - Private
 
-    private let engine = AVAudioEngine()
+    private var engine = AVAudioEngine()
 
     /// Accumulated audio samples in 16kHz mono Float32 (WhisperKit/Parakeet expected format).
     private var audioSamples: [Float] = []
@@ -91,6 +112,20 @@ class UnifiedAudioEngine: ObservableObject {
     /// WHY: iOS forbids changing AVAudioSession category from background.
     /// We configure once and keep the category set forever.
     private var sessionConfigured = false
+
+    /// True when an AVAudioSession interruption is currently in flight.
+    ///
+    /// WHY tracked separately from `engine.isRunning`: When an interruption begins,
+    /// iOS deactivates the session under us; the engine may still report `isRunning`
+    /// momentarily, but the next `installTap`/`start` will fail. Routing decisions
+    /// (Live Activity, transitionToRecording guard) need a fast in-process flag to
+    /// know the audio layer is degraded (issue #106).
+    private var isInterrupted = false
+
+    /// Tokens for the AVAudioSession lifecycle observers, retained so we can
+    /// remove them in `deinit` and avoid leaking notifications across hot reloads
+    /// or future re-instantiation.
+    private var notificationObservers: [NSObjectProtocol] = []
 
     /// Sample gating flag read from the audio thread.
     /// WHY nonisolated(unsafe): Read from audio callback thread (single reader pattern).
@@ -127,6 +162,176 @@ class UnifiedAudioEngine: ObservableObject {
     private nonisolated(unsafe) var audioThreadSampleCount: Int = 0
 
     private let waveformBarCount = 30
+
+    // MARK: - Init / Deinit
+
+    init() {
+        registerInterruptionObservers()
+    }
+
+    deinit {
+        for token in notificationObservers {
+            NotificationCenter.default.removeObserver(token)
+        }
+    }
+
+    /// Register observers for AVAudioSession lifecycle events that can break the
+    /// engine without our knowledge — phone calls, Siri, route loss, media services
+    /// reset (issue #106).
+    ///
+    /// WHY in init (not after first start): Apple delivers the .began interruption
+    /// notification immediately when the OS interrupts us, even if we haven't yet
+    /// activated the session. Registering early means we never miss one. Observers
+    /// are cheap when the session isn't active.
+    private func registerInterruptionObservers() {
+        let center = NotificationCenter.default
+
+        let interruptionToken = center.addObserver(
+            forName: AVAudioSession.interruptionNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            Task { @MainActor in
+                self?.handleInterruption(note)
+            }
+        }
+
+        let routeChangeToken = center.addObserver(
+            forName: AVAudioSession.routeChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            Task { @MainActor in
+                self?.handleRouteChange(note)
+            }
+        }
+
+        let mediaResetToken = center.addObserver(
+            forName: AVAudioSession.mediaServicesWereResetNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.handleMediaServicesReset()
+            }
+        }
+
+        notificationObservers = [interruptionToken, routeChangeToken, mediaResetToken]
+    }
+
+    /// AVAudioSession interruption handler.
+    ///
+    /// On `.began`: tear down the engine and mark the session unhealthy. The Live
+    /// Activity must dismiss because a dead session means the next dictation will
+    /// be a cold start, not a warm start (issue #106).
+    ///
+    /// On `.ended` with `.shouldResume`: try to reactivate and re-warm. If recovery
+    /// fails (rare — usually means the OS still holds the audio resource), we leave
+    /// the engine cold and accept that the next dictation pays the cold-start cost.
+    private func handleInterruption(_ note: Notification) {
+        guard let userInfo = note.userInfo,
+              let typeRaw = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
+              let type = AVAudioSession.InterruptionType(rawValue: typeRaw) else {
+            return
+        }
+
+        switch type {
+        case .began:
+            let reason = userInfo[AVAudioSessionInterruptionReasonKey].flatMap { value -> String in
+                if let raw = value as? UInt,
+                   let parsed = AVAudioSession.InterruptionReason(rawValue: raw) {
+                    return "\(parsed)"
+                }
+                return "\(value)"
+            } ?? "unknown"
+
+            isInterrupted = true
+            isRecording = false
+            isRecordingFlag = false
+
+            // Stop the engine so the next start() reinstalls the tap with a fresh
+            // hardware format. Don't deactivate the session — iOS will do that for us
+            // and re-asks ownership when the interruption ends.
+            engine.inputNode.removeTap(onBus: 0)
+            engine.stop()
+
+            PersistentLog.log(.audioInterruptionBegan(reason: reason))
+
+            // Notify in-process listeners (LiveActivityManager, DictationCoordinator)
+            // immediately. Darwin notification mirrors for cross-process consumers
+            // (keyboard ext) so they can stop trusting the warm-state contract.
+            NotificationCenter.default.post(name: .dictusAudioSessionInterrupted, object: nil)
+            DarwinNotificationCenter.post(DarwinNotificationName.audioSessionInterrupted)
+
+        case .ended:
+            let optionsRaw = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt ?? 0
+            let options = AVAudioSession.InterruptionOptions(rawValue: optionsRaw)
+            let shouldResume = options.contains(.shouldResume)
+
+            var restored = false
+            if shouldResume {
+                do {
+                    try configureAudioSession()
+                    try warmUp()
+                    isInterrupted = false
+                    restored = true
+                    PersistentLog.log(.warmStateRestored(context: "interruptionEnded"))
+                } catch {
+                    PersistentLog.log(.engineWarmUpFailed(
+                        context: "interruptionEnded",
+                        error: error.localizedDescription
+                    ))
+                }
+            }
+            PersistentLog.log(.audioInterruptionEnded(shouldResume: shouldResume, restored: restored))
+
+        @unknown default:
+            return
+        }
+    }
+
+    /// Audio route change handler. Logs only — most route changes (headphones
+    /// plugged/unplugged) are handled transparently by AVAudioEngine. We do NOT
+    /// tear down the engine here; that path is reserved for explicit interruptions.
+    /// If the input route disappears entirely, the next recording attempt fails
+    /// gracefully via the hwFormat guards in `startEngine()`.
+    private func handleRouteChange(_ note: Notification) {
+        guard let userInfo = note.userInfo,
+              let raw = userInfo[AVAudioSessionRouteChangeReasonKey] as? UInt,
+              let reason = AVAudioSession.RouteChangeReason(rawValue: raw) else {
+            return
+        }
+
+        let inputs = AVAudioSession.sharedInstance()
+            .currentRoute.inputs
+            .map { $0.portType.rawValue }
+            .joined(separator: ",")
+
+        PersistentLog.log(.audioRouteChanged(
+            reason: "\(reason)",
+            details: "inputs=\(inputs.isEmpty ? "none" : inputs)"
+        ))
+    }
+
+    /// AVAudioSession.mediaServicesWereReset handler. This is rare but brutal:
+    /// the entire audio stack is reset by the OS and ALL existing AVAudioEngine
+    /// instances are invalid. We must allocate a fresh engine and reconfigure
+    /// before any future start() call.
+    private func handleMediaServicesReset() {
+        PersistentLog.log(.audioMediaServicesReset)
+
+        engine.inputNode.removeTap(onBus: 0)
+        engine.stop()
+        engine = AVAudioEngine()
+        converter = nil
+        sessionConfigured = false
+        isInterrupted = true
+        isRecording = false
+        isRecordingFlag = false
+
+        NotificationCenter.default.post(name: .dictusAudioSessionInterrupted, object: nil)
+        DarwinNotificationCenter.post(DarwinNotificationName.audioSessionInterrupted)
+    }
 
     // MARK: - Session & Permissions (ported from AudioRecorder)
 

--- a/DictusApp/Audio/UnifiedAudioEngine.swift
+++ b/DictusApp/Audio/UnifiedAudioEngine.swift
@@ -122,6 +122,18 @@ class UnifiedAudioEngine: ObservableObject {
     /// know the audio layer is degraded (issue #106).
     private var isInterrupted = false
 
+    /// Re-entry guard for the interruption handler. Prevents a second `.began` /
+    /// `.ended` arriving while we're still mutating engine state from a previous
+    /// event (Siri → ringing call back-to-back), which would leave a dangling tap.
+    private var isHandlingInterruption = false
+
+    /// Generation counter for the underlying AVAudioEngine instance. Bumped on
+    /// `handleMediaServicesReset` when we replace the engine. The audio tap closure
+    /// captures the generation it was installed under — if a buffer arrives after
+    /// the engine has been replaced, the closure bails out instead of writing into
+    /// shared `nonisolated(unsafe)` state and racing with the new engine's tap.
+    private nonisolated(unsafe) var engineGeneration: UInt64 = 0
+
     /// Tokens for the AVAudioSession lifecycle observers, retained so we can
     /// remove them in `deinit` and avoid leaking notifications across hot reloads
     /// or future re-instantiation.
@@ -183,6 +195,11 @@ class UnifiedAudioEngine: ObservableObject {
     /// notification immediately when the OS interrupts us, even if we haven't yet
     /// activated the session. Registering early means we never miss one. Observers
     /// are cheap when the session isn't active.
+    ///
+    /// WHY no `queue: .main` + `Task { @MainActor }` double hop: each Task adds a
+    /// runloop tick of latency between AVAudioSession posting the notification and
+    /// us mutating `isInterrupted`. Since this class is @MainActor, dispatching
+    /// the closure to MainActor.assumeIsolated handles isolation directly.
     private func registerInterruptionObservers() {
         let center = NotificationCenter.default
 
@@ -191,9 +208,7 @@ class UnifiedAudioEngine: ObservableObject {
             object: nil,
             queue: .main
         ) { [weak self] note in
-            Task { @MainActor in
-                self?.handleInterruption(note)
-            }
+            MainActor.assumeIsolated { self?.handleInterruption(note) }
         }
 
         let routeChangeToken = center.addObserver(
@@ -201,9 +216,7 @@ class UnifiedAudioEngine: ObservableObject {
             object: nil,
             queue: .main
         ) { [weak self] note in
-            Task { @MainActor in
-                self?.handleRouteChange(note)
-            }
+            MainActor.assumeIsolated { self?.handleRouteChange(note) }
         }
 
         let mediaResetToken = center.addObserver(
@@ -211,9 +224,7 @@ class UnifiedAudioEngine: ObservableObject {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            Task { @MainActor in
-                self?.handleMediaServicesReset()
-            }
+            MainActor.assumeIsolated { self?.handleMediaServicesReset() }
         }
 
         notificationObservers = [interruptionToken, routeChangeToken, mediaResetToken]
@@ -229,6 +240,20 @@ class UnifiedAudioEngine: ObservableObject {
     /// fails (rare — usually means the OS still holds the audio resource), we leave
     /// the engine cold and accept that the next dictation pays the cold-start cost.
     private func handleInterruption(_ note: Notification) {
+        // Re-entry guard: a second interruption arriving before we finish handling
+        // the previous one (Siri → ringing call back-to-back) would leave a dangling
+        // tap. The MainActor isolation already serialises calls, so the flag only
+        // needs to cover async work inside this method (warmUp on .ended).
+        guard !isHandlingInterruption else {
+            PersistentLog.log(.engineWarmUpFailed(
+                context: "interruption",
+                error: "reentrant interruption ignored"
+            ))
+            return
+        }
+        isHandlingInterruption = true
+        defer { isHandlingInterruption = false }
+
         guard let userInfo = note.userInfo,
               let typeRaw = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
               let type = AVAudioSession.InterruptionType(rawValue: typeRaw) else {
@@ -270,10 +295,14 @@ class UnifiedAudioEngine: ObservableObject {
 
             var restored = false
             if shouldResume {
+                // configureAudioSession + warmUp may legitimately fail if the app is
+                // still backgrounded (iOS forbids setActive(true) from background).
+                // The catch leaves isInterrupted=true; didBecomeActive will retry via
+                // its own warmUp path, and `startEngine()` clears `isInterrupted` on
+                // success — so we don't need to flip the flag here on the failure path.
                 do {
                     try configureAudioSession()
                     try warmUp()
-                    isInterrupted = false
                     restored = true
                     PersistentLog.log(.warmStateRestored(context: "interruptionEnded"))
                 } catch {
@@ -322,6 +351,10 @@ class UnifiedAudioEngine: ObservableObject {
 
         engine.inputNode.removeTap(onBus: 0)
         engine.stop()
+        // Bump generation BEFORE replacing the engine so any in-flight tap callbacks
+        // from the old engine see a stale generation and bail out instead of writing
+        // into shared audio-thread state and racing with the new engine's tap.
+        engineGeneration &+= 1
         engine = AVAudioEngine()
         converter = nil
         sessionConfigured = false
@@ -565,10 +598,18 @@ class UnifiedAudioEngine: ObservableObject {
         // our pre-flight guards don't cover (#71, #102). Without this shim the
         // process aborts with SIGABRT. Swift imports the Objective-C
         // `tryBlock:error:` as a throwing method.
+        // Capture the engine generation at install time. Buffers arriving after a
+        // mediaServicesWereReset has bumped the generation (and replaced the engine)
+        // belong to the dead engine and must be discarded — otherwise they race
+        // with the new engine's tap on shared `nonisolated(unsafe)` audio-thread
+        // state (issue #106 review).
+        let installedGeneration = engineGeneration
         do {
             try ObjCExceptionCatcher.catchException {
                 inputNode.installTap(onBus: 0, bufferSize: 4096, format: hwFormat) { [weak self] buffer, _ in
-                    self?.processBuffer(buffer)
+                    guard let self else { return }
+                    guard installedGeneration == self.engineGeneration else { return }
+                    self.processBuffer(buffer)
                 }
             }
         } catch {
@@ -598,6 +639,13 @@ class UnifiedAudioEngine: ObservableObject {
             inputNode.removeTap(onBus: 0)
             throw swiftStartError
         }
+
+        // Engine is healthy again — clear any interruption flag set by a previous
+        // .began handler. Centralising the clear here means every successful start
+        // path (warmUp, startRecording, didBecomeActive recovery, forceRestart,
+        // .ended interruption resume) ends up healthy without each caller having
+        // to remember to flip the flag.
+        isInterrupted = false
 
         if #available(iOS 14.0, *) {
             DictusLogger.app.info("UnifiedAudioEngine started (hw: \(hwFormat.sampleRate, privacy: .public)Hz -> 16kHz)")

--- a/DictusApp/Audio/UnifiedAudioEngine.swift
+++ b/DictusApp/Audio/UnifiedAudioEngine.swift
@@ -139,6 +139,25 @@ class UnifiedAudioEngine: ObservableObject {
     /// or future re-instantiation.
     private var notificationObservers: [NSObjectProtocol] = []
 
+    /// Pending idle-release work item (issue #106 Phase B). Armed at the end of
+    /// every recording (`collectSamples`) and cancelled at the start of any new
+    /// recording or warm-up. If it ever fires, `releaseWarmState()` tears down
+    /// the engine + session so the device stops paying for `UIBackgroundModes:audio`.
+    private var idleReleaseWorkItem: DispatchWorkItem?
+
+    /// Time at which the most recent recording session ended (`collectSamples`
+    /// or `cancelDictation` path). Used to compute how long the engine sat idle
+    /// before being released — emitted in the `warmStateReleased(idleSeconds:)`
+    /// log event for tuning the timeout.
+    private var lastIdleStartTime: Date?
+
+    /// Idle window after which the warm engine + session are released. Hardcoded
+    /// for this iteration; a user-facing setting will land as a follow-up
+    /// (issue #106 out-of-scope). 10 minutes balances UX (warm starts feel
+    /// instant within a normal "back-and-forth dictation session") against
+    /// battery drain (3.3%/h baseline drops to ~0%/h after release).
+    private let idleReleaseInterval: TimeInterval = 10 * 60
+
     /// Sample gating flag read from the audio thread.
     /// WHY nonisolated(unsafe): Read from audio callback thread (single reader pattern).
     /// Written from main thread via startRecording()/collectSamples()/stopEngine().
@@ -182,6 +201,7 @@ class UnifiedAudioEngine: ObservableObject {
     }
 
     deinit {
+        idleReleaseWorkItem?.cancel()
         for token in notificationObservers {
             NotificationCenter.default.removeObserver(token)
         }
@@ -273,6 +293,7 @@ class UnifiedAudioEngine: ObservableObject {
             isInterrupted = true
             isRecording = false
             isRecordingFlag = false
+            cancelIdleRelease()
 
             // Stop the engine so the next start() reinstalls the tap with a fresh
             // hardware format. Don't deactivate the session — iOS will do that for us
@@ -349,6 +370,7 @@ class UnifiedAudioEngine: ObservableObject {
     private func handleMediaServicesReset() {
         PersistentLog.log(.audioMediaServicesReset)
 
+        cancelIdleRelease()
         engine.inputNode.removeTap(onBus: 0)
         engine.stop()
         // Bump generation BEFORE replacing the engine so any in-flight tap callbacks
@@ -426,6 +448,9 @@ class UnifiedAudioEngine: ObservableObject {
     /// Start the engine in idle mode (running but not recording).
     /// Keeps the app alive in background via UIBackgroundModes:audio.
     func warmUp() throws {
+        // Cancel any pending idle release — we're explicitly going back warm.
+        cancelIdleRelease()
+
         guard !engine.isRunning else {
             PersistentLog.log(.engineWarmUpSuccess(context: "already running"))
             return
@@ -437,6 +462,9 @@ class UnifiedAudioEngine: ObservableObject {
     /// Begin recording: purge idle audio and start accumulating samples.
     /// If the engine isn't running yet, starts it first (<100ms).
     func startRecording() throws {
+        // Cancel any pending idle release — recording activity resets the timer.
+        cancelIdleRelease()
+
         if !engine.isRunning {
             try startEngine()
         }
@@ -471,6 +499,10 @@ class UnifiedAudioEngine: ObservableObject {
         bufferEnergy = []
         bufferSeconds = 0
 
+        // Arm the idle-release timer (issue #106 Phase B). If the user starts a
+        // new recording or warms up before the timer fires, it gets cancelled.
+        scheduleIdleRelease()
+
         return samples
     }
 
@@ -479,6 +511,7 @@ class UnifiedAudioEngine: ObservableObject {
     ///
     /// - Returns: Audio samples ready for transcription.
     func stopEngine() -> [Float] {
+        cancelIdleRelease()
         isRecording = false
         isRecordingFlag = false
 
@@ -501,6 +534,7 @@ class UnifiedAudioEngine: ObservableObject {
     /// Fully deactivate audio: stop engine + deactivate AVAudioSession.
     /// Call when user explicitly stops all audio (e.g., Power button in Dynamic Island).
     func deactivateSession() {
+        cancelIdleRelease()
         isRecording = false
         isRecordingFlag = false
         engine.inputNode.removeTap(onBus: 0)
@@ -517,6 +551,7 @@ class UnifiedAudioEngine: ObservableObject {
     /// Force restart the engine (stop + removeTap + reconfigure + start).
     /// Used to recover from zombie engine state where isRunning == true but tap receives no buffers.
     func forceRestart() {
+        cancelIdleRelease()
         engine.inputNode.removeTap(onBus: 0)
         engine.stop()
         sessionConfigured = false
@@ -529,6 +564,78 @@ class UnifiedAudioEngine: ObservableObject {
         } catch {
             PersistentLog.log(.engineWarmUpFailed(context: "forceRestart", error: error.localizedDescription))
         }
+    }
+
+    // MARK: - Idle Release (issue #106 Phase B)
+
+    /// Arm the idle-release work item. Idempotent: cancels any prior timer first.
+    /// The work runs on the main queue after `idleReleaseInterval` elapses with
+    /// no recording activity. Must be called from MainActor context.
+    private func scheduleIdleRelease() {
+        cancelIdleRelease()
+        lastIdleStartTime = Date()
+
+        let work = DispatchWorkItem { [weak self] in
+            MainActor.assumeIsolated {
+                self?.releaseWarmState(reason: "idleTimeout")
+            }
+        }
+        idleReleaseWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + idleReleaseInterval, execute: work)
+    }
+
+    /// Cancel a pending idle release. Safe to call when none is armed.
+    private func cancelIdleRelease() {
+        idleReleaseWorkItem?.cancel()
+        idleReleaseWorkItem = nil
+    }
+
+    /// Tear down the warm-state engine and deactivate the AVAudioSession.
+    ///
+    /// Called by the idle timer (`scheduleIdleRelease`). Public so the
+    /// scenePhase.active path can call it explicitly if needed (currently
+    /// unused — re-warm goes through `warmUp` which trumps the timer). After
+    /// release, the next dictation will pay the cold-start cost (~100ms engine
+    /// boot + cached WhisperKit init).
+    ///
+    /// Posts both an in-process notification (Live Activity dismisses) and a
+    /// Darwin notification (cross-process consumers can react). Issue #106.
+    func releaseWarmState(reason: String) {
+        // No-op if already released. Prevents double-deactivation logs and
+        // redundant Darwin posts when called from multiple paths.
+        guard engine.isRunning || sessionConfigured else { return }
+
+        let idleSeconds: Int = {
+            guard let started = lastIdleStartTime else { return 0 }
+            return Int(Date().timeIntervalSince(started))
+        }()
+
+        isRecording = false
+        isRecordingFlag = false
+
+        engine.inputNode.removeTap(onBus: 0)
+        engine.stop()
+
+        // Bump generation so any in-flight tap callback bails out before mutating
+        // shared audio-thread state (matches the mediaServicesWereReset pattern).
+        engineGeneration &+= 1
+
+        try? AVAudioSession.sharedInstance().setActive(
+            false,
+            options: .notifyOthersOnDeactivation
+        )
+        sessionConfigured = false
+        converter = nil
+        lastIdleStartTime = nil
+        idleReleaseWorkItem = nil
+
+        PersistentLog.log(.warmStateReleased(idleSeconds: idleSeconds))
+        if #available(iOS 14.0, *) {
+            DictusLogger.app.info("Warm state released after \(idleSeconds, privacy: .public)s idle (reason: \(reason, privacy: .public))")
+        }
+
+        NotificationCenter.default.post(name: .dictusWarmStateReleased, object: nil)
+        DarwinNotificationCenter.post(DarwinNotificationName.warmStateReleased)
     }
 
     // MARK: - Private Helpers

--- a/DictusApp/Audio/UnifiedAudioEngine.swift
+++ b/DictusApp/Audio/UnifiedAudioEngine.swift
@@ -314,26 +314,23 @@ class UnifiedAudioEngine: ObservableObject {
             let options = AVAudioSession.InterruptionOptions(rawValue: optionsRaw)
             let shouldResume = options.contains(.shouldResume)
 
-            var restored = false
-            if shouldResume {
-                // configureAudioSession + warmUp may legitimately fail if the app is
-                // still backgrounded (iOS forbids setActive(true) from background).
-                // The catch leaves isInterrupted=true; didBecomeActive will retry via
-                // its own warmUp path, and `startEngine()` clears `isInterrupted` on
-                // success — so we don't need to flip the flag here on the failure path.
-                do {
-                    try configureAudioSession()
-                    try warmUp()
-                    restored = true
-                    PersistentLog.log(.warmStateRestored(context: "interruptionEnded"))
-                } catch {
-                    PersistentLog.log(.engineWarmUpFailed(
-                        context: "interruptionEnded",
-                        error: error.localizedDescription
-                    ))
-                }
-            }
-            PersistentLog.log(.audioInterruptionEnded(shouldResume: shouldResume, restored: restored))
+            // We deliberately do NOT auto-resume here even when shouldResume is true.
+            //
+            // WHY: the user just finished a phone call (or whatever interruption);
+            // they have not asked to dictate. Eagerly re-warming the engine
+            // re-activates AVAudioSession, which iOS surfaces as the orange mic
+            // indicator in its Dynamic Island — but our Live Activity is already
+            // dismissed (Phase A correctly tears it down on .began). The combination
+            // is the worst of both: audio resources held + no Dictus UX visible.
+            //
+            // Instead, leave the engine cold and rely on the natural re-warm paths:
+            //  - if user reopens the app, DictationCoordinator's didBecomeActive
+            //    observer calls warmUp.
+            //  - if user taps the keyboard mic, the cold-start dictation path
+            //    starts the engine fresh.
+            // Either way, the warm-state contract matches reality and the orange
+            // mic only appears when the user actually wants to record (issue #106).
+            PersistentLog.log(.audioInterruptionEnded(shouldResume: shouldResume, restored: false))
 
         @unknown default:
             return

--- a/DictusApp/Audio/UnifiedAudioEngine.swift
+++ b/DictusApp/Audio/UnifiedAudioEngine.swift
@@ -792,7 +792,27 @@ class UnifiedAudioEngine: ObservableObject {
     /// SAMPLE GATING: Samples only accumulate when isRecordingFlag is true. When idle,
     /// the engine still processes buffers for heartbeat + waveform (keeps background alive)
     /// but discards audio data. This prevents the 64M idle sample accumulation bug (#38).
+    ///
+    /// IDLE FAST PATH (issue #106 Phase C): When `isRecordingFlag` is false, we skip the
+    /// converter, waveform compute, energy buffer maintenance, and the main-thread
+    /// dispatch — none of those outputs are consumed when no one is dictating. We only
+    /// emit a sparse heartbeat (every 10s instead of 1s) so the keyboard's watchdog
+    /// can still see the app is alive when a future dictation starts. The watchdog
+    /// itself is gated to active dictation states (KeyboardState.startWatchdog), so a
+    /// stale heartbeat during pure idle never triggers a reset.
     private nonisolated func processBuffer(_ buffer: AVAudioPCMBuffer) {
+        let now = Date().timeIntervalSince1970
+
+        // Idle fast path — sparse heartbeat only.
+        if !isRecordingFlag {
+            let idleHeartbeatThrottle: TimeInterval = 10.0
+            if now - lastHeartbeatWrite >= idleHeartbeatThrottle {
+                lastHeartbeatWrite = now
+                AppGroup.defaults.set(now, forKey: SharedKeys.recordingHeartbeat)
+            }
+            return
+        }
+
         guard let converter else { return }
 
         // Calculate output frame count: input frames * (target rate / source rate) + 1
@@ -848,16 +868,14 @@ class UnifiedAudioEngine: ObservableObject {
             audioThreadWaveformBins.removeFirst(audioThreadWaveformBins.count - waveformBarCount)
         }
 
-        let now = Date().timeIntervalSince1970
-
-        // Write heartbeat (~1Hz) — always, even when idle (keeps background alive)
+        // Write heartbeat (~1Hz) during recording
         if now - lastHeartbeatWrite >= 1.0 {
             lastHeartbeatWrite = now
             AppGroup.defaults.set(now, forKey: SharedKeys.recordingHeartbeat)
         }
 
-        // Write waveform data + elapsed time to App Group (~5Hz) — only when recording
-        if isRecordingFlag, now - lastWaveformWrite >= 0.2 {
+        // Write waveform data + elapsed time to App Group (~5Hz)
+        if now - lastWaveformWrite >= 0.2 {
             lastWaveformWrite = now
             audioThreadSampleCount += 0 // count is updated in main thread dispatch below
             let snapshot = makeWaveformSnapshot()
@@ -880,9 +898,7 @@ class UnifiedAudioEngine: ObservableObject {
         }
 
         // Track sample count on audio thread (needed for elapsed time in App Group writes)
-        if isRecordingFlag {
-            audioThreadSampleCount += samples.count
-        }
+        audioThreadSampleCount += samples.count
 
         // === Main thread dispatch (for in-app UI: RecordingView, SwiftUI) ===
 

--- a/DictusApp/Audio/UnifiedAudioEngine.swift
+++ b/DictusApp/Audio/UnifiedAudioEngine.swift
@@ -796,16 +796,21 @@ class UnifiedAudioEngine: ObservableObject {
     /// IDLE FAST PATH (issue #106 Phase C): When `isRecordingFlag` is false, we skip the
     /// converter, waveform compute, energy buffer maintenance, and the main-thread
     /// dispatch — none of those outputs are consumed when no one is dictating. We only
-    /// emit a sparse heartbeat (every 10s instead of 1s) so the keyboard's watchdog
-    /// can still see the app is alive when a future dictation starts. The watchdog
-    /// itself is gated to active dictation states (KeyboardState.startWatchdog), so a
-    /// stale heartbeat during pure idle never triggers a reset.
+    /// emit a sparse heartbeat (every 3s instead of 1s) so the keyboard's watchdog
+    /// can still see the app is alive when a future dictation starts.
+    ///
+    /// WHY 3s (not 10s): `isRecordingFlag` is false during `.transcribing` too —
+    /// `collectSamples()` flips it to false before transcription begins. The keyboard
+    /// watchdog falls back to the heartbeat with a 5s threshold during active dictation.
+    /// A 10s throttle let transcriptions longer than 5s falsely trip the watchdog.
+    /// 3s keeps us safely below the threshold; the per-buffer drain reduction comes
+    /// from skipping conversion + waveform compute, not from the heartbeat cadence.
     private nonisolated func processBuffer(_ buffer: AVAudioPCMBuffer) {
         let now = Date().timeIntervalSince1970
 
         // Idle fast path — sparse heartbeat only.
         if !isRecordingFlag {
-            let idleHeartbeatThrottle: TimeInterval = 10.0
+            let idleHeartbeatThrottle: TimeInterval = 3.0
             if now - lastHeartbeatWrite >= idleHeartbeatThrottle {
                 lastHeartbeatWrite = now
                 AppGroup.defaults.set(now, forKey: SharedKeys.recordingHeartbeat)

--- a/DictusApp/Audio/UnifiedAudioEngine.swift
+++ b/DictusApp/Audio/UnifiedAudioEngine.swift
@@ -590,6 +590,19 @@ class UnifiedAudioEngine: ObservableObject {
         idleReleaseWorkItem = nil
     }
 
+    /// Wall-clock backstop for the asyncAfter timer. If iOS suspended the main
+    /// queue while we were backgrounded, `scheduleIdleRelease`'s `asyncAfter`
+    /// can fire late or get coalesced. The DictationCoordinator's
+    /// `didBecomeActive` handler calls this to verify: if we have been idle
+    /// past the threshold without the timer firing, release now (the engine is
+    /// burning battery for nothing). Issue #106 Phase B.
+    func enforceIdleReleaseIfDue() {
+        guard let started = lastIdleStartTime else { return }
+        let idle = Date().timeIntervalSince(started)
+        guard idle >= idleReleaseInterval else { return }
+        releaseWarmState(reason: "wallClockBackstop")
+    }
+
     /// Tear down the warm-state engine and deactivate the AVAudioSession.
     ///
     /// Called by the idle timer (`scheduleIdleRelease`). Public so the

--- a/DictusApp/DictationCoordinator.swift
+++ b/DictusApp/DictationCoordinator.swift
@@ -164,6 +164,21 @@ class DictationCoordinator: ObservableObject {
             }
         }
 
+        // Cancel any in-flight dictation when the audio session is interrupted
+        // (phone call, Siri, etc.) or media services are reset. UnifiedAudioEngine
+        // already tore down the engine; we just need to clean up the dictation
+        // pipeline state and notify the keyboard that the recording failed
+        // (issue #106).
+        NotificationCenter.default.addObserver(
+            forName: .dictusAudioSessionInterrupted,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.handleAudioInterruptionDuringDictation()
+            }
+        }
+
         // WHY observe didBecomeActive (not willEnterForeground):
         // willEnterForeground fires while the audio session is still interrupted.
         // didBecomeActive fires AFTER the app is fully active and the audio session
@@ -458,6 +473,43 @@ class DictationCoordinator: ObservableObject {
     func resetStatus() {
         updateStatus(.idle)
         // Keep lastResult so HomeView can display the last transcription card.
+    }
+
+    /// Handle an audio session interruption that fired while dictation was active.
+    ///
+    /// UnifiedAudioEngine has already stopped the engine and posted the in-process
+    /// notification. We only need to clean up the dictation pipeline: cancel the
+    /// in-flight task, drop accumulated samples, write a "failed" status to App
+    /// Group so the keyboard's overlay closes, and notify the user via the Live
+    /// Activity (LiveActivityManager handles its own end via the same notification).
+    /// Issue #106.
+    private func handleAudioInterruptionDuringDictation() {
+        let wasActive = (status == .recording || status == .requested || status == .transcribing)
+        guard wasActive else {
+            // Engine died while idle — nothing to roll back. The standby DI is
+            // dismissed by LiveActivityManager via the same notification.
+            return
+        }
+
+        dictationTask?.cancel()
+        dictationTask = nil
+        stopTranscriptionWatchdog()
+
+        bufferEnergy = []
+        bufferSeconds = 0
+        cleanupRecordingKeys()
+
+        // Surface the failure to the keyboard via App Group + Darwin notification
+        // so the overlay collapses instead of timing out via the watchdog.
+        defaults.set(DictationStatus.failed.rawValue, forKey: SharedKeys.dictationStatus)
+        defaults.synchronize()
+        DarwinNotificationCenter.post(DarwinNotificationName.statusChanged)
+
+        updateStatus(.failed)
+
+        if #available(iOS 14.0, *) {
+            DictusLogger.app.warning("Dictation cancelled by audio session interruption")
+        }
     }
 
     // MARK: - Private Helpers

--- a/DictusApp/DictationCoordinator.swift
+++ b/DictusApp/DictationCoordinator.swift
@@ -499,12 +499,8 @@ class DictationCoordinator: ObservableObject {
         bufferSeconds = 0
         cleanupRecordingKeys()
 
-        // Surface the failure to the keyboard via App Group + Darwin notification
-        // so the overlay collapses instead of timing out via the watchdog.
-        defaults.set(DictationStatus.failed.rawValue, forKey: SharedKeys.dictationStatus)
-        defaults.synchronize()
-        DarwinNotificationCenter.post(DarwinNotificationName.statusChanged)
-
+        // updateStatus(.failed) handles both the App Group write and the Darwin
+        // statusChanged post — no manual duplication needed (issue #106 review).
         updateStatus(.failed)
 
         if #available(iOS 14.0, *) {

--- a/DictusApp/DictationCoordinator.swift
+++ b/DictusApp/DictationCoordinator.swift
@@ -198,6 +198,15 @@ class DictationCoordinator: ObservableObject {
                     context: "didBecomeActive"
                 ))
 
+                // Wall-clock backstop for Phase B's idle-release timer (issue #106).
+                // If iOS suspended the main queue while we were backgrounded, the
+                // asyncAfter scheduled in scheduleIdleRelease may fire late. On
+                // foreground transition we have a reliable runloop again — this
+                // call releases the warm state if the idle interval already
+                // expired during the suspension. Must happen BEFORE warmUp below,
+                // otherwise we'd warm an engine that should be released.
+                self.audioEngine.enforceIdleReleaseIfDue()
+
                 // Recover DI if it was lost (Activity.request fails from background on cold start).
                 // Must happen BEFORE pendingColdStartDictation so transitionToRecording finds an activity.
                 LiveActivityManager.shared.ensureActivityAlive()

--- a/DictusApp/Info.plist
+++ b/DictusApp/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>15</string>
+	<string>13</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusApp/Info.plist
+++ b/DictusApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>14</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusApp/Info.plist
+++ b/DictusApp/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>15</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusApp/Info.plist
+++ b/DictusApp/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>14</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusApp/LiveActivityManager.swift
+++ b/DictusApp/LiveActivityManager.swift
@@ -138,6 +138,94 @@ class LiveActivityManager {
         ) { [weak self] _ in
             self?.endAllActivitiesSync()
         }
+
+        // End the Live Activity when the audio session is interrupted (phone call,
+        // Siri, etc.) or media services were reset. The DI must NOT keep showing
+        // a "ready to dictate" indicator while the underlying audio engine is dead;
+        // the user perceives this as broken — they tap and get a cold start instead
+        // of the warm dictation the DI implied (issue #106).
+        NotificationCenter.default.addObserver(
+            forName: .dictusAudioSessionInterrupted,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.endActivityForAudioInterruption()
+            }
+        }
+
+        // Dismiss the standby DI when the warm-state engine is released after the
+        // idle timeout (issue #106 Phase B). A standby pill suggests the next
+        // dictation is instant — but the engine is asleep, so it would be a cold
+        // start. End the activity so the UI matches reality.
+        NotificationCenter.default.addObserver(
+            forName: .dictusWarmStateReleased,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.endActivityForWarmStateRelease()
+            }
+        }
+    }
+
+    /// Tear down the Live Activity because the audio session was interrupted.
+    /// Force-syncs internal state before issuing the async `activity.end` so a
+    /// concurrent `transitionToRecording` can't resurrect the dead activity.
+    func endActivityForAudioInterruption() {
+        guard let activity = currentActivity else {
+            // No activity to end, but reset state in case it was leaked.
+            currentPhase = .idle
+            syncStateMachine(to: .idle)
+            return
+        }
+
+        autoDismissTask?.cancel()
+        autoDismissTask = nil
+        cancelRecordingWatchdog()
+
+        currentActivity = nil
+        currentPhase = .idle
+        syncStateMachine(to: .idle)
+        PersistentLog.log(.liveActivityEnded(reason: "audioInterrupted"))
+
+        Task {
+            let finalState = DictusLiveActivityAttributes.ContentState(phase: .failed)
+            await activity.end(
+                .init(state: finalState, staleDate: nil),
+                dismissalPolicy: .immediate
+            )
+            DictusLogger.app.info("Live Activity ended -- audio session interrupted")
+        }
+    }
+
+    /// Tear down the Live Activity because the warm-state engine was released.
+    /// The DI is dismissed gracefully (.standby final state, not .failed) since
+    /// nothing actually went wrong — the app simply went idle (issue #106).
+    func endActivityForWarmStateRelease() {
+        guard let activity = currentActivity else {
+            currentPhase = .idle
+            syncStateMachine(to: .idle)
+            return
+        }
+
+        autoDismissTask?.cancel()
+        autoDismissTask = nil
+        cancelRecordingWatchdog()
+
+        currentActivity = nil
+        currentPhase = .idle
+        syncStateMachine(to: .idle)
+        PersistentLog.log(.liveActivityEnded(reason: "warmStateReleased"))
+
+        Task {
+            let finalState = DictusLiveActivityAttributes.ContentState(phase: .standby)
+            await activity.end(
+                .init(state: finalState, staleDate: nil),
+                dismissalPolicy: .immediate
+            )
+            DictusLogger.app.info("Live Activity ended -- warm state released after idle timeout")
+        }
     }
 
     // MARK: - Standby Mode

--- a/DictusCore/Sources/DictusCore/DarwinNotifications.swift
+++ b/DictusCore/Sources/DictusCore/DarwinNotifications.swift
@@ -24,6 +24,18 @@ public enum DarwinNotificationName {
     /// Used when the app is already running in background — avoids opening the app via URL.
     /// Fallback: if app doesn't respond within 500ms, keyboard opens dictus://dictate URL.
     public static let startRecording = "com.pivi.dictus.startRecording" as CFString
+
+    /// Posted by DictusApp when AVAudioSession is interrupted (phone call, Siri, etc.)
+    /// or when media services were reset by the OS. Consumers tear down dependent
+    /// state — Live Activity ends, in-flight transcription is cancelled, the keyboard
+    /// can show a "session interrupted" indicator if desired (issue #106).
+    public static let audioSessionInterrupted = "com.pivi.dictus.audioSessionInterrupted" as CFString
+
+    /// Posted by DictusApp when the warm-state engine is released after the idle
+    /// timeout (issue #106 Phase B). Consumers should treat the next dictation
+    /// request as a cold start. Used to dismiss the Dynamic Island standby indicator
+    /// so the UI no longer suggests "ready to dictate" when the engine is asleep.
+    public static let warmStateReleased = "com.pivi.dictus.warmStateReleased" as CFString
 }
 
 /// Global callback registry for Darwin notifications.

--- a/DictusCore/Sources/DictusCore/LogEvent.swift
+++ b/DictusCore/Sources/DictusCore/LogEvent.swift
@@ -50,6 +50,12 @@ public enum LogEvent: Sendable {
     case audioEngineStopped
     case audioSessionConfigured(category: String)
     case audioSessionFailed(error: String)
+    case audioInterruptionBegan(reason: String)
+    case audioInterruptionEnded(shouldResume: Bool, restored: Bool)
+    case audioRouteChanged(reason: String, details: String)
+    case audioMediaServicesReset
+    case warmStateReleased(idleSeconds: Int)
+    case warmStateRestored(context: String)
 
     // MARK: Transcription
     case transcriptionStarted(modelName: String)
@@ -150,7 +156,9 @@ public enum LogEvent: Sendable {
         switch self {
         case .dictationStarted, .dictationCompleted, .dictationFailed, .dictationDeferred:
             return .dictation
-        case .audioEngineStarted, .audioEngineStopped, .audioSessionConfigured, .audioSessionFailed:
+        case .audioEngineStarted, .audioEngineStopped, .audioSessionConfigured, .audioSessionFailed,
+             .audioInterruptionBegan, .audioInterruptionEnded, .audioRouteChanged,
+             .audioMediaServicesReset, .warmStateReleased, .warmStateRestored:
             return .audio
         case .transcriptionStarted, .transcriptionCompleted, .transcriptionFailed, .recordingTooShort,
              .transcriptionPerformance:
@@ -204,7 +212,8 @@ public enum LogEvent: Sendable {
         // Warnings
         case .dictationDeferred, .watchdogReset, .engineWarmUpFailed, .recordingTooShort,
              .waveformStall, .waveformTimelineNotFiring,
-             .coldStartDarwinFallback, .modelPrewarmTimeout:
+             .coldStartDarwinFallback, .modelPrewarmTimeout,
+             .audioInterruptionBegan, .audioMediaServicesReset:
             return .warning
 
         // Info (normal operations: starts, completes, selections, configs)
@@ -225,7 +234,9 @@ public enum LogEvent: Sendable {
              .coldStartURLReceived, .coldStartFlagSet, .coldStartRetry,
              .overlayShown, .overlayHidden, .statusChanged,
              .waveformAppeared, .waveformDisappeared, .waveformRefreshIDChanged,
-             .waveformEnergyTransition, .overlayBodyEvaluated, .overlayRecreated:
+             .waveformEnergyTransition, .overlayBodyEvaluated, .overlayRecreated,
+             .audioInterruptionEnded, .audioRouteChanged,
+             .warmStateReleased, .warmStateRestored:
             return .info
 
         // Debug (internal state transitions)
@@ -255,6 +266,12 @@ public enum LogEvent: Sendable {
         case .audioEngineStopped: return "audioEngineStopped"
         case .audioSessionConfigured: return "audioSessionConfigured"
         case .audioSessionFailed: return "audioSessionFailed"
+        case .audioInterruptionBegan: return "audioInterruptionBegan"
+        case .audioInterruptionEnded: return "audioInterruptionEnded"
+        case .audioRouteChanged: return "audioRouteChanged"
+        case .audioMediaServicesReset: return "audioMediaServicesReset"
+        case .warmStateReleased: return "warmStateReleased"
+        case .warmStateRestored: return "warmStateRestored"
         case .transcriptionStarted: return "transcriptionStarted"
         case .transcriptionCompleted: return "transcriptionCompleted"
         case .transcriptionFailed: return "transcriptionFailed"
@@ -347,6 +364,18 @@ public enum LogEvent: Sendable {
             return "category=\(category)"
         case .audioSessionFailed(let error):
             return "error=\(error)"
+        case .audioInterruptionBegan(let reason):
+            return "reason=\(reason)"
+        case .audioInterruptionEnded(let shouldResume, let restored):
+            return "shouldResume=\(shouldResume) restored=\(restored)"
+        case .audioRouteChanged(let reason, let details):
+            return "reason=\(reason) details=\(details)"
+        case .audioMediaServicesReset:
+            return ""
+        case .warmStateReleased(let idleSeconds):
+            return "idleSeconds=\(idleSeconds)"
+        case .warmStateRestored(let context):
+            return "context=\(context)"
 
         // Transcription
         case .transcriptionStarted(let modelName):

--- a/DictusCore/Sources/DictusCore/MemoryFootprint.swift
+++ b/DictusCore/Sources/DictusCore/MemoryFootprint.swift
@@ -1,0 +1,26 @@
+// DictusCore/MemoryFootprint.swift
+import Foundation
+import Darwin
+
+/// Reads the resident memory footprint of the current process via Mach task info.
+///
+/// Keyboard extensions have a hard ~50 MB budget — iOS terminates the process
+/// when it gets close. Logging RSS at lifecycle boundaries lets us see where
+/// the spend goes (baseline vs transient peaks during rebuild) so we can
+/// target reductions instead of guessing.
+public enum MemoryFootprint {
+    /// Current resident size (MB, integer). Returns -1 on failure.
+    public static func residentMB() -> Int {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.size) / 4
+        let kr = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), $0, &count)
+            }
+        }
+        guard kr == KERN_SUCCESS else { return -1 }
+        // phys_footprint is what iOS uses for the jetsam budget — closer to the
+        // "real" number than resident_size, which excludes compressed pages.
+        return Int(info.phys_footprint / (1024 * 1024))
+    }
+}

--- a/DictusKeyboard/Info.plist
+++ b/DictusKeyboard/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>14</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusKeyboard/Info.plist
+++ b/DictusKeyboard/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.0</string>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>14</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusKeyboard/Info.plist
+++ b/DictusKeyboard/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.0</string>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>15</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusKeyboard/Info.plist
+++ b/DictusKeyboard/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.0</string>
 	<key>CFBundleVersion</key>
-	<string>15</string>
+	<string>13</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusKeyboard/KeyboardRootView.swift
+++ b/DictusKeyboard/KeyboardRootView.swift
@@ -25,7 +25,6 @@ extension DefaultKeyboardLayer {
 /// zero-latency touch handling. The key grid needs UICollectionView's proven touch
 /// pipeline for zero dead zones. Mixing UIKit keys + SwiftUI chrome gives us both.
 struct KeyboardRootView: View {
-    let controller: UIInputViewController
     let controllerID: String
     @ObservedObject private var state = KeyboardState.shared
     @ObservedObject private var waveformDriver = KeyboardWaveformDriver.shared
@@ -48,6 +47,11 @@ struct KeyboardRootView: View {
     /// Callback when the user cycles language via the toolbar switcher.
     /// The controller uses this to reload the GiellaKeyboardView with the new layout.
     var onLanguageChanged: ((SupportedLanguage) -> Void)?
+
+    /// Invoked when the user taps the emoji picker's dismiss button.
+    /// Supplied by KeyboardViewController with [weak self] capture so we don't
+    /// retain the controller through the hosting view (issue #134).
+    var onEmojiDismiss: (() -> Void)?
 
     /// WHY @Environment here: openURL is the SwiftUI way to open URLs.
     /// Keyboard extensions cannot access UIApplication.shared, but SwiftUI's
@@ -94,7 +98,7 @@ struct KeyboardRootView: View {
                     VStack(spacing: 0) {
                         // Toolbar stays visible during emoji browsing
                         ToolbarView(
-                            hasFullAccess: controller.hasFullAccess,
+                            hasFullAccess: state.controller?.hasFullAccess ?? false,
                             dictationStatus: state.dictationStatus,
                             onMicTap: {
                                 showingEmoji = false
@@ -110,19 +114,19 @@ struct KeyboardRootView: View {
                         // Emoji picker uses exact measured dimensions
                         EmojiPickerView(
                             onEmojiInsert: { emoji in
-                                controller.textDocumentProxy.insertText(emoji)
+                                state.controller?.textDocumentProxy.insertText(emoji)
                                 HapticFeedback.keyTapped()
                             },
                             onDelete: {
-                                controller.textDocumentProxy.deleteBackward()
+                                state.controller?.textDocumentProxy.deleteBackward()
                                 HapticFeedback.keyTapped()
                             },
                             onDismiss: {
-                                // Call toggleEmojiPicker() on the controller which handles:
-                                // hiding emoji, showing giellaKeyboard, shrinking hosting,
-                                // and posting .dictusToggleEmoji (which .onReceive picks up
-                                // to set showingEmoji = false).
-                                (controller as? KeyboardViewController)?.toggleEmojiPicker()
+                                // Invokes KeyboardViewController.toggleEmojiPicker() via
+                                // [weak self] closure injected at viewDidLoad time.
+                                // Avoids the (controller as? KeyboardViewController) cast
+                                // that used to require a strong controller ref (#134).
+                                onEmojiDismiss?()
                             },
                             availableWidth: geo.size.width,
                             availableHeight: geo.size.height - 52
@@ -132,7 +136,7 @@ struct KeyboardRootView: View {
             } else {
                 // Toolbar only -- the keyboard grid is UIKit, managed by KeyboardViewController
                 ToolbarView(
-                    hasFullAccess: controller.hasFullAccess,
+                    hasFullAccess: state.controller?.hasFullAccess ?? false,
                     dictationStatus: state.dictationStatus,
                     onMicTap: { state.startRecording() },
                     statusMessage: state.statusMessage,
@@ -193,8 +197,9 @@ struct KeyboardRootView: View {
                 action: "onAppear",
                 details: "status=\(state.dictationStatus.rawValue) visible=\(state.isKeyboardVisible) owner=\(state.activeControllerID ?? "none") controllerID=\(controllerID)"
             ))
-            // Provide controller reference to KeyboardState for auto-insert.
-            state.controller = controller
+            // state.controller is set by KeyboardViewController.viewWillAppear to avoid
+            // a strong ref cycle through the hosting view (#134). openURL must stay
+            // here — it's a SwiftUI @Environment value, only capturable from a View.
             state.openURL = { url in openURL(url) }
 
             // Pre-allocate haptic generators so the first key tap has zero latency.
@@ -245,7 +250,7 @@ struct KeyboardRootView: View {
     private func handleSuggestionTap(index: Int) {
         guard index < suggestionState.suggestions.count else { return }
         let suggestion = suggestionState.suggestions[index]
-        let proxy = controller.textDocumentProxy
+        guard let proxy = state.controller?.textDocumentProxy else { return }
 
         // Prediction mode: insert word + trailing space, bypass autocorrect, chain predictions.
         if suggestionState.mode == .predictions {

--- a/DictusKeyboard/KeyboardRootView.swift
+++ b/DictusKeyboard/KeyboardRootView.swift
@@ -151,6 +151,13 @@ struct KeyboardRootView: View {
                 // No bottom spacer -- the UIKit keyboard handles its own height
             }
         }
+        // Issue #142: force the body to fill its hosting frame top-aligned.
+        // Without this, when the hosting view expands from 52→276pt on mic
+        // tap but SwiftUI hasn't yet re-rendered ToolbarView→RecordingOverlay
+        // (1-frame async lag), UIHostingController centres the 52pt toolbar
+        // intrinsic content inside its 276pt frame — and iOS's keyboard-down
+        // animation snapshot freezes that centred-toolbar layout on screen.
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .background(Color.clear)
         .onChange(of: showsOverlay) { _, isShowing in
             let usedFallback = isShowing && state.activeControllerID == nil

--- a/DictusKeyboard/KeyboardViewController.swift
+++ b/DictusKeyboard/KeyboardViewController.swift
@@ -35,6 +35,18 @@ class KeyboardViewController: UIInputViewController {
     /// Changes from toolbarHeight (52pt) to full height when recording overlay is active.
     private var hostingHeightConstraint: NSLayoutConstraint?
 
+    /// Idle-state bottom anchor: hosting sits directly above the keyboard.
+    /// Active when not recording / emoji. Deactivated when expanding to fill
+    /// the full keyboard area, where we instead pin hosting's bottom to
+    /// kbInputView's bottom so the overlay fills the entire keyboard.
+    private var hostingBottomToKeyboardTop: NSLayoutConstraint?
+
+    /// Expanded-state bottom anchor: hosting's bottom == kbInputView's bottom.
+    /// Active during recording overlay or emoji picker (when keyboard is
+    /// hidden). With this active + height=276, hosting fills the whole
+    /// keyboard area without leaving stripes off-screen.
+    private var hostingBottomToInputBottom: NSLayoutConstraint?
+
     /// Fixed toolbar height matching ToolbarView (52pt: 48pt content + 4pt top padding).
     private let toolbarHeight: CGFloat = 52
 
@@ -75,6 +87,18 @@ class KeyboardViewController: UIInputViewController {
         // Do NOT set translatesAutoresizingMaskIntoConstraints = false on the inputView.
         // iOS manages the inputView's frame via autoresizing masks -- disabling them
         // causes the view to collapse to zero width.
+
+        // #92 fix: kbInputView is opaque by default (UIInputView base) and with
+        // backgroundColor=nil it paints a default grey in any region not covered
+        // by a subview. During iOS's keyboard entry animation, iOS forces the
+        // inputView to ~504pt at constraint priority 1000 (we cannot win against
+        // it). Our content fills only 276pt — without these two lines, the
+        // remaining 228pt rendered as a visible grey rectangle. Forcing the view
+        // truly transparent + non-opaque makes that uncovered area composite
+        // with whatever sits behind the keyboard window (the host app),
+        // matching what Apple's own keyboards do.
+        kbInputView.backgroundColor = .clear
+        kbInputView.isOpaque = false
 
         // --- 1. Create the giellakbd-ios UIKit keyboard ---
         let definition = KeyboardLayouts.current()
@@ -165,43 +189,57 @@ class KeyboardViewController: UIInputViewController {
         // must be able to EXPAND to full height during recording overlay.
         hosting.view.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
 
-        // Pin keyboard grid to a fixed height (key grid only) instead of stretching
-        // to kbInputView.bottomAnchor. WHY: during iOS's keyboard entry animation,
-        // kbInputView transiently has height ~504pt before settling to our 276pt
-        // constraint. With a bottom-anchor pin the giellaKeyboard would stretch to
-        // ~452pt → visible "double-size keys" flash. With a fixed heightAnchor the
-        // grid stays at keyGridHeight regardless; iOS's transient extra space shows
-        // up as kbInputView's plain background below the grid (much less jarring).
+        // Pin keyboard grid to a fixed height (key grid only) so it never stretches
+        // beyond its natural 224pt — even when iOS forces the inputView to 504pt
+        // during the entry animation. With a bottom-anchor pin the giellaKeyboard
+        // would stretch to ~452pt → "double-size keys" flash (#116 / ba12a69).
         let keyGridHeight = computeKeyboardHeight() - toolbarHeight
         let keyboardHeight = keyboard.heightAnchor.constraint(equalToConstant: keyGridHeight)
         keyboardHeight.priority = UILayoutPriority(999)
 
-        NSLayoutConstraint.activate([
-            // Toolbar (SwiftUI hosting) at top
-            hosting.view.topAnchor.constraint(equalTo: kbInputView.topAnchor),
-            hosting.view.leadingAnchor.constraint(equalTo: kbInputView.leadingAnchor),
-            hosting.view.trailingAnchor.constraint(equalTo: kbInputView.trailingAnchor),
-            hostingHeight,
+        // #92 fix: bottom-anchor the content stack inside kbInputView (matches
+        // upstream giellakbd-ios). Combined with kbInputView.backgroundColor =
+        // .clear, this makes the 228pt empty zone appear at the TOP of the
+        // expanded inputView during the entry animation transient — i.e. in
+        // the host-app-content region right above the toolbar — instead of at
+        // the bottom (between keys and screen edge), which was extremely
+        // visible. With the inputView transparent the host app shows through,
+        // matching what Apple's own keyboards render in that area.
+        let hostingBottomIdle = hosting.view.bottomAnchor.constraint(equalTo: keyboard.topAnchor)
+        let hostingBottomExpanded = hosting.view.bottomAnchor.constraint(equalTo: kbInputView.bottomAnchor)
+        hostingBottomIdle.isActive = true
+        hostingBottomExpanded.isActive = false
+        self.hostingBottomToKeyboardTop = hostingBottomIdle
+        self.hostingBottomToInputBottom = hostingBottomExpanded
 
-            // UIKit keyboard below toolbar with FIXED height (no bottomAnchor pin)
-            keyboard.topAnchor.constraint(equalTo: hosting.view.bottomAnchor),
+        NSLayoutConstraint.activate([
+            // UIKit keyboard pinned to the bottom of the inputView
+            keyboard.bottomAnchor.constraint(equalTo: kbInputView.bottomAnchor),
             keyboard.leadingAnchor.constraint(equalTo: kbInputView.leadingAnchor),
             keyboard.trailingAnchor.constraint(equalTo: kbInputView.trailingAnchor),
             keyboardHeight,
+
+            // Toolbar (SwiftUI hosting) — bottom anchor swapped at runtime
+            // (see hostingBottomToKeyboardTop / hostingBottomToInputBottom)
+            hosting.view.leadingAnchor.constraint(equalTo: kbInputView.leadingAnchor),
+            hosting.view.trailingAnchor.constraint(equalTo: kbInputView.trailingAnchor),
+            hostingHeight,
         ])
 
-        // --- 6. Set explicit height constraint on inputView ---
-        // Priority 999 (just below .required) wins against iOS's transition-time
-        // inputView sizing while staying breakable in genuinely unrecoverable
-        // situations. iOS settles to our 276pt value ~500ms after viewDidAppear
-        // (verified by deferred layoutSnapshot probes). Constraint on self.view
-        // was tried and reverted — it did not improve settlement behaviour and
-        // added an unnecessary layer of negotiation.
-        let height = computeKeyboardHeight()
-        let constraint = kbInputView.heightAnchor.constraint(equalToConstant: height)
-        constraint.priority = UILayoutPriority(999)
-        constraint.isActive = true
-        self.heightConstraint = constraint
+        // --- 6. Defer the height constraint to viewDidLayoutSubviews first run ---
+        // #92: installing this constraint in viewDidLoad fights iOS's
+        // priority-1000 UIView-Encapsulated-Layout-Height during the entry
+        // animation, producing a visible "keyboard grows then shrinks"
+        // transient (956 → 504 → 276 over ~150ms).
+        //
+        // Upstream giellakbd-ios installs its height constraint in
+        // viewDidLayoutSubviews first run, dispatched async to the main queue,
+        // with the comment: "If this is removed, iPhone 5s glitches before
+        // finding the correct height." Adding the constraint AFTER iOS has
+        // completed its initial layout pass lets our 999-priority constraint
+        // win without fighting the encapsulated-layout-height directly.
+        //
+        // Constraint creation moved to installInputViewHeightConstraint().
 
         // Attempt to prevent top-row key popup clipping. iOS may re-enforce
         // clipsToBounds -- if so, this is a known limitation of third-party keyboard extensions.
@@ -357,6 +395,7 @@ class KeyboardViewController: UIInputViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+
         // Issue #116 diagnostic: snapshot final frames after layout settles.
         // We log both sizes and constraint constants so we can detect priority mismatches
         // where iOS imposed a different height than we asked for.
@@ -375,6 +414,58 @@ class KeyboardViewController: UIInputViewController {
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
             self?.logLayoutSnapshot(action: "layoutSnapshot_2000ms")
+        }
+    }
+
+    /// First-run flag for viewDidLayoutSubviews. Used by upstream
+    /// giellakbd-ios pattern (#92): install the input view height constraint
+    /// after iOS finishes its initial layout pass, not in viewDidLoad.
+    private var isFirstLayoutPass = true
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        if isFirstLayoutPass {
+            isFirstLayoutPass = false
+            // Defer constraint installation to the next runloop turn so we
+            // don't mutate constraints inside iOS's own layout pass. Upstream
+            // comment: "If this is removed, iPhone 5s glitches before finding
+            // the correct height."
+            DispatchQueue.main.async { [weak self] in
+                self?.installInputViewHeightConstraint()
+            }
+        }
+    }
+
+    /// Installs the 999-priority height constraint on kbInputView. Called once
+    /// (lazy) from the first viewDidLayoutSubviews via async dispatch. Adding
+    /// the constraint here, AFTER iOS has completed its initial layout pass,
+    /// lets us win against the encapsulated-layout-height (priority 1000)
+    /// without the entry animation flashing at 504pt.
+    private func installInputViewHeightConstraint() {
+        guard heightConstraint == nil, let kbInputView = inputView else { return }
+        let height = computeKeyboardHeight()
+        let constraint = kbInputView.heightAnchor.constraint(equalToConstant: height)
+        constraint.priority = UILayoutPriority(999)
+        constraint.isActive = true
+        self.heightConstraint = constraint
+    }
+
+    /// Swap hosting view's bottom anchor between idle and expanded positions.
+    /// - Idle: hosting.bottom = keyboard.top (sits above the keys at 52pt).
+    /// - Expanded: hosting.bottom = kbInputView.bottom (fills the full
+    ///   keyboard area, used when the recording overlay or emoji picker is
+    ///   shown and the keyboard view is hidden).
+    ///
+    /// Without this swap, expanding the hosting height alone (with the idle
+    /// bottom anchor still active) pushes hosting.top above kbInputView,
+    /// leaving the overlay stuck off-screen — the bug in #92 follow-up.
+    private func setHostingExpanded(_ expanded: Bool) {
+        if expanded {
+            hostingBottomToKeyboardTop?.isActive = false
+            hostingBottomToInputBottom?.isActive = true
+        } else {
+            hostingBottomToInputBottom?.isActive = false
+            hostingBottomToKeyboardTop?.isActive = true
         }
     }
 
@@ -574,6 +665,7 @@ class KeyboardViewController: UIInputViewController {
             // Expand hosting view to fill the full keyboard area for the recording overlay
             let fullHeight = computeKeyboardHeight()
             hostingHeightConstraint?.constant = fullHeight
+            setHostingExpanded(true)
             PersistentLog.log(.diagnosticProbe(
                 component: "KeyboardViewController",
                 instanceID: controllerID,
@@ -583,6 +675,7 @@ class KeyboardViewController: UIInputViewController {
         } else if !isShowingEmoji {
             // Restore toolbar-only height (unless emoji picker is open)
             hostingHeightConstraint?.constant = toolbarHeight
+            setHostingExpanded(false)
             PersistentLog.log(.diagnosticProbe(
                 component: "KeyboardViewController",
                 instanceID: controllerID,
@@ -693,19 +786,32 @@ class KeyboardViewController: UIInputViewController {
         // Add to view hierarchy below the hosting view
         kbInputView.addSubview(keyboard)
 
-        // Re-create constraints. Same heightAnchor approach as viewDidLoad — fixed
-        // 224pt height instead of bottomAnchor pin to prevent layout-transition flash.
+        // Re-create constraints. Mirrors the bottom-anchor layout from viewDidLoad
+        // (#92 fix): keyboard pinned to kbInputView.bottomAnchor with a fixed
+        // height, hosting view sits directly above it.
+        //
+        // Note: the old hostingBottomToKeyboardTop pointed at the previous
+        // keyboard view (about to be deallocated) — we deactivate it and
+        // create a new one referencing the new keyboard.
+        hostingBottomToKeyboardTop?.isActive = false
         if let hostingView = hostingController?.view {
             let keyGridHeight = computeKeyboardHeight() - toolbarHeight
             let keyboardHeight = keyboard.heightAnchor.constraint(equalToConstant: keyGridHeight)
             keyboardHeight.priority = UILayoutPriority(999)
+            let newHostingBottomIdle = hostingView.bottomAnchor.constraint(equalTo: keyboard.topAnchor)
             NSLayoutConstraint.activate([
-                keyboard.topAnchor.constraint(equalTo: hostingView.bottomAnchor),
+                keyboard.bottomAnchor.constraint(equalTo: kbInputView.bottomAnchor),
                 keyboard.leadingAnchor.constraint(equalTo: kbInputView.leadingAnchor),
                 keyboard.trailingAnchor.constraint(equalTo: kbInputView.trailingAnchor),
                 keyboardHeight,
+                newHostingBottomIdle,
             ])
+            self.hostingBottomToKeyboardTop = newHostingBottomIdle
         }
+        // reloadKeyboardLayout always returns the layout to idle (the height
+        // is reset to toolbarHeight just below). Make sure the expanded bottom
+        // anchor isn't lingering active from a previous recording/emoji state.
+        hostingBottomToInputBottom?.isActive = false
 
         self.giellaKeyboard = keyboard
 
@@ -766,6 +872,7 @@ class KeyboardViewController: UIInputViewController {
             // Expand hosting to cover keyboard area for emoji picker
             let fullHeight = computeKeyboardHeight()
             hostingHeightConstraint?.constant = fullHeight
+            setHostingExpanded(true)
             PersistentLog.log(.diagnosticProbe(
                 component: "KeyboardViewController",
                 instanceID: controllerID,
@@ -774,6 +881,7 @@ class KeyboardViewController: UIInputViewController {
             ))
         } else {
             hostingHeightConstraint?.constant = toolbarHeight
+            setHostingExpanded(false)
             PersistentLog.log(.diagnosticProbe(
                 component: "KeyboardViewController",
                 instanceID: controllerID,

--- a/DictusKeyboard/KeyboardViewController.swift
+++ b/DictusKeyboard/KeyboardViewController.swift
@@ -168,6 +168,17 @@ class KeyboardViewController: UIInputViewController {
         // must be able to EXPAND to full height during recording overlay.
         hosting.view.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
 
+        // Pin keyboard grid to a fixed height (key grid only) instead of stretching
+        // to kbInputView.bottomAnchor. WHY: during iOS's keyboard entry animation,
+        // kbInputView transiently has height ~504pt before settling to our 276pt
+        // constraint. With a bottom-anchor pin the giellaKeyboard would stretch to
+        // ~452pt → visible "double-size keys" flash. With a fixed heightAnchor the
+        // grid stays at keyGridHeight regardless; iOS's transient extra space shows
+        // up as kbInputView's plain background below the grid (much less jarring).
+        let keyGridHeight = computeKeyboardHeight() - toolbarHeight
+        let keyboardHeight = keyboard.heightAnchor.constraint(equalToConstant: keyGridHeight)
+        keyboardHeight.priority = UILayoutPriority(999)
+
         NSLayoutConstraint.activate([
             // Toolbar (SwiftUI hosting) at top
             hosting.view.topAnchor.constraint(equalTo: kbInputView.topAnchor),
@@ -175,11 +186,11 @@ class KeyboardViewController: UIInputViewController {
             hosting.view.trailingAnchor.constraint(equalTo: kbInputView.trailingAnchor),
             hostingHeight,
 
-            // UIKit keyboard below toolbar
+            // UIKit keyboard below toolbar with FIXED height (no bottomAnchor pin)
             keyboard.topAnchor.constraint(equalTo: hosting.view.bottomAnchor),
             keyboard.leadingAnchor.constraint(equalTo: kbInputView.leadingAnchor),
             keyboard.trailingAnchor.constraint(equalTo: kbInputView.trailingAnchor),
-            keyboard.bottomAnchor.constraint(equalTo: kbInputView.bottomAnchor),
+            keyboardHeight,
         ])
 
         // --- 6. Set explicit height constraint on inputView ---
@@ -662,13 +673,17 @@ class KeyboardViewController: UIInputViewController {
         // Add to view hierarchy below the hosting view
         kbInputView.addSubview(keyboard)
 
-        // Re-create constraints
+        // Re-create constraints. Same heightAnchor approach as viewDidLoad — fixed
+        // 224pt height instead of bottomAnchor pin to prevent layout-transition flash.
         if let hostingView = hostingController?.view {
+            let keyGridHeight = computeKeyboardHeight() - toolbarHeight
+            let keyboardHeight = keyboard.heightAnchor.constraint(equalToConstant: keyGridHeight)
+            keyboardHeight.priority = UILayoutPriority(999)
             NSLayoutConstraint.activate([
                 keyboard.topAnchor.constraint(equalTo: hostingView.bottomAnchor),
                 keyboard.leadingAnchor.constraint(equalTo: kbInputView.leadingAnchor),
                 keyboard.trailingAnchor.constraint(equalTo: kbInputView.trailingAnchor),
-                keyboard.bottomAnchor.constraint(equalTo: kbInputView.bottomAnchor),
+                keyboardHeight,
             ])
         }
 

--- a/DictusKeyboard/KeyboardViewController.swift
+++ b/DictusKeyboard/KeyboardViewController.swift
@@ -95,13 +95,20 @@ class KeyboardViewController: UIInputViewController {
         self.giellaKeyboard = keyboard
 
         // --- 3. Create SwiftUI hosting for toolbar + recording overlay ONLY ---
+        // NOTE: do NOT pass `self` into KeyboardRootView. Storing the controller on
+        // the View struct creates a strong ref cycle through UIHostingController that
+        // prevents stale controllers from deiniting across app-switches (#134).
+        // The view accesses the controller through KeyboardState.shared.controller
+        // (weak), which is set in viewWillAppear below.
         let rootView = KeyboardRootView(
-            controller: self,
             controllerID: controllerID,
             suggestionState: suggestionState,
             bridge: keyBridge,
             onLanguageChanged: { [weak self] newLang in
                 self?.handleLanguageChange(newLang)
+            },
+            onEmojiDismiss: { [weak self] in
+                self?.toggleEmojiPicker()
             }
         )
         let hosting = UIHostingController(rootView: rootView)
@@ -228,6 +235,10 @@ class KeyboardViewController: UIInputViewController {
         ))
         PersistentLog.log(.keyboardDidAppear)
         KeyboardState.shared.registerControllerAppearance(controllerID: controllerID)
+        // Point KeyboardState's weak controller ref at the currently-visible controller
+        // so call sites in KeyboardRootView and KeyboardState can access textDocumentProxy.
+        // Previously set from KeyboardRootView.onAppear, which held a strong ref → #134.
+        KeyboardState.shared.controller = self
         hasAppeared = true
 
         // (Re)subscribe to dictation status here, not in viewDidLoad.

--- a/DictusKeyboard/KeyboardViewController.swift
+++ b/DictusKeyboard/KeyboardViewController.swift
@@ -10,11 +10,10 @@ class KeyboardViewController: UIInputViewController {
     private var hostingController: UIHostingController<KeyboardRootView>?
     private var dictationStatusCancellable: AnyCancellable?
 
-    /// Central SuggestionState owned by the controller and injected into both
-    /// the bridge (for keystroke-driven updates) and the SwiftUI root view (for display).
-    /// WHY here: Single ownership avoids duplicate instances and ensures bridge updates
-    /// are reflected in the suggestion bar without additional synchronization.
-    private let suggestionState = SuggestionState()
+    /// Process-wide SuggestionState (see SuggestionState.shared). Per-controller
+    /// instances leaked via SwiftUI @ObservedObject backing storage that survives
+    /// KeyboardViewController.deinit; the singleton makes the leak benign.
+    private let suggestionState = SuggestionState.shared
 
     /// The giellakbd-ios UICollectionView keyboard, added as a direct UIKit subview.
     /// WHY not wrapped in UIViewRepresentable: SwiftUI recreates representable views
@@ -50,8 +49,6 @@ class KeyboardViewController: UIInputViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         PersistentLog.source = "KBD"
-        // Memory footprint at entry — baseline BEFORE this controller's allocations.
-        // Lets us measure how much each rebuild costs vs how much stays resident.
         let memEntry = MemoryFootprint.residentMB()
         PersistentLog.log(.diagnosticProbe(
             component: "KeyboardViewController",
@@ -443,13 +440,36 @@ class KeyboardViewController: UIInputViewController {
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
+        let hadColorChange = traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)
+        PersistentLog.log(.diagnosticProbe(
+            component: "KeyboardViewController",
+            instanceID: controllerID,
+            action: "traitCollectionDidChange",
+            details: "prevStyle=\(previousTraitCollection?.userInterfaceStyle.rawValue ?? -1) newStyle=\(traitCollection.userInterfaceStyle.rawValue) hadColorChange=\(hadColorChange)"
+        ))
         // Update keyboard theme when dark/light mode changes while keyboard is visible.
-        if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
-            giellaKeyboard?.updateTheme(theme: Theme.current(for: traitCollection))
+        if hadColorChange {
+            let newTheme = Theme.current(for: traitCollection)
+            giellaKeyboard?.updateTheme(theme: newTheme)
         }
     }
 
     deinit {
+        // Symmetric tear-down for the addChild()/didMove(toParent:) we did in viewDidLoad.
+        // Without this, UIKit holds the hosting controller in `children` and SwiftUI may
+        // keep its observation graph alive past our own deinit, perpetuating the
+        // KeyboardRootView zombies seen receiving activeControllerChanged broadcasts in
+        // logs (#134). Same reasoning applies to giellaKeyboard's superview membership.
+        hostingController?.willMove(toParent: nil)
+        hostingController?.view.removeFromSuperview()
+        hostingController?.removeFromParent()
+        hostingController = nil
+
+        giellaKeyboard?.removeFromSuperview()
+        giellaKeyboard = nil
+
+        bridge = nil
+
         PersistentLog.log(.diagnosticProbe(
             component: "KeyboardViewController",
             instanceID: controllerID,

--- a/DictusKeyboard/KeyboardViewController.swift
+++ b/DictusKeyboard/KeyboardViewController.swift
@@ -50,11 +50,14 @@ class KeyboardViewController: UIInputViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         PersistentLog.source = "KBD"
+        // Memory footprint at entry — baseline BEFORE this controller's allocations.
+        // Lets us measure how much each rebuild costs vs how much stays resident.
+        let memEntry = MemoryFootprint.residentMB()
         PersistentLog.log(.diagnosticProbe(
             component: "KeyboardViewController",
             instanceID: controllerID,
             action: "viewDidLoad",
-            details: "controllerClass=\(String(describing: type(of: self)))"
+            details: "controllerClass=\(String(describing: type(of: self))) memMB=\(memEntry)"
         ))
 
         #if DEBUG
@@ -209,6 +212,17 @@ class KeyboardViewController: UIInputViewController {
             self.suggestionState.updateAsync(context: context)
             self.bridge?.updateCapitalization()
         }
+
+        // Memory after all viewDidLoad allocations — delta vs entry tells us
+        // per-controller allocation cost (UIHostingController + GiellaKeyboardView
+        // + SuggestionState + DictusKeyboardBridge + constraints).
+        let memExit = MemoryFootprint.residentMB()
+        PersistentLog.log(.diagnosticProbe(
+            component: "KeyboardViewController",
+            instanceID: controllerID,
+            action: "viewDidLoad_exit",
+            details: "memMB=\(memExit) delta=\(memExit - memEntry)"
+        ))
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -231,7 +245,7 @@ class KeyboardViewController: UIInputViewController {
             component: "KeyboardViewController",
             instanceID: controllerID,
             action: "viewWillAppear_entry",
-            details: "animated=\(animated) status=\(entryStatus) storedStatus=\(entryStoredStatus) coldStart=\(entryColdStart) inputBounds=\(Int(entryBounds.width))x\(Int(entryBounds.height)) hostingConst=\(hostingHeightConstraint?.constant ?? -1) heightConst=\(heightConstraint?.constant ?? -1)"
+            details: "animated=\(animated) status=\(entryStatus) storedStatus=\(entryStoredStatus) coldStart=\(entryColdStart) inputBounds=\(Int(entryBounds.width))x\(Int(entryBounds.height)) hostingConst=\(hostingHeightConstraint?.constant ?? -1) heightConst=\(heightConstraint?.constant ?? -1) memMB=\(MemoryFootprint.residentMB())"
         ))
         PersistentLog.log(.keyboardDidAppear)
         KeyboardState.shared.registerControllerAppearance(controllerID: controllerID)
@@ -367,7 +381,7 @@ class KeyboardViewController: UIInputViewController {
             component: "KeyboardViewController",
             instanceID: controllerID,
             action: action,
-            details: "inputBounds=\(Int(inputBounds.width))x\(Int(inputBounds.height)) viewBounds=\(Int(viewBounds.width))x\(Int(viewBounds.height)) keyboardFrame=\(Int(keyboardFrame.width))x\(Int(keyboardFrame.height)) hostingFrame=\(Int(hostingFrame.width))x\(Int(hostingFrame.height)) hostingConst=\(hostingHeightConstraint?.constant ?? -1) heightConst=\(heightConstraint?.constant ?? -1) status=\(KeyboardState.shared.dictationStatus.rawValue)"
+            details: "inputBounds=\(Int(inputBounds.width))x\(Int(inputBounds.height)) viewBounds=\(Int(viewBounds.width))x\(Int(viewBounds.height)) keyboardFrame=\(Int(keyboardFrame.width))x\(Int(keyboardFrame.height)) hostingFrame=\(Int(hostingFrame.width))x\(Int(hostingFrame.height)) hostingConst=\(hostingHeightConstraint?.constant ?? -1) heightConst=\(heightConstraint?.constant ?? -1) status=\(KeyboardState.shared.dictationStatus.rawValue) memMB=\(MemoryFootprint.residentMB())"
         ))
     }
 
@@ -381,7 +395,7 @@ class KeyboardViewController: UIInputViewController {
             component: "KeyboardViewController",
             instanceID: controllerID,
             action: "viewDidDisappear",
-            details: "animated=\(animated)"
+            details: "animated=\(animated) memMB=\(MemoryFootprint.residentMB())"
         ))
         PersistentLog.log(.keyboardDidDisappear)
         KeyboardState.shared.registerControllerDisappearance(controllerID: controllerID)
@@ -403,6 +417,19 @@ class KeyboardViewController: UIInputViewController {
         // Darwin observers cleaned up by KeyboardState deinit
     }
 
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // iOS sends this shortly before it's willing to jetsam the extension.
+        // Logging it proves whether the grey-overlay freeze correlates with
+        // a memory-pressure signal iOS actually gave us vs an out-of-the-blue kill.
+        PersistentLog.log(.diagnosticProbe(
+            component: "KeyboardViewController",
+            instanceID: controllerID,
+            action: "didReceiveMemoryWarning",
+            details: "memMB=\(MemoryFootprint.residentMB())"
+        ))
+    }
+
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         // Update keyboard theme when dark/light mode changes while keyboard is visible.
@@ -416,7 +443,7 @@ class KeyboardViewController: UIInputViewController {
             component: "KeyboardViewController",
             instanceID: controllerID,
             action: "deinit",
-            details: ""
+            details: "memMB=\(MemoryFootprint.residentMB())"
         ))
     }
 

--- a/DictusKeyboard/KeyboardViewController.swift
+++ b/DictusKeyboard/KeyboardViewController.swift
@@ -497,13 +497,6 @@ class KeyboardViewController: UIInputViewController {
             details: "animated=\(animated) memMB=\(MemoryFootprint.residentMB())"
         ))
         PersistentLog.log(.keyboardDidDisappear)
-        KeyboardState.shared.registerControllerDisappearance(controllerID: controllerID)
-        PersistentLog.log(.diagnosticProbe(
-            component: "KeyboardViewController",
-            instanceID: controllerID,
-            action: "registeredDisappearance",
-            details: ""
-        ))
 
         // Tear down the dictation status subscription so this (now-detached)
         // controller no longer reacts when KeyboardState publishes. iOS caches
@@ -512,6 +505,41 @@ class KeyboardViewController: UIInputViewController {
         // viewWillAppear re-subscribes on reattach.
         dictationStatusCancellable?.cancel()
         dictationStatusCancellable = nil
+
+        // Issue #142: skip registerControllerDisappearance during an active
+        // dictation session. iOS calls viewDidDisappear on the keyboard right
+        // before bringing DictusApp foreground for cold-start; an immediate
+        // unregister would flip activeControllerID→nil and isKeyboardVisible
+        // →false, making KeyboardRootView.showsOverlay recompute to false and
+        // SwiftUI swap RecordingOverlay→ToolbarView while hostingConst is still
+        // 276pt. iOS's keyboard-down animation snapshot then captures that
+        // inconsistent layout (toolbar centred in expanded hosting), freezing
+        // it on screen for the duration of the transition.
+        //
+        // The successor controller's registerControllerAppearance overwrites
+        // activeControllerID, so a clean handoff happens automatically. If
+        // the keyboard is truly dismissed during recording (no successor), the
+        // synchronous deinit safety net below catches it.
+        let status = KeyboardState.shared.dictationStatus
+        let isActiveSession = status == .requested
+            || status == .recording
+            || status == .transcribing
+        if isActiveSession {
+            PersistentLog.log(.diagnosticProbe(
+                component: "KeyboardViewController",
+                instanceID: controllerID,
+                action: "skippedUnregister_activeSession",
+                details: "status=\(status.rawValue) activeID=\(KeyboardState.shared.activeControllerID ?? "none")"
+            ))
+        } else {
+            KeyboardState.shared.registerControllerDisappearance(controllerID: controllerID)
+            PersistentLog.log(.diagnosticProbe(
+                component: "KeyboardViewController",
+                instanceID: controllerID,
+                action: "registeredDisappearance",
+                details: ""
+            ))
+        }
 
         // Darwin observers cleaned up by KeyboardState deinit
     }
@@ -546,6 +574,17 @@ class KeyboardViewController: UIInputViewController {
     }
 
     deinit {
+        // Issue #142 safety net: viewDidDisappear skips unregistration during
+        // an active dictation session to avoid a SwiftUI race that produces a
+        // centred-toolbar visual artefact during cold-start handoff. If iOS
+        // deallocates us while we still own activeControllerID (no successor
+        // controller registered, e.g. a truly dismissed keyboard during
+        // recording), unregister now — synchronous deinit is past any SwiftUI
+        // race window so it's safe.
+        if KeyboardState.shared.activeControllerID == controllerID {
+            KeyboardState.shared.registerControllerDisappearance(controllerID: controllerID)
+        }
+
         // Symmetric tear-down for the addChild()/didMove(toParent:) we did in viewDidLoad.
         // Without this, UIKit holds the hosting controller in `children` and SwiftUI may
         // keep its observation graph alive past our own deinit, perpetuating the

--- a/DictusKeyboard/TextPrediction/SuggestionState.swift
+++ b/DictusKeyboard/TextPrediction/SuggestionState.swift
@@ -44,6 +44,13 @@ struct AutocorrectState {
 /// handles UITextDocumentProxy interaction.
 class SuggestionState: ObservableObject {
 
+    /// Process-wide shared instance.
+    /// Per-controller instances were being retained by SwiftUI's @ObservedObject backing
+    /// store past their owning KeyboardViewController.deinit (#134). Sharing makes the
+    /// leak no-op since all observers point to the same instance — only one keyboard
+    /// is visible at a time.
+    static let shared = SuggestionState()
+
     @Published var suggestions: [String] = []
     @Published var mode: SuggestionMode = .idle
     @Published var currentWord: String = ""
@@ -57,7 +64,11 @@ class SuggestionState: ObservableObject {
     /// Cleared when the user starts typing a new word.
     var rejectedWords: Set<String> = []
 
-    private let engine = TextPredictionEngine()
+    /// Shared engine — heavy resources (frequency dict, trie) are process-wide singletons
+    /// to avoid the per-controller leak documented in #134.
+    private let engine = TextPredictionEngine.shared
+
+    private init() {}
 
     /// Serial background queue for suggestion computation.
     /// WHY serial: Ensures suggestion computations don't race each other.

--- a/DictusKeyboard/TextPrediction/TextPredictionEngine.swift
+++ b/DictusKeyboard/TextPrediction/TextPredictionEngine.swift
@@ -17,12 +17,19 @@ import DictusCore
 /// rank results by word frequency (most common words first).
 class TextPredictionEngine {
 
+    /// Shared instance — engines are heavy (~3 MiB FrequencyDictionary + AOSP trie mmap).
+    /// Per-controller instances were leaking via SwiftUI @ObservedObject zombies that
+    /// survive their owning KeyboardViewController.deinit (KeyboardRootView struct held
+    /// alive by KeyboardState.shared.objectWillChange subscription). Sharing the heavy
+    /// resources means the leak no longer multiplies memory per app-switch cycle.
+    static let shared = TextPredictionEngine()
+
     private let textChecker = UITextChecker()
     private var frequencyDict = FrequencyDictionary()
     private let aospTrieEngine = AOSPTrieEngine()
     private var language: String = "fr"
 
-    init() {
+    private init() {
         // Verify language is available in UITextChecker
         let available = UITextChecker.availableLanguages
         if !available.contains(where: { $0.hasPrefix(language) }) {

--- a/DictusWidgets/Info.plist
+++ b/DictusWidgets/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>14</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/DictusWidgets/Info.plist
+++ b/DictusWidgets/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.0</string>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>15</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/DictusWidgets/Info.plist
+++ b/DictusWidgets/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.0</string>
 	<key>CFBundleVersion</key>
-	<string>15</string>
+	<string>13</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/DictusWidgets/Info.plist
+++ b/DictusWidgets/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.0</string>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>14</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/getdictus/dictus-ios/actions/workflows/ci.yml"><img src="https://github.com/getdictus/dictus-ios/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
   <img src="https://img.shields.io/badge/platform-iOS%2017%2B-lightgrey.svg" alt="Platform: iOS 17+" />
   <img src="https://img.shields.io/badge/swift-5.9%2B-orange.svg" alt="Swift 5.9+" />

--- a/docs/GIT_WORKFLOW.md
+++ b/docs/GIT_WORKFLOW.md
@@ -70,21 +70,7 @@ main (production)              <- App Store + TestFlight public
 
 ## Version numbering
 
-We follow [Semantic Versioning](https://semver.org/):
-
-```
-MAJOR.MINOR.PATCH
-
-1.0.0  — First App Store release
-1.1.0  — New feature added (e.g., custom vocabulary)
-1.1.1  — Bug fix on 1.1.0
-2.0.0  — Major breaking change (rare for mobile apps)
-```
-
-**Xcode specifics:**
-- `CFBundleShortVersionString` = marketing version (1.2.0) — shown to users
-- `CFBundleVersion` = build number (1, 2, 3...) — must increment for every TestFlight upload
-- Build number resets are allowed per marketing version but keeping it incrementing is simpler
+See **[VERSIONING.md](VERSIONING.md)** for the full policy — when to bump MAJOR vs MINOR vs PATCH, why we dropped `-beta.N` suffixes, historical tags, and the release checklist.
 
 ## TestFlight distribution
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,0 +1,95 @@
+# Versioning — Dictus
+
+How we number releases and tags. Complements [GIT_WORKFLOW.md](GIT_WORKFLOW.md).
+
+## TL;DR
+
+- One version line: `X.Y.Z` — [Semantic Versioning](https://semver.org/).
+- No `-beta.N` suffix. TestFlight = our current distribution channel, not a sematic status.
+- Each tag is a full release. If we promote a TestFlight build to App Store later, it's the **same build** (same tag, same `CFBundleVersion`).
+- `CFBundleVersion` (Apple build number) always increments; never resets.
+
+## When to bump each digit
+
+| Bump | When | Example |
+| --- | --- | --- |
+| **PATCH** `X.Y.Z → X.Y.(Z+1)` | Bug fix, polish, perf tweak, no new user-facing feature | Fix #134 keyboard freeze → `1.6.1` |
+| **MINOR** `X.Y.Z → X.(Y+1).0` | New user-facing feature, new supported language, new model in catalog | German layout → `1.7.0` |
+| **MAJOR** `X.Y.Z → (X+1).0.0` | First public App Store release, premium launch, breaking UX shift | App Store public → `2.0.0` |
+
+Rule of thumb: **ask "does a returning user notice something new?"** — if yes → MINOR at least. If they just notice things work better → PATCH.
+
+## `CFBundleVersion` (Apple build number)
+
+- Incremented on **every** TestFlight upload, even if `X.Y.Z` doesn't change (re-upload after an entitlement tweak, etc.).
+- Never resets. `1 → 2 → 3 → ... → 13 → 14 → ...` regardless of the marketing version jump.
+- Same build number across all three targets (App / Keyboard / Widgets) — automated bump covers them all.
+
+## What shipped so far (historical — do not rewrite)
+
+| Tag | `CFBundleShortVersionString` | `CFBundleVersion` | Notes |
+| --- | --- | --- | --- |
+| `v1.6.0-beta.1` → `v1.6.0-beta.4` | `1.6.0` (frozen across 4 betas) | 10 → 11 → 12 → 13 | Pre-switch-to-semver. Kept as-is for TestFlight release-note continuity. |
+
+Next tag onward follows the rules below — we do **not** retro-rename `beta.1–4`.
+
+## The next tag
+
+Heuristic:
+
+1. Since `v1.6.0-beta.4`, is the incoming change a fix-only patch?
+   - Yes → `v1.6.1` (first clean-numbering patch after beta line).
+   - No → step 2.
+2. Is it a notable new feature (German layout, new model, visible UX)?
+   - Yes → `v1.7.0`.
+   - No → re-classify — probably patch.
+3. Is it App Store public launch or premium launch?
+   - Yes → `v2.0.0`.
+
+Planned near-term:
+- **`v1.7.0`** — German keyboard layout (new feature → MINOR).
+- Fix #134 (retain cycle) will likely land inside `v1.7.0` alongside other work, not a standalone patch, unless it ships first on its own.
+
+## TestFlight vs. App Store (Option A)
+
+We use a **single distribution line**. There is no `-beta` parallel to a stable version.
+
+```
+develop ───┬──> TestFlight (internal)
+           │
+main ──────┴──> TestFlight (external, when we have it)
+                └──> App Store (same build, promoted when validated)
+```
+
+- `develop` builds go to internal testers as they're uploaded.
+- When a build is stabilised and we want public release, we merge `develop → main`, tag `vX.Y.Z`, and **that same archive** is the one we submit to App Store review.
+- No "rebuild for production" — the tested bits are the shipped bits.
+
+This keeps version numbers honest: `v1.6.1` on TestFlight = `v1.6.1` on App Store. No `.beta` suffix to strip.
+
+## Release checklist
+
+When `develop` is ready to ship:
+
+1. Decide the tag per the heuristic above.
+2. Bump `CFBundleShortVersionString` in all three Info.plists (App / Keyboard / Widgets) to the new `X.Y.Z`.
+3. Bump `CFBundleVersion` by one across all three plists.
+4. Commit: `chore: bump to X.Y.Z (build N)`.
+5. Open PR `develop → main`, merge.
+6. `git checkout main && git pull`.
+7. `git tag -a vX.Y.Z -m "vX.Y.Z — short one-liner"` + `git push origin vX.Y.Z`.
+8. Archive in Xcode, upload to App Store Connect.
+9. Once accepted for TestFlight: `gh release create vX.Y.Z --title "..." --notes "..."` (use `--prerelease` only if the build is not intended for external TestFlight / App Store).
+10. Merge `main → develop` to keep branches in sync.
+
+## Release-notes naming (GitHub + TestFlight)
+
+- GitHub release title: `vX.Y.Z — short summary` (e.g. `v1.7.0 — German layout + keyboard stability fix`).
+- TestFlight "What to Test" notes: user-facing bullets, English, no internal jargon, no issue numbers that testers can't click. Keep internal technical notes for the GitHub release body.
+
+## Common mistakes to avoid
+
+- ❌ Re-using a version number for a re-upload — always bump `CFBundleVersion` at minimum.
+- ❌ Adding `-beta.N` to a new tag — obsolete convention, drops for all tags from `v1.6.1` onward.
+- ❌ Letting `CFBundleVersion` drift between targets (App=13, Keyboard=11, Widgets=12 style) — always bump all three together.
+- ❌ Tagging before the merge lands on `main` — the tag should point to a commit that is reachable from `main`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
TestFlight release v1.6.1 — bug fix patch on top of v1.6.0-beta.4.

## Fixes

- **#134** — keyboard extension retain cycle + memory footprint instrumentation (PR #135)
- **#92** — keyboard load flash partial fix: defer height constraint, bottom-anchor content (PR #139)
- **#106** — background lifecycle overhaul: Live Activity ↔ audio session sync, idle warm-state release after 10 min, drain throttling (PR #140)
- **#142** — cold-start keyboard layout glitch: toolbar centring during handoff (PR #143)

## Infra

- CI workflow: GitHub Actions build + SwiftLint on macOS 26 / Xcode 26.3 (PR #145)

## Versioning

- `CFBundleShortVersionString`: 1.6.0 → 1.6.1
- `CFBundleVersion`: 13 → 14
- All three targets bumped together (App / Keyboard / Widgets) in PR #147

## Known open (not regressing)

- #144 Whisper turbo unreliable (concurrent dispatch) — predates this build
- Cold-start auto-return to keyboard — still unsolved, not in this build

🤖 Generated with [Claude Code](https://claude.com/claude-code)