### PR TITLE
perf(#141): trim EN/ES/DE Natural prompts to cut prefill latency

### DIFF
--- a/DictusCore/Sources/DictusCore/Polish/Prompts/PolishNaturalPromptDE.swift
+++ b/DictusCore/Sources/DictusCore/Polish/Prompts/PolishNaturalPromptDE.swift
@@ -53,28 +53,16 @@ enum PolishNaturalPromptDE {
 
         Examples:
 
-        INPUT: hey hast du heute abend zeit wir können uns gegen sieben treffen
-        OUTPUT: Hey, hast du heute Abend Zeit? Wir können uns gegen 7 treffen.
-
-        INPUT: ich muss die feature today shippen ich hab keine wahl
-        OUTPUT: Ich muss die Feature today shippen. Ich hab keine Wahl.
-
-        INPUT: das meeting ist am fünften märz um vierzehn uhr komma sei nicht zu spät
-        OUTPUT: Das Meeting ist am 5. März um 14 Uhr, sei nicht zu spät.
-
         INPUT: äh ich ich glaube wir sollten jetzt nicht gehen weißt du
         OUTPUT: Ich glaube, wir sollten jetzt nicht gehen.
 
         INPUT: hallo komma wie gehts dir fragezeichen ich hab deinen bericht gelesen komma und ich finde er ist gut
         OUTPUT: Hallo, wie geht's dir? Ich hab deinen Bericht gelesen, und ich finde er ist gut.
 
-        Line-break marker examples. `<<NL>>` represents a hard line break. Keep it at the same position; capitalize the sentence that follows:
+        Line-break marker example. `<<NL>>` represents a hard line break. Keep it at the same position; capitalize the sentence that follows:
 
         INPUT: hallo, wie geht's dir?<<NL>>ich hoffe es geht dir gut,<<NL>>bis bald.
         OUTPUT: Hallo, wie geht's dir?<<NL>>Ich hoffe es geht dir gut,<<NL>>Bis bald.
-
-        INPUT: erste zeile.<<NL>>zweite zeile.
-        OUTPUT: Erste Zeile.<<NL>>Zweite Zeile.
 
         COUNTER-EXAMPLES — the WRONG outputs below violate PRESERVE rules. The model often defaults to these formalisations; never produce them.
 
@@ -82,17 +70,9 @@ enum PolishNaturalPromptDE {
         WRONG: Hey, hast du mal eine Minute? Ich brauche deine Meinung.
         RIGHT: Hey, hast du mal 'ne Minute? Ich brauch deine Meinung.
 
-        INPUT: gehste mit zum kumpel heute abend wir grillen
-        WRONG: Gehst du mit zum Freund heute Abend? Wir grillen.
-        RIGHT: Gehste mit zum Kumpel heute Abend? Wir grillen.
-
         INPUT: ich hab heute ein meeting mit dem team about the new feature
         WRONG: Ich habe heute eine Besprechung mit dem Team über die neue Funktion.
         RIGHT: Ich hab heute ein Meeting mit dem Team about the new feature.
-
-        INPUT: meine klamotten sind echt geil heute
-        WRONG: Meine Kleidung ist wirklich toll heute.
-        RIGHT: Meine Klamotten sind echt geil heute.
         """
     }
 }

--- a/DictusCore/Sources/DictusCore/Polish/Prompts/PolishNaturalPromptEN.swift
+++ b/DictusCore/Sources/DictusCore/Polish/Prompts/PolishNaturalPromptEN.swift
@@ -57,45 +57,21 @@ enum PolishNaturalPromptEN {
 
         Examples:
 
-        INPUT: hey are you free tonight we can meet around 7
-        OUTPUT: Hey, are you free tonight? We can meet around 7.
-
-        INPUT: i need to push this fix before the standup or the team will be blocked
-        OUTPUT: I need to push this fix before the standup or the team will be blocked.
-
-        INPUT: meeting is on march fifth at two pm comma dont be late
-        OUTPUT: Meeting is on March 5 at 2 pm, don't be late.
-
         INPUT: uh i i think we should ship it
         OUTPUT: I think we should ship it.
 
-        INPUT: i use whisperkit for transcription and github for code
-        OUTPUT: I use WhisperKit for transcription and GitHub for code.
-
         INPUT: hi comma hows it going question mark i read your report comma and i think its great
         OUTPUT: Hi, how's it going? I read your report, and I think it's great.
-
-        INPUT: hello exclamation mark can you send me the file comma please question mark
-        OUTPUT: Hello! Can you send me the file, please?
-
-        INPUT: yeah like i i was thinking that like you know we should try it
-        OUTPUT: Yeah, I was thinking that we should try it.
-
-        INPUT: ok so were running a quick test now to see if youre doing your job right you know
-        OUTPUT: Ok, so we're running a quick test now to see if you're doing your job right.
 
         ASR-repair example. A segment of the input is incoherent (pseudo-fragment that does not fit); reconstruct the intent in English:
 
         INPUT: and so basically uhuh blegh blegh I was working on the thing yesterday
         OUTPUT: And so basically I was working on the thing yesterday.
 
-        Line-break marker examples. `<<NL>>` represents a hard line break. Keep it at the same position; capitalize the sentence that follows:
+        Line-break marker example. `<<NL>>` represents a hard line break. Keep it at the same position; capitalize the sentence that follows:
 
         INPUT: hi how are you doing today<<NL>>i hope you are doing well,<<NL>>see you soon.
         OUTPUT: Hi, how are you doing today?<<NL>>I hope you are doing well,<<NL>>See you soon.
-
-        INPUT: first line.<<NL>>second line.
-        OUTPUT: First line.<<NL>>Second line.
 
         COUNTER-EXAMPLES — the WRONG outputs below violate PRESERVE rules. The model often defaults to these formalisations; never produce them.
 
@@ -103,17 +79,9 @@ enum PolishNaturalPromptEN {
         WRONG: Hey, I am going to grab lunch around noon. Do you want to come?
         RIGHT: Hey, I'm gonna grab lunch around noon. You wanna come?
 
-        INPUT: i gotta finish this before 9am cuz the client is waiting
-        WRONG: I have to finish this before 9 AM because the client is waiting.
-        RIGHT: I gotta finish this before 9am cuz the client is waiting.
-
         INPUT: that dude is kinda weird but hes a good guy
         WRONG: That person is somewhat strange, but he is a good man.
         RIGHT: That dude is kinda weird, but he's a good guy.
-
-        INPUT: lemme push this fix and ill let you know
-        WRONG: Let me push this fix and I will let you know.
-        RIGHT: Lemme push this fix and I'll let you know.
         """
     }
 }

--- a/DictusCore/Sources/DictusCore/Polish/Prompts/PolishNaturalPromptES.swift
+++ b/DictusCore/Sources/DictusCore/Polish/Prompts/PolishNaturalPromptES.swift
@@ -53,31 +53,16 @@ enum PolishNaturalPromptES {
 
         Examples:
 
-        INPUT: hola estas libre esta noche podemos vernos a las siete
-        OUTPUT: Hola, ¿estás libre esta noche? Podemos vernos a las 7.
-
-        INPUT: tengo que shippear la feature today no tengo otra
-        OUTPUT: Tengo que shippear la feature today. No tengo otra.
-
-        INPUT: la reunion es el cinco de marzo a las dos de la tarde coma no llegues tarde
-        OUTPUT: La reunión es el 5 de marzo a las 2 de la tarde, no llegues tarde.
-
         INPUT: eh yo yo creo que no deberíamos ir ahora ¿sabes?
         OUTPUT: Yo creo que no deberíamos ir ahora.
 
         INPUT: hola coma como estas signo de interrogacion he leido tu reporte coma y creo que esta bien
         OUTPUT: Hola, ¿cómo estás? He leído tu reporte, y creo que está bien.
 
-        INPUT: pues que que que pasa con esto
-        OUTPUT: Pues, ¿qué pasa con esto?
-
-        Line-break marker examples. `<<NL>>` represents a hard line break. Keep it at the same position; capitalize the sentence that follows:
+        Line-break marker example. `<<NL>>` represents a hard line break. Keep it at the same position; capitalize the sentence that follows:
 
         INPUT: hola, ¿cómo estás?<<NL>>espero que vayas bien,<<NL>>hasta pronto.
         OUTPUT: Hola, ¿cómo estás?<<NL>>Espero que vayas bien,<<NL>>Hasta pronto.
-
-        INPUT: primera línea.<<NL>>segunda línea.
-        OUTPUT: Primera línea.<<NL>>Segunda línea.
 
         COUNTER-EXAMPLES — the WRONG outputs below violate PRESERVE rules. The model often defaults to these formalisations; never produce them.
 
@@ -85,17 +70,9 @@ enum PolishNaturalPromptES {
         WRONG: Oye, vamos para la playa este fin de semana con los hombres del trabajo.
         RIGHT: Oye, vamos pa la playa este finde con los tíos del trabajo.
 
-        INPUT: tengo que currar hasta las ocho hoy estoy hasta el moño
-        WRONG: Tengo que trabajar hasta las 8 hoy, estoy harto.
-        RIGHT: Tengo que currar hasta las 8 hoy, estoy hasta el moño.
-
         INPUT: tio el meeting de mañana es a las nueve no llegues tarde
         WRONG: Hombre, la reunión de mañana es a las 9. No llegues tarde.
         RIGHT: Tío, el meeting de mañana es a las 9. No llegues tarde.
-
-        INPUT: ese plan suena guay hagamoslo este weekend
-        WRONG: Ese plan suena genial, hagámoslo este fin de semana.
-        RIGHT: Ese plan suena guay, hagámoslo este weekend.
         """
     }
 }


### PR DESCRIPTION
## What

Replicates the FR Natural-prompt trim (`9cf19fa`, merged in #181) for the three other languages: **EN, ES, DE**. Same logic, different language.

The bulkiest, lowest-ROI part of each prompt — the **examples** and **counter-examples** — is cut. The contract (`RULES` / `PRESERVE` / `FORBIDDEN` / glossary) is left **untouched**.

## Why

Each prompt's instruction block is re-prefilled on every cold call once the prompt-prefix cache decays after idle. The on-device latency data from #141 showed that prefill is the floor (~1.2s) on the cold path. FR was trimmed first because it was the only language validated by the on-device protocol; this is the EN/ES/DE fast-follow.

## Changes

| Lang | Examples | Counter-examples |
|------|----------|------------------|
| EN | 9 → 2 (+ASR-repair, +1 `<<NL>>`) | 4 → 2 |
| ES | 6 → 2 (+1 `<<NL>>`) | 4 → 2 |
| DE | 5 → 2 (+1 `<<NL>>`) | 4 → 2 |

**Kept examples** retain coverage: filler+stutter, verbal punctuation, ASR-repair, and a single `<<NL>>` marker.
**Kept counter-examples**: familiar-register expansion + tech-anglicism translation — the two formalisations the model defaults to.

Note: ES and DE end at 2 examples (+NL) rather than 3 because neither had a dedicated ASR-repair *example* to begin with (rule 8 itself is still present in both). The trim only removes — no content was invented for parity.

## Validation

- `swift build` (DictusCore, macOS) passes.
- ⚠️ Quality not yet validated for EN/ES/DE — **native speakers will test** before this is relied on in production. Reversible per-language if a re-test shows regression.

Refs #141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)