### PR TITLE
fix(#141): polish post-pass cleanups + trim FR prompt (latency)

### DIFF
--- a/DictusApp/Polish/Prompts/PolishNaturalPromptFR.swift
+++ b/DictusApp/Polish/Prompts/PolishNaturalPromptFR.swift
@@ -59,54 +59,23 @@ enum PolishNaturalPromptFR {
 
         Examples:
 
-        INPUT: yo tu m'avais dit que tu passais à l'appart cet aprem vers 16h ça tient toujours
-        OUTPUT: Yo, tu m'avais dit que tu passais à l'appart cet aprem vers 16h, ça tient toujours ?
-
-        INPUT: faut absolument que je merge cette PR avant le standup de demain matin
-        OUTPUT: Faut absolument que je merge cette PR avant le standup de demain matin.
-
-        INPUT: cest le cinq mars deux mille vingt six on se retrouve a quatorze heures
-        OUTPUT: C’est le 5 mars 2026, on se retrouve à 14 heures.
-
         INPUT: euh je je sais pas trop si on doit y aller maintenant tu vois
         OUTPUT: Je sais pas trop si on doit y aller maintenant.
 
-        INPUT: jutilise whisperkit pour la transcription et github pour le code
-        OUTPUT: J’utilise WhisperKit pour la transcription et GitHub pour le code.
-
         INPUT: salut comment tu vas point d'interrogation j'ai bien lu ton rapport virgule et je pense que c'est bien
         OUTPUT: Salut, comment tu vas ? J’ai bien lu ton rapport, et je pense que c’est bien.
-
-        INPUT: bonjour point d'exclamation tu peux m'envoyer le fichier virgule s'il te plaît point d'interrogation
-        OUTPUT: Bonjour ! Tu peux m’envoyer le fichier, s’il te plaît ?
-
-        INPUT: première partie point virgule deuxième partie point d'exclamation
-        OUTPUT: Première partie ; deuxième partie !
-
-        INPUT: ah ouais je je trouve que comme comme on disait c'est pas mal
-        OUTPUT: Ah ouais, je trouve que comme on disait, c’est pas mal.
-
-        INPUT: ok donc la on va faire un petit test pour voir si tu fais bien ton travail tu vois
-        OUTPUT: Ok, donc là on va faire un petit test pour voir si tu fais bien ton travail.
 
         ASR-repair example. A segment of the input is incoherent (pseudo-English fragment from a French speaker); reconstruct the intent in French:
 
         INPUT: j'ai voulu passer voir Marie hier soir but the thing yet would happen sense thinks et finalement j'ai abandonné
         OUTPUT: J’ai voulu passer voir Marie hier soir, et finalement j’ai abandonné.
 
-        Line-break marker examples. `<<NL>>` represents a hard line break. Keep it at the same position; capitalize the sentence that follows:
+        Line-break marker example. `<<NL>>` represents a hard line break. Keep it at the same position; capitalize the sentence that follows:
 
         INPUT: bonjour, comment ça va ?<<NL>>j'espère que tu vas bien,<<NL>>à bientôt.
         OUTPUT: Bonjour, comment ça va ?<<NL>>J’espère que tu vas bien,<<NL>>À bientôt.
 
-        INPUT: première ligne.<<NL>>deuxième ligne.
-        OUTPUT: Première ligne.<<NL>>Deuxième ligne.
-
         COUNTER-EXAMPLES — the WRONG outputs below violate PRESERVE rules. The model often defaults to these formalisations; never produce them.
-
-        INPUT: bon je rentre chez moi à 18h on se voit demain
-        WRONG: Bon, je rentre chez moi à 18 heures, on se voit demain.
-        RIGHT: Bon, je rentre chez moi à 18h, on se voit demain.
 
         INPUT: t'as pas oublié notre rdv ce midi
         WRONG: Tu n'as pas oublié notre rendez-vous ce midi ?
@@ -115,14 +84,6 @@ enum PolishNaturalPromptFR {
         INPUT: j'ai eu un meeting avec le client today on a réglé pas mal de trucs
         WRONG: J'ai eu une réunion avec le client aujourd'hui, on a réglé beaucoup de choses.
         RIGHT: J'ai eu un meeting avec le client today, on a réglé pas mal de trucs.
-
-        INPUT: c'est pas grave on peut faire ça plus tard
-        WRONG: Ce n'est pas grave, on peut faire cela plus tard.
-        RIGHT: C'est pas grave, on peut faire ça plus tard.
-
-        INPUT: faut que je commit ce fix avant le deploy de demain
-        WRONG: Il faut que je valide cette correction avant le déploiement de demain.
-        RIGHT: Faut que je commit ce fix avant le deploy de demain.
         """
     }
 }

--- a/DictusCore/Sources/DictusCore/Polish/PolishPostpass.swift
+++ b/DictusCore/Sources/DictusCore/Polish/PolishPostpass.swift
@@ -42,6 +42,20 @@ public enum PolishPostpass {
         var out = polished
         out = out.replacingOccurrences(of: newlineMarker, with: "\n")
 
+        // Collapse stray newlines (language-agnostic). Each "retour à la ligne"
+        // encodes to exactly one marker, but the model adds its OWN paragraph
+        // breaks around the marker when the text looks structured (a meeting
+        // recap, an enumeration). After decode those stack into `\n\n\n\n`.
+        // Reduce any run of whitespace-separated newlines to a single `\n`, and
+        // trim the spaces hugging each break. We deliberately drop the
+        // single-vs-blank-line distinction — the verbal command does not carry
+        // it, and the model mangles blank lines unreliably anyway.
+        out = out.replacingOccurrences(
+            of: #"[ \t]*\n(?:[ \t]*\n)*[ \t]*"#,
+            with: "\n",
+            options: [.regularExpression]
+        )
+
         switch language {
         case .french:
             // NBSP before ? ! ; :. Pattern matches ONE ASCII space (U+0020)
@@ -51,6 +65,18 @@ public enum PolishPostpass {
             out = out.replacingOccurrences(
                 of: #"[ ]([?!;:])"#,
                 with: "\u{00A0}$1",
+                options: [.regularExpression]
+            )
+            // Restore the accent on a sentence-initial capital `A` — Apple FM
+            // drops accents on capitals just like it drops the NBSP. Narrow on
+            // purpose: a standalone `A` at a sentence start (string start, after
+            // a newline, or after `. ! ? :`) followed by a lowercase word is
+            // almost always the preposition `À` (À très vite / bientôt / plus
+            // tard). If the next word is uppercase (acronym, proper noun) or it
+            // is `A.` (abbreviation), the pattern does not match and we leave it.
+            out = out.replacingOccurrences(
+                of: #"(^|\n|[.!?:]\s+)A(\s+\p{Ll})"#,
+                with: "$1À$2",
                 options: [.regularExpression]
             )
         case .english, .spanish, .german:

--- a/DictusCore/Tests/DictusCoreTests/Polish/PolishPostpassTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/Polish/PolishPostpassTests.swift
@@ -105,6 +105,85 @@ final class PolishPostpassTests: XCTestCase {
         )
     }
 
+    // MARK: - Decode: stray-newline collapse (fix A)
+
+    func testDecodeCollapsesStackedNewlines() {
+        // Marker decodes to one `\n`; the model added 3 more around it.
+        XCTAssertEqual(
+            PolishPostpass.decodeFromEngine("a.<<NL>>\n\n\nb", language: .french),
+            "a.\nb"
+        )
+    }
+
+    func testDecodeCollapsesNewlinesWithSurroundingSpaces() {
+        XCTAssertEqual(
+            PolishPostpass.decodeFromEngine("réunion. \n\n\n\n Premièrement", language: .french),
+            "réunion.\nPremièrement"
+        )
+    }
+
+    func testDecodeLeavesSingleNewlineUntouched() {
+        XCTAssertEqual(
+            PolishPostpass.decodeFromEngine("a<<NL>>b", language: .french),
+            "a\nb"
+        )
+    }
+
+    func testDecodeTrickyMeetingRecapHasSingleBreaks() {
+        // Test 4 from the 08/06 Wispr comparison: 3 line breaks, each previously
+        // ballooned to `\n\n\n\n`. Expect exactly one `\n` per section.
+        let engineOutput = "Voici le compte rendu.<<NL>>\n\n\nPremièrement, on a validé le budget\u{00A0}!<<NL>>\n\n\nDeuxièmement, d'accord\u{00A0}?<<NL>>\n\n\nA très vite."
+        XCTAssertEqual(
+            PolishPostpass.decodeFromEngine(engineOutput, language: .french),
+            "Voici le compte rendu.\nPremièrement, on a validé le budget\u{00A0}!\nDeuxièmement, d'accord\u{00A0}?\nÀ très vite."
+        )
+    }
+
+    // MARK: - Decode: capital À accent (fix C)
+
+    func testDecodeRestoresSentenceInitialAAfterNewline() {
+        XCTAssertEqual(
+            PolishPostpass.decodeFromEngine("Budget validé\u{00A0}!<<NL>>A très vite.", language: .french),
+            "Budget validé\u{00A0}!\nÀ très vite."
+        )
+    }
+
+    func testDecodeRestoresAAtStringStart() {
+        XCTAssertEqual(
+            PolishPostpass.decodeFromEngine("A demain, on en reparle.", language: .french),
+            "À demain, on en reparle."
+        )
+    }
+
+    func testDecodeRestoresAAfterPeriod() {
+        XCTAssertEqual(
+            PolishPostpass.decodeFromEngine("C'est noté. A plus tard.", language: .french),
+            "C'est noté. À plus tard."
+        )
+    }
+
+    func testDecodeDoesNotTouchAFollowedByUppercase() {
+        // "A" before an acronym / proper noun is left alone.
+        XCTAssertEqual(
+            PolishPostpass.decodeFromEngine("A WhisperKit on doit ça.", language: .french),
+            "A WhisperKit on doit ça."
+        )
+    }
+
+    func testDecodeDoesNotTouchAbbreviationA() {
+        // "A." (abbreviation, no following space+lowercase) is left alone.
+        XCTAssertEqual(
+            PolishPostpass.decodeFromEngine("A. Dupont est là.", language: .french),
+            "A. Dupont est là."
+        )
+    }
+
+    func testDecodeAAccentIsFrenchOnly() {
+        let input = "A demain."
+        XCTAssertEqual(PolishPostpass.decodeFromEngine(input, language: .english), input)
+        XCTAssertEqual(PolishPostpass.decodeFromEngine(input, language: .german), input)
+    }
+
     // MARK: - Combined behaviour
 
     func testFullPipelineFrench() {


### PR DESCRIPTION
Polish quality fixes from the 08/06 Wispr Flow comparison, validated on device (iPhone 15 Pro Max / iOS 26.5). All three changes verified in a 5-case re-test.

## What's in here

**A — Stray-newline collapse** (`PolishPostpass.decodeFromEngine`, deterministic): each "retour à la ligne" encodes to one `<<NL>>` marker, but Apple FM adds its own paragraph breaks around it, stacking into `\n\n\n\n`. Now collapsed to a single `\n`.

**C — Capital À accent** (`PolishPostpass`, FR only, deterministic): the model drops accents on capitals (like the NBSP). Narrow rule restores a sentence-initial standalone `A`+lowercase → `À` (À très vite / bientôt). Leaves `A Acronym` and `A.` untouched.

**D — Trim FR Natural prompt** (`PolishNaturalPromptFR`): examples 10→4, counter-examples 5→2. RULES / PRESERVE / FORBIDDEN / glossary untouched.

## Device validation (5 cases)

- **A**: Test 4 now has a single `\n` per section (was `\n\n\n\n`). ✅
- **C**: Test 4 outputs `À très vite.` accented (was `A très vite`). ✅
- **D — no quality regression**: anglicisms preserved (Test 2), Parakeet English errors translated to French (Test 5), long text faithful (Test 3), normal register clean (Test 1). ✅
- **D — latency bonus**: ~1.3s cut on *every* call (cold path, dictations spaced 30-60s):

| Test | Before | After |
|---|---|---|
| 1 | 3753ms | 2823ms |
| 2 | 3806ms | 2680ms |
| 3 (long) | 5615ms | 4249ms |
| 4 | 4632ms | 3026ms |
| 5 | 4771ms | 3323ms |

Confirms the prompt prefill was a major latency cost; trimming ~2KB of examples cut it uniformly.

## Tests
- `PolishPostpassTests`: +11 cases for A/C. 73 DictusCore tests green.
- `xcodebuild build -scheme DictusApp` → BUILD SUCCEEDED.