### PR TITLE
release(1.7.1): cold-start fix #167 + version bump

### DIFF
--- a/DictusApp/DictationCoordinator.swift
+++ b/DictusApp/DictationCoordinator.swift
@@ -321,8 +321,14 @@ class DictationCoordinator: ObservableObject {
         // queue dispatches that all collapsed into 3+ concurrent transcribe()
         // calls when the load resolved. Reading the App Group state lets us short-
         // circuit cleanly — the keyboard's overlay UI surfaces the wait to the user.
+        //
+        // Issue #167: URL-scheme cold-start launches arrive while the init-preload
+        // is still loading the model. Failing here would route first-use dictation
+        // into `failed` state. Skip the guard for fromURL=true and let the existing
+        // cold-start defer at line ~368 park the request as `pendingColdStartDictation`
+        // — the retry's `ensureEngineReady` awaits the in-flight initTask via its lock.
         let currentLoadState = defaults.string(forKey: SharedKeys.modelLoadState) ?? ModelLoadState.idle.rawValue
-        if currentLoadState == ModelLoadState.loading.rawValue {
+        if currentLoadState == ModelLoadState.loading.rawValue && !fromURL {
             PersistentLog.log(.dictationDeferred(reason: "model load in flight (state=loading)"))
             handleError(String(localized: "Model is loading. Please wait."))
             return

--- a/DictusApp/Info.plist
+++ b/DictusApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.0</string>
+	<string>1.7.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>16</string>
+	<string>17</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusKeyboard/Info.plist
+++ b/DictusKeyboard/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.0</string>
+	<string>1.7.1</string>
 	<key>CFBundleVersion</key>
-	<string>16</string>
+	<string>17</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusWidgets/Info.plist
+++ b/DictusWidgets/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.0</string>
+	<string>1.7.1</string>
 	<key>CFBundleVersion</key>
-	<string>16</string>
+	<string>17</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
## Summary

Bundles the **#167 cold-start model-loading race fix** with the **1.7.1 release bump** (Info.plists 1.7.0/16 → 1.7.1/17).

Closes #167.

## What's in 1.7.1 (since 1.7.0 / build 16)

| PR | Issue | Sujet |
|----|-------|-------|
| #164 | #144 | Turbo load gate + ModelLoadingOverlay UX (3 commits) |
| #169 | #163 | Turbo long-audio diagnostic infrastructure |
| #170 | #168 | VAD chunking experiment + tuning notes |
| #171 |  | Speed-score recalibration (turbo signaled slow) |
| **this** | **#167** | **Cold-start model-loading race fix** |

## #167 — Cold-start fix

### Root cause
`DictationCoordinator.startDictation(fromURL:)` ran the guard added for #144 (refuse mic taps during a turbo model swap) before the cold-start defer logic. URL-scheme launches arrive at `appState=.inactive` while `init-preload` is in flight (`modelLoadState=.loading`), so the guard fired, called `handleError(...)` → `updateStatus(.failed)`. User had to tap the mic a second time.

### Fix
Skip the guard when `fromURL == true`. The existing cold-start defer below parks the request as `pendingColdStartDictation`; `didBecomeActive` retries it. The retry's `ensureEngineReady()` awaits the in-flight `initTask` via its lock — no duplicate model loads. Darwin-notification path (#144's protection, `fromURL=false`) unchanged.

### Verification (manual cold-start repro)

| Test | Path | Outcome |
|------|------|---------|
| 1 | Cold start | ✅ `coldStartRetry` → `transcriptionCompleted words=7` |
| 2 | Cold start | ⚠️ Cold-start path OK, Parakeet returned empty result (unrelated, not #167) |
| 3 | Warm start | ✅ `transcriptionCompleted words=10` |
| 4 | Cold start | ✅ `coldStartRetry` → `transcriptionCompleted words=7` |

Before fix: `dictationDeferred reason=model load in flight` → `statusChanged from=idle to=failed`
After fix: `dictationDeferred reason=cold start deferred to didBecomeActive` → `coldStartRetry` → `dictationStarted` → recording

## Release plan

- [x] Bump Info.plists to 1.7.1 / build 17 (3 plists in sync)
- [ ] Merge this PR into develop
- [ ] Open release PR develop → main
- [ ] Merge to main, tag v1.7.1
- [ ] Build + upload to TestFlight from Xcode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
