### PR TITLE
fix(#185): verbal-punctuation fidelity — deterministic fallback + drop the bare "point" rule

### DIFF
--- a/DictusApp/Polish/PolishCoordinator.swift
+++ b/DictusApp/Polish/PolishCoordinator.swift
@@ -169,23 +169,30 @@ public final class PolishCoordinator {
 
         // Skip on gibberish — preserves trust per ADR 0002 §"skip-on-gibberish rule".
         guard let detected else {
+            // Return the deterministic floor, NOT the literal raw: the verbal-
+            // punctuation pre-pass already ran (~0ms) and the user expects their
+            // spoken "virgule"/"point" turned into marks even when the LLM is
+            // skipped. Same value the < engineMinDuration gate returns. (#185)
             let preprocessMs = Int(Date().timeIntervalSince(methodStart) * 1000)
+            let postStart = Date()
+            let fallback = PolishPostpass.decodeFromEngine(preprocessed, language: target)
+            let postMs = Int(Date().timeIntervalSince(postStart) * 1000)
             let m = PolishMetrics(
                 engine: engineID,
                 mode: nil,
                 targetLanguage: target,
                 detectedLanguage: nil,
                 rawCharCount: raw.count,
-                polishedCharCount: raw.count,
-                latencyMs: preprocessMs,
+                polishedCharCount: fallback.count,
+                latencyMs: preprocessMs + postMs,
                 outcome: .skipped,
                 sttEngine: sttEngine.rawValue,
                 sttModelID: sttModelID,
-                timings: PolishTimings(preprocessMs: preprocessMs, engineMs: 0, postprocessMs: 0)
+                timings: PolishTimings(preprocessMs: preprocessMs, engineMs: 0, postprocessMs: postMs)
             )
             PolishMetrics.log(m)
             await metricsRing.append(PolishDebugEntry(raw: raw, polished: nil, metrics: m))
-            return raw
+            return fallback
         }
 
         let mode = PolishPipeline.mode(sttEngine: sttEngine, detected: detected, target: target)
@@ -207,7 +214,10 @@ public final class PolishCoordinator {
         // True total, methodStart → here. Any gap vs (pre+engine+post) is
         // Swift Task scheduling / actor-hop overhead — itself worth seeing.
         let totalMs = Int(Date().timeIntervalSince(methodStart) * 1000)
-        let returned: String = (bundle.outcome == .success) ? (bundle.engineOutput ?? raw) : raw
+        // On any non-success (engine failed, guardrail rejected, cancelled) fall
+        // back to the deterministic floor, never the literal raw — see
+        // `PolishPipeline.resolvedOutput`. (#185)
+        let returned = PolishPipeline.resolvedOutput(bundle, preprocessed: preprocessed, target: target)
 
         let m = PolishMetrics(
             engine: engineID,

--- a/DictusCore/Sources/DictusCore/Polish/PolishPipeline.swift
+++ b/DictusCore/Sources/DictusCore/Polish/PolishPipeline.swift
@@ -76,6 +76,26 @@ public enum PolishPipeline {
         }
     }
 
+    /// The string the user actually receives, given a transform `Result` and the
+    /// deterministic pre-pass output. On `.success` it's the accepted engine
+    /// output; on EVERY other outcome (gibberish-skip, engine failure, guardrail
+    /// rejection, cancellation) it's the deterministic floor — the pre-pass text
+    /// with newline markers decoded and target-language typography applied.
+    ///
+    /// Crucially it is NEVER the literal `raw`: a non-success must not throw away
+    /// the free, deterministic verbal-punctuation work (otherwise the user sees
+    /// the spoken command words "virgule" / "point" left in the text). This
+    /// matches what the coordinator's `< engineMinDuration` gate already returns.
+    /// (#185)
+    public static func resolvedOutput(_ result: Result,
+                                      preprocessed: String,
+                                      target: SupportedLanguage) -> String {
+        if result.outcome == .success, let output = result.engineOutput {
+            return output
+        }
+        return PolishPostpass.decodeFromEngine(preprocessed, language: target)
+    }
+
     // MARK: - Language detection + mode selection
 
     /// Default top-language confidence below which text is treated as gibberish

--- a/DictusCore/Sources/DictusCore/Polish/VerbalPunctuationPrepass.swift
+++ b/DictusCore/Sources/DictusCore/Polish/VerbalPunctuationPrepass.swift
@@ -17,8 +17,21 @@ import Foundation
 /// Scope at round 1: French and English. Spanish/German added in step 7.
 ///
 /// Known false positives: literal references to punctuation ("ma virgule est
-/// cassée", "I had a period of doubt") become substitutions. Accepted — the
-/// dictation use case is dominant in practice.
+/// cassée") become substitutions. Accepted — the dictation use case is
+/// dominant in practice.
+///
+/// EXCLUDED ON PURPOSE — the bare sentence-period word (#185): French "point"
+/// and English "period" are NOT in the rules. Unlike every other command they
+/// are extremely common ordinary words ("un point de vue", "faire le point", "à
+/// quel point" / "a period of time", "period drama"), and being single short
+/// tokens they offer no multi-word context to disambiguate. Converting them
+/// silently corrupts the sentence ("un point final" → "un. final"). We accept
+/// the cost of dropping them because the LLM already supplies the terminal
+/// period at natural sentence boundaries on its own (observed on device). The
+/// unambiguous multi-word marks that merely CONTAIN "point" ("point
+/// d'interrogation", "point d'exclamation", "point virgule") stay. The same
+/// principle pre-emptively bars Spanish "punto" and German "Punkt" when those
+/// languages get rules. Revisit once the LLM owns punctuation contextually.
 public enum VerbalPunctuationPrepass {
 
     /// Apply the language's verbal-punctuation rules to `raw`. Returns the
@@ -43,14 +56,16 @@ public enum VerbalPunctuationPrepass {
         switch language {
         case .french:  return frenchRules
         case .english: return englishRules
+        // Not yet implemented. When adding rules, do NOT include the bare
+        // period word ("punto" / "Punkt") — see the type doc-comment (#185).
         case .spanish, .german: return []
         }
     }
 
     /// Order matters: multi-word phrases before shorter substrings that would
-    /// otherwise match a piece of them. `\b` enforces word boundaries so
-    /// "trois points" (plural) does NOT trigger the singular "point" rule.
-    /// `['’]` matches both ASCII and typographic apostrophe.
+    /// otherwise match a piece of them. `\b` enforces word boundaries.
+    /// `['’]` matches both ASCII and typographic apostrophe. The bare "point"
+    /// rule is intentionally absent — see the type doc-comment (#185).
     private static let frenchRules: [(pattern: String, replacement: String)] = [
         (#"\bretour à la ligne\b"#, "\n"),
         (#"\bnouvelle ligne\b"#, "\n"),
@@ -60,9 +75,10 @@ public enum VerbalPunctuationPrepass {
         (#"\bpoint virgule\b"#, ";"),
         (#"\bdeux points\b"#, ":"),
         (#"\bvirgule\b"#, ","),
-        (#"\bpoint\b"#, "."),
     ]
 
+    /// The bare "period" rule is intentionally absent — see the type
+    /// doc-comment (#185). "full stop" stays: it is unambiguous.
     private static let englishRules: [(pattern: String, replacement: String)] = [
         (#"\bnew line\b"#, "\n"),
         (#"\bnewline\b"#, "\n"),
@@ -71,7 +87,6 @@ public enum VerbalPunctuationPrepass {
         (#"\bfull stop\b"#, "."),
         (#"\bsemicolon\b"#, ";"),
         (#"\bcolon\b"#, ":"),
-        (#"\bperiod\b"#, "."),
         (#"\bcomma\b"#, ","),
     ]
 

--- a/DictusCore/Sources/polish-harness/fixtures/seed.json
+++ b/DictusCore/Sources/polish-harness/fixtures/seed.json
@@ -80,5 +80,85 @@
       { "notContains": "how are you" },
       { "lengthRatioMax": 1.4 }
     ]
+  },
+
+  {
+    "id": "8-verbal-clean",
+    "lang": "fr",
+    "sttEngine": "PK",
+    "_note": "Device export 2026-06-09, event 1. Clean verbal punctuation, succeeds on device.",
+    "raw": "Ok, virgule, petit test, virgule, deuxième test, point.",
+    "expect": [
+      { "notContains": "virgule" },
+      { "contains": "test" }
+    ]
+  },
+  {
+    "id": "9-verbal-questions",
+    "lang": "fr",
+    "sttEngine": "PK",
+    "_note": "Device export 2026-06-09, event 2. Spoken ? and ! commands.",
+    "raw": "Salut, comment ça va ? Point d'interrogation. Génial. Point d'exclamation.",
+    "expect": [
+      { "notContains": "Point d'interrogation" },
+      { "notContains": "Point d'exclamation" },
+      { "contains": "?" }
+    ]
+  },
+  {
+    "id": "10-verbal-list-parakeet-error",
+    "lang": "fr",
+    "sttEngine": "PK",
+    "_note": "Device export 2026-06-09, event 3. Parakeet mis-heard 'deux points'->'de point', 'lait'->'les', 'oeufs'->'oeuf'. Out-of-scope STT errors; kept to watch the verbal pre-pass behaviour.",
+    "raw": "Liste de point, pain, point virgule, les point virgule, oeuf, point.",
+    "expect": [
+      { "notContains": "point virgule" }
+    ]
+  },
+  {
+    "id": "11-verbal-newlines",
+    "lang": "fr",
+    "sttEngine": "PK",
+    "_note": "Device export 2026-06-09, event 4. 'retour a la ligne' -> newline. Works on device (simulator-only failure was an Apple FM proxy artefact).",
+    "raw": "Première ligne, retour à la ligne. Deuxième ligne, retour à la ligne, troisième ligne.",
+    "expect": [
+      { "notContains": "retour à la ligne" },
+      { "regexAbsent": "<<NL>>" }
+    ]
+  },
+  {
+    "id": "12-point-final-KNOWN-BUG-B",
+    "lang": "fr",
+    "sttEngine": "PK",
+    "_note": "Device export 2026-06-09, events 5/8/9/10. KNOWN STRUCTURAL BUG B (#185): the pre-pass regex converts the literal noun 'point' in 'un point final' -> 'un. final.'. Engine then engineFailed 4/4 on device. EXPECTED TO FAIL until the LLM owns punctuation (regex cannot tell the noun from the command). Do not paper over with brittle heuristics.",
+    "raw": "Je mets un point final point.",
+    "expect": [
+      { "contains": "point final" }
+    ]
+  },
+  {
+    "id": "13-verbal-mixed",
+    "lang": "fr",
+    "sttEngine": "PK",
+    "_note": "Device export 2026-06-09, event 6. Succeeds on device.",
+    "raw": "Bonjour Pierre, tu vas bien. Point d'interrogation. A très vite. Point.",
+    "expect": [
+      { "notContains": "Point d'interrogation" },
+      { "contains": "Pierre" },
+      { "contains": "?" }
+    ]
+  },
+  {
+    "id": "14-verbal-long-mixed",
+    "lang": "fr",
+    "sttEngine": "PK",
+    "_note": "Device export 2026-06-09, event 7. Long mixed clip, succeeds on device.",
+    "raw": "Donc là je fais un petit test de transcription, retour à la ligne. Je vais faire des tests avec de la ponctuation. Point. Ça marche. Point d'exclamation. Est-ce que c'est normal ? Point d'interrogation.",
+    "expect": [
+      { "notContains": "retour à la ligne" },
+      { "notContains": "Point d'exclamation" },
+      { "notContains": "Point d'interrogation" },
+      { "regexAbsent": "<<NL>>" }
+    ]
   }
 ]

--- a/DictusCore/Sources/polish-harness/fixtures/seed.json
+++ b/DictusCore/Sources/polish-harness/fixtures/seed.json
@@ -127,10 +127,10 @@
     ]
   },
   {
-    "id": "12-point-final-KNOWN-BUG-B",
+    "id": "12-point-noun-preserved",
     "lang": "fr",
     "sttEngine": "PK",
-    "_note": "Device export 2026-06-09, events 5/8/9/10. KNOWN STRUCTURAL BUG B (#185): the pre-pass regex converts the literal noun 'point' in 'un point final' -> 'un. final.'. Engine then engineFailed 4/4 on device. EXPECTED TO FAIL until the LLM owns punctuation (regex cannot tell the noun from the command). Do not paper over with brittle heuristics.",
+    "_note": "Device export 2026-06-09, events 5/8/9/10. Was Bug B: the pre-pass converted the noun 'point' in 'un point final' -> 'un. final'. Fixed (#185) by dropping the bare 'point' rule. The noun must now survive the pre-pass intact. The trailing spoken 'point' command stays a word too (accepted trade-off until the LLM owns punctuation).",
     "raw": "Je mets un point final point.",
     "expect": [
       { "contains": "point final" }

--- a/DictusCore/Sources/polish-harness/main.swift
+++ b/DictusCore/Sources/polish-harness/main.swift
@@ -104,12 +104,15 @@ struct RunOutcome {
 func runOnce(_ fx: Fixture, engine: AppleFoundationModelsPolishEngine) async -> RunOutcome {
     let target = fx.language
     let preprocessed = VerbalPunctuationPrepass.apply(fx.raw, language: target)
+    // Mirror the coordinator's fallback: non-success returns the deterministic
+    // floor (decoded pre-pass), never the literal raw. (#185)
     guard let detected = PolishPipeline.detectLanguage(in: preprocessed) else {
-        return RunOutcome(final: fx.raw, engineOutput: nil, outcome: .skipped, engineMs: 0, detected: nil, mode: nil)
+        let fallback = PolishPostpass.decodeFromEngine(preprocessed, language: target)
+        return RunOutcome(final: fallback, engineOutput: nil, outcome: .skipped, engineMs: 0, detected: nil, mode: nil)
     }
     let mode = PolishPipeline.mode(sttEngine: fx.speechEngine, detected: detected, target: target)
     let r = await PolishPipeline.transform(preprocessed: preprocessed, engine: engine, target: target, mode: mode)
-    let final = (r.outcome == .success) ? (r.engineOutput ?? fx.raw) : fx.raw
+    let final = PolishPipeline.resolvedOutput(r, preprocessed: preprocessed, target: target)
     return RunOutcome(final: final, engineOutput: r.engineOutput, outcome: r.outcome, engineMs: r.engineMs, detected: detected, mode: mode)
 }
 

--- a/DictusCore/Tests/DictusCoreTests/Polish/PolishPipelineTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/Polish/PolishPipelineTests.swift
@@ -36,6 +36,51 @@ final class PolishPipelineTests: XCTestCase {
         XCTAssertTrue(result.engineOutput?.contains("\n") == true)
     }
 
+    // MARK: - resolvedOutput()  (#185)
+
+    /// On success the user gets the engine output verbatim.
+    func testResolvedOutputReturnsEngineOutputOnSuccess() {
+        let result = PolishPipeline.Result(
+            engineOutput: "Ok, petit test.", outcome: .success, engineMs: 5, postprocessMs: 0
+        )
+        let out = PolishPipeline.resolvedOutput(result, preprocessed: "ignored", target: .french)
+        XCTAssertEqual(out, "Ok, petit test.")
+    }
+
+    /// On a non-success outcome the user gets the deterministic floor (decoded
+    /// pre-pass), NOT the literal raw — the verbal-punctuation work survives an
+    /// engine failure. Here the pre-pass already turned "virgule" into ",".
+    func testResolvedOutputFallsBackToPreprocessedOnEngineFailed() {
+        let preprocessed = "Ok, petit test."
+        let result = PolishPipeline.Result(
+            engineOutput: nil, outcome: .engineFailed, engineMs: 600, postprocessMs: 0
+        )
+        let out = PolishPipeline.resolvedOutput(result, preprocessed: preprocessed, target: .french)
+        XCTAssertEqual(out, preprocessed)
+        XCTAssertFalse(out.contains("virgule"))
+    }
+
+    /// A guardrail rejection discards the engine output and also falls back to
+    /// the deterministic floor rather than the raw.
+    func testResolvedOutputFallsBackToPreprocessedOnGuardrailReject() {
+        let preprocessed = "Bonjour Pierre."
+        let result = PolishPipeline.Result(
+            engineOutput: "something the guardrail rejected", outcome: .rejectedGuardrail, engineMs: 700, postprocessMs: 1
+        )
+        let out = PolishPipeline.resolvedOutput(result, preprocessed: preprocessed, target: .french)
+        XCTAssertEqual(out, preprocessed)
+    }
+
+    /// The floor still applies French typography (NBSP before `?`) on fallback,
+    /// proving it routes through `decodeFromEngine`, not a bare passthrough.
+    func testResolvedOutputAppliesTypographyOnFallback() {
+        let result = PolishPipeline.Result(
+            engineOutput: nil, outcome: .cancelled, engineMs: 0, postprocessMs: 0
+        )
+        let out = PolishPipeline.resolvedOutput(result, preprocessed: "ça va ?", target: .french)
+        XCTAssertEqual(out, "ça va\u{00A0}?")
+    }
+
     // MARK: - detectLanguage()
 
     func testDetectLanguageReturnsNilForEmpty() {

--- a/DictusCore/Tests/DictusCoreTests/Polish/VerbalPunctuationPrepassTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/Polish/VerbalPunctuationPrepassTests.swift
@@ -41,11 +41,18 @@ final class VerbalPunctuationPrepassTests: XCTestCase {
         )
     }
 
-    func testFrenchPointSingleWord() {
-        XCTAssertEqual(
-            VerbalPunctuationPrepass.apply("la phrase est finie point", language: .french),
-            "la phrase est finie."
-        )
+    /// The bare "point" word is intentionally NOT converted (#185): it collides
+    /// with the common French noun. The LLM supplies the terminal period.
+    func testFrenchBarePointNotConverted() {
+        let raw = "la phrase est finie point"
+        XCTAssertEqual(VerbalPunctuationPrepass.apply(raw, language: .french), raw)
+    }
+
+    /// The noun "point" inside a sentence must survive untouched (#185) — this
+    /// is the whole reason the bare rule was dropped.
+    func testFrenchPointNounPreserved() {
+        let raw = "je partage un point de vue sur ce point final"
+        XCTAssertEqual(VerbalPunctuationPrepass.apply(raw, language: .french), raw)
     }
 
     func testFrenchMultipleSubstitutionsInOneSentence() {
@@ -93,8 +100,9 @@ final class VerbalPunctuationPrepassTests: XCTestCase {
         )
     }
 
-    /// "trois points" (plural) must NOT match the singular "point" rule.
-    func testFrenchWordBoundaryProtectsPlural() {
+    /// "trois points" (plural) is untouched — and since the bare "point" rule
+    /// was dropped (#185), so is the singular form.
+    func testFrenchPointsPluralUntouched() {
         let raw = "j'ai mis trois points sur ma carte"
         let result = VerbalPunctuationPrepass.apply(raw, language: .french)
         XCTAssertEqual(result, raw)
@@ -137,11 +145,18 @@ final class VerbalPunctuationPrepassTests: XCTestCase {
         )
     }
 
-    func testEnglishPeriodAndComma() {
+    /// "full stop" converts but the bare "period" word does not (#185) — it
+    /// collides with the common English noun ("a period of time").
+    func testEnglishBarePeriodNotConverted() {
         XCTAssertEqual(
             VerbalPunctuationPrepass.apply("hello comma world period", language: .english),
-            "hello, world."
+            "hello, world period"
         )
+    }
+
+    func testEnglishPeriodNounPreserved() {
+        let raw = "we had a long period of calm"
+        XCTAssertEqual(VerbalPunctuationPrepass.apply(raw, language: .english), raw)
     }
 
     func testEnglishSemicolonAndColon() {
@@ -166,7 +181,8 @@ final class VerbalPunctuationPrepassTests: XCTestCase {
     }
 
     func testEnglishMultipleSubstitutions() {
-        let raw = "Hi how are you question mark I read your report comma and I think it's great period"
+        // "period" stays a word (#185); "full stop" gives the terminal mark.
+        let raw = "Hi how are you question mark I read your report comma and I think it's great full stop"
         let expected = "Hi how are you ? I read your report, and I think it's great."
         XCTAssertEqual(VerbalPunctuationPrepass.apply(raw, language: .english), expected)
     }
@@ -194,12 +210,12 @@ final class VerbalPunctuationPrepassTests: XCTestCase {
         XCTAssertEqual(VerbalPunctuationPrepass.apply(raw, language: .french), raw)
     }
 
-    /// Multiple-word punctuation must win over single-word: don't let \bpoint\b
-    /// match the "point" inside "point d'interrogation".
-    func testFrenchOrderingMultiWordWins() {
+    /// Multi-word "point d'interrogation" still converts; the trailing bare
+    /// "point" now stays a word (#185).
+    func testFrenchMultiWordConvertsBarePointStays() {
         XCTAssertEqual(
             VerbalPunctuationPrepass.apply("la question est point d'interrogation pas point", language: .french),
-            "la question est ? pas."
+            "la question est ? pas point"
         )
     }
 


### PR DESCRIPTION
Closes #185.

On-device testing of verbal punctuation (FR, Parakeet, Apple FM) surfaced two distinct problems. Both are addressed here; the structural root cause is fixed by simplification rather than heuristics.

## 1. Fall back to the deterministic floor, never the raw (`9e53f0c`)

When the polish engine does not produce an accepted result — `skipped` (gibberish), `engineFailed`, `rejectedGuardrail`, `cancelled` — the coordinator returned the original `raw` STT text, throwing away the verbal-punctuation pre-pass that had already run. The user saw spoken command words ("virgule", "point") left as literal words instead of the marks they asked for.

- New single source of truth `PolishPipeline.resolvedOutput(result, preprocessed:, target:)`: on success returns the engine output, otherwise the deterministic floor `decodeFromEngine(preprocessed)` — the same value the `< engineMinDuration` gate already returns.
- Both `PolishCoordinator` fallback paths (skip + main) and the eval harness `runOnce` route through it, so app and harness stay identical.
- +4 deterministic `resolvedOutput` tests.

## 2. Drop the bare "point" / "period" rule (`b5847ac`)

The sentence-period commands — FR "point", EN "period" — are removed from the pre-pass. Unlike every other command they are common ordinary words ("un point de vue", "faire le point", "à quel point" / "a period of time", "period drama") and, as single short tokens, carry no context to disambiguate. Converting them silently corrupted the sentence: "un point final" → "un. final".

Dropping them is acceptable because the LLM already supplies the terminal period at natural sentence boundaries on its own (observed on device). The unambiguous multi-word marks that merely contain "point" (point d'interrogation / d'exclamation / virgule) stay, as does English "full stop". The same principle is documented to pre-emptively bar Spanish "punto" and German "Punkt" when those languages get rules.

**Trade-off:** an explicitly spoken trailing "point"/"period" now depends on the LLM to render it as a period — usually handled, occasionally left as the literal word. The proper long-term fix is to let a context-aware round-2 LLM own punctuation and remove the regex pre-pass entirely.

## Validation

- `swift test` — 306 tests, 0 failures.
- `swift run polish-harness eval` (macOS 26 + Apple Intelligence) — the captured device fixtures pass; `12-point-noun-preserved` confirms "Je mets un point final point." → "Je mets un point final."
- On device (`dictus-polish-debug-20260611-084111.json`): noun "point" preserved across real dictations (incl. a meta-comment using "le point" 3×, all intact); the earlier "Retourne" leftover did not recur (it was Parakeet STT variance, not our code).

## Not in scope

- Parakeet STT errors on plausible valid words ("retour"→"retourne", "deux points"→"de point") — ADR 0003 faithfulness contract forbids the LLM correcting valid words.
- The LLM-owns-punctuation migration that removes the regex pre-pass — tracked under #141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)