### PR TITLE
chore: formalize deployment runbook (TestFlight + App Store)

### DIFF
--- a/DictusApp/Info.plist
+++ b/DictusApp/Info.plist
@@ -31,6 +31,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>17</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusKeyboard/Info.plist
+++ b/DictusKeyboard/Info.plist
@@ -20,6 +20,8 @@
 	<string>1.7.1</string>
 	<key>CFBundleVersion</key>
 	<string>17</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusWidgets/Info.plist
+++ b/DictusWidgets/Info.plist
@@ -20,6 +20,8 @@
 	<string>1.7.1</string>
 	<key>CFBundleVersion</key>
 	<string>17</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/docs/GIT_WORKFLOW.md
+++ b/docs/GIT_WORKFLOW.md
@@ -1,167 +1,166 @@
 # Git & Release Workflow — Dictus
 
 Guide for managing branches, releases, and TestFlight/App Store distribution.
+Version-numbering policy lives in **[VERSIONING.md](VERSIONING.md)**.
 
 ## Branch strategy
 
 ```
-main (production)              <- App Store + TestFlight public
+main (production)              <- App Store + external TestFlight. Tagged vX.Y.Z.
   |
   +-- develop                  <- Daily integration, internal TestFlight builds
   |     |
-  |     +-- feature/xxx       <- New feature (one branch per feature/issue)
-  |     +-- fix/xxx           <- Bug fix
-  |     +-- chore/xxx         <- Maintenance, refactoring, docs
-  |
-  +-- release/x.y.z           <- Release preparation (freeze, QA, bugfix only)
+  |     +-- feature/xxx        <- New feature (one branch per feature/issue)
+  |     +-- fix/xxx            <- Bug fix
+  |     +-- chore/xxx          <- Maintenance, refactoring, docs
   |
   +-- hotfix/xxx               <- Critical production fix (branches from main)
 ```
 
+We deliberately **do not use `release/*` freeze branches** — for a solo/small
+team they add ceremony without value. A release is pinned to a specific commit
+via its `build/N` tag instead (see Runbook B). The promote script creates a
+throwaway `release/X.Y.Z` branch only as a vehicle to open the PR; it is not a
+QA-freeze phase and is deleted on merge.
+
 ## Branch roles
 
-| Branch | Purpose | Who merges here | TestFlight | App Store |
+| Branch | Purpose | Merges in via | TestFlight | App Store |
 |---|---|---|---|---|
-| `main` | Stable production code | release/* and hotfix/* only | Public beta | Yes |
-| `develop` | Integration of ongoing work | feature/*, fix/*, chore/* | Internal testing | No |
-| `feature/*` | Single feature development | Developer (PR to develop) | No | No |
-| `fix/*` | Bug fix | Developer (PR to develop) | No | No |
-| `release/x.y.z` | Pre-release freeze & QA | Bugfixes only (no new features) | QA testing | When ready |
+| `main` | Stable production code | PR from develop (release) or hotfix/* | External (public) | Yes |
+| `develop` | Integration of ongoing work | PR from feature/*, fix/*, chore/* | Internal | No |
+| `feature/*` `fix/*` `chore/*` | One unit of work | Developer (PR to develop) | No | No |
 | `hotfix/*` | Critical fix on production | Developer (PR to main) | If needed | Yes |
 
 ## Workflow: Feature development
 
 ```
-1. git checkout develop
-2. git pull origin develop
-3. git checkout -b feature/my-feature
-4. ... work, commit frequently ...
-5. Push + open PR to develop
-6. Code review (if applicable) + merge
+1. git checkout develop && git pull origin develop
+2. git checkout -b feature/my-feature      # or fix/ , chore/
+3. ... work, commit frequently ...
+4. git push -u origin feature/my-feature
+5. Open PR → develop, CI green, merge (--merge, never squash)
 ```
 
-## Workflow: Preparing a release
+## Runbook A — Cut a TestFlight build (from `develop`)
+
+Internal TestFlight builds come from `develop`. One command does the version
+bump across all three plists, the commit, the `build/N` tag, and the push:
+
+```sh
+git checkout develop && git pull origin develop
+
+scripts/cut-testflight.sh          # build-number bump only (same marketing version)
+scripts/cut-testflight.sh 1.8.0    # ALSO set the marketing version to 1.8.0
+
+# then, in Xcode:
+#   Product ▸ Archive  (scheme DictusApp, on develop)  →  Distribute  →  App Store Connect
+```
+
+The script refuses to run on a dirty / out-of-sync develop and refuses a
+duplicate build number. After it runs, the build is traceable forever via its
+`build/N` tag — no manual tagging, nothing to forget.
+
+## Runbook B — Promote a build to the App Store
+
+Key idea: **a release is pinned to the commit that produced the tested build,
+not to develop's current tip.** develop keeps moving while a build is in
+TestFlight; we ship the exact commit behind `build/N`.
+
+### Worked example
 
 ```
-1. develop is stable and ready
-2. git checkout develop
-3. git checkout -b release/1.2.0
-4. Bump version number in Xcode (CFBundleShortVersionString)
-5. Bump build number (CFBundleVersion)
-6. QA testing on this branch — only bugfixes allowed, no new features
-7. Fix any issues directly on release/1.2.0
-8. When ready:
-   a. Merge release/1.2.0 into main
-   b. Tag: git tag v1.2.0
-   c. Merge main back into develop (to sync bugfixes)
-   d. Delete release/1.2.0
+develop:  …──X──A──B──C──D──Z        ← a month of work after the build
+              │
+              └─ X = "chore: bump to 1.8.0 (build 18)"   [tag build/18]  ← on TestFlight
+
+# A month later we decide build 18 is good. We must bring ONLY X to main
+# (A…Z are not ancestors of X, so a merge of X excludes them):
+
+scripts/promote-to-appstore.sh 18
+```
+
+The script:
+1. Resolves `build/18` → commit X and marketing version `1.8.0`.
+2. Creates an ephemeral `release/1.8.0` branch at X and opens a PR → `main`.
+3. Waits for required checks (`Build`, `SwiftLint`), then merges with `--admin`
+   (you are in main's bypass list; you cannot self-approve, so `--admin` is how
+   the merge lands).
+4. Tags `v1.8.0` (annotated) on main + pushes, creates the GitHub Release.
+5. **Back-merges `main → develop`** — the step whose omission caused the v1.7.1
+   drift. Never skipped because the script owns it.
+6. Prints the App Store Connect checklist.
+
+### App Store Connect (the only manual part)
+
+```
+1. My Apps → Dictus → the X.Y.Z App Store version (create it on first launch).
+2. Build section → select build N (already uploaded from TestFlight). No rebuild.
+3. First submission only: complete the listing — screenshots (6.9" + 6.5"),
+   description, keywords, support URL, privacy policy URL, category, age rating,
+   price/availability, and the App Privacy questionnaire ("Data Not Collected",
+   Dictus is offline).
+4. App Review Information → Notes: explain the keyboard needs Full Access for the
+   MICROPHONE (on-device dictation, no keystroke logging/transmission) and how to
+   enable the keyboard. This is the #1 review risk for keyboard extensions.
+5. Export compliance: ITSAppUsesNonExemptEncryption is set in Info.plist → no prompt.
+6. Submit for Review (24–48h typical).
+```
+
+### Doing it by hand (if not using the script)
+
+```sh
+git checkout main && git pull origin main
+git merge build/18 --no-ff -m "release: v1.8.0 (build 18)"   # brings ONLY X's history
+git tag -a v1.8.0 -m "v1.8.0 — short one-liner" && git push origin main v1.8.0
+gh release create v1.8.0 --title "v1.8.0 — …" --notes "…"
+git checkout develop && git merge main --no-edit && git push origin develop   # resync
 ```
 
 ## Workflow: Hotfix (critical production bug)
 
 ```
-1. git checkout main
+1. git checkout main && git pull
 2. git checkout -b hotfix/fix-crash
-3. Fix the issue
-4. Merge into main + tag (v1.2.1)
-5. Merge main back into develop
-6. Delete hotfix branch
+3. ... fix, commit ...
+4. PR → main, CI green, merge (--admin)
+5. Bump build number (and PATCH version) → cut/upload, then tag vX.Y.(Z+1) on main
+6. git checkout develop && git merge main   # resync, always
 ```
-
-## Version numbering
-
-See **[VERSIONING.md](VERSIONING.md)** for the full policy — when to bump MAJOR vs MINOR vs PATCH, why we dropped `-beta.N` suffixes, historical tags, and the release checklist.
 
 ## TestFlight distribution
 
-TestFlight has two tester groups:
-
-### Internal testing (up to 100 testers)
-- Team members only (requires App Store Connect access)
-- No Apple review needed
-- Builds available immediately after processing
-- Use for: daily develop builds, quick iteration
-
-### External testing (up to 10,000 testers)
-- Public link, anyone can join
-- Requires Apple Beta App Review (lighter than full review, usually < 24h)
-- Use for: public beta from main or release/* branches
-- Builds expire after 90 days
-
-### Recommended TestFlight setup for Dictus
-
-| Group | Source branch | Purpose |
-|---|---|---|
-| Internal — Dev team | `develop` | Latest features, may be unstable |
-| External — Beta testers | `main` or `release/*` | Stable builds for public testing |
-
-## App Store submission
-
-```
-1. main is tagged with vX.Y.Z
-2. Archive in Xcode: Product > Archive
-3. Upload to App Store Connect
-4. Fill in release notes, screenshots, metadata
-5. Submit for review (usually 24-48h)
-6. Once approved: release manually or set auto-release
-```
+| Group | Source branch | Apple review | Purpose |
+|---|---|---|---|
+| Internal — Dev team (≤100) | `develop` | None | Daily builds, fast iteration |
+| External — Public beta (≤10k) | `main` | Beta App Review (light, <24h) | Stable public testing |
 
 ## Commit message convention
 
-Format: `type: short description`
+Format: `type: short description` — types: `feat`, `fix`, `chore`, `refactor`,
+`docs`, `test`, `style`, `perf`. Scope an issue with `feat(#141): …`.
 
 ```
-feat: add custom vocabulary import
+feat(#141): add Apple FM polish layer
 fix: resolve crash on long dictation
-chore: bump WhisperKit to 0.17.0
-refactor: extract SubscriptionManager to DictusCore
-docs: update release workflow guide
+chore: bump to 1.8.0 (build 18)
 ```
-
-Types: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`, `style`, `perf`
-
-## Current phase (pre-release)
-
-While waiting for Apple Developer enrollment:
-
-```
-main          <- Single stable branch (current setup)
-  |
-  +-- feature/*   <- Feature branches as needed
-```
-
-Once the Developer account is active:
-1. Create `develop` from `main`
-2. Start working on `develop`
-3. `main` becomes the production branch
-4. Set up TestFlight internal + external groups
 
 ## Quick reference
 
 ```bash
-# Start a new feature
+# New unit of work
 git checkout develop && git pull
-git checkout -b feature/my-feature
+git checkout -b feature/my-feature      # → PR to develop
 
-# Finish a feature
-git push -u origin feature/my-feature
-# Open PR to develop on GitHub
-
-# Start a release
+# Cut a TestFlight build
 git checkout develop && git pull
-git checkout -b release/1.2.0
+scripts/cut-testflight.sh 1.8.0         # then Xcode Archive → upload
 
-# Ship the release
-git checkout main && git merge release/1.2.0
-git tag v1.2.0 && git push origin main --tags
-git checkout develop && git merge main
-git branch -d release/1.2.0
+# Ship a build to the App Store
+scripts/promote-to-appstore.sh 18       # PR→main, tag, release, back-merge
 
 # Emergency hotfix
 git checkout main && git pull
-git checkout -b hotfix/fix-crash
-# ... fix, commit ...
-git checkout main && git merge hotfix/fix-crash
-git tag v1.2.1 && git push origin main --tags
-git checkout develop && git merge main
+git checkout -b hotfix/fix-crash        # → PR to main, then resync develop
 ```

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -4,10 +4,13 @@ How we number releases and tags. Complements [GIT_WORKFLOW.md](GIT_WORKFLOW.md).
 
 ## TL;DR
 
-- One version line: `X.Y.Z` — [Semantic Versioning](https://semver.org/).
-- No `-beta.N` suffix. TestFlight = our current distribution channel, not a sematic status.
-- Each tag is a full release. If we promote a TestFlight build to App Store later, it's the **same build** (same tag, same `CFBundleVersion`).
-- `CFBundleVersion` (Apple build number) always increments; never resets.
+- One marketing version line: `X.Y.Z` — [Semantic Versioning](https://semver.org/). **No `-beta` suffix** anywhere (not in the plist, not in tags). TestFlight is a *channel*, not a version status.
+- `CFBundleVersion` (Apple build number) is a plain integer that **always increments, never resets** — shared identically across the 3 targets (App / Keyboard / Widgets).
+- **Two kinds of tags, two purposes:**
+  - **`build/N`** — a *lightweight* git tag on every TestFlight build. Cheap, not a GitHub Release. It answers "when did we cut build N and from which commit?" and is the anchor we promote from.
+  - **`vX.Y.Z`** — an *annotated* tag + GitHub Release, created **only** when a build is promoted to the App Store. One per shipped version.
+- **A release is pinned to a commit, never to "develop's current tip."** We promote the exact commit that produced the tested TestFlight build (its `build/N` tag), even if develop has moved on since.
+- Two scripts make it deterministic: [`scripts/cut-testflight.sh`](../scripts/cut-testflight.sh) and [`scripts/promote-to-appstore.sh`](../scripts/promote-to-appstore.sh).
 
 ## When to bump each digit
 
@@ -15,82 +18,88 @@ How we number releases and tags. Complements [GIT_WORKFLOW.md](GIT_WORKFLOW.md).
 | --- | --- | --- |
 | **PATCH** `X.Y.Z → X.Y.(Z+1)` | Bug fix, polish, perf tweak, no new user-facing feature | Fix #134 keyboard freeze → `1.6.1` |
 | **MINOR** `X.Y.Z → X.(Y+1).0` | New user-facing feature, new supported language, new model in catalog | German layout → `1.7.0` |
-| **MAJOR** `X.Y.Z → (X+1).0.0` | First public App Store release, premium launch, breaking UX shift | App Store public → `2.0.0` |
+| **MAJOR** `X.Y.Z → (X+1).0.0` | Premium launch, breaking UX shift | Premium → `2.0.0` |
 
 Rule of thumb: **ask "does a returning user notice something new?"** — if yes → MINOR at least. If they just notice things work better → PATCH.
 
-## `CFBundleVersion` (Apple build number)
+> Note: the **first App Store release is not automatically a MAJOR**. We shipped `v1.x` on TestFlight for a long time; the first public App Store submission keeps the normal `1.Y.Z` line (it's the same product, same version line — just a new distribution channel).
 
-- Incremented on **every** TestFlight upload, even if `X.Y.Z` doesn't change (re-upload after an entitlement tweak, etc.).
-- Never resets. `1 → 2 → 3 → ... → 13 → 14 → ...` regardless of the marketing version jump.
-- Same build number across all three targets (App / Keyboard / Widgets) — automated bump covers them all.
+## Build numbers vs. version — the two-axis model
+
+```
+CFBundleShortVersionString (marketing)  →  what users see: 1.8.0   (SemVer, no suffix)
+CFBundleVersion            (build no.)  →  what Apple tracks: 18    (integer, ++ every upload)
+```
+
+- The **build number** increments on **every** upload (TestFlight or App Store), even if the marketing version is unchanged (re-upload after an entitlement tweak, a second beta of the same version, etc.). It is unique across the whole App Store Connect history for the app and never repeats.
+- The **marketing version** only changes when you start a new user-facing version. Several TestFlight builds can share one marketing version (`1.8.0` builds 18, 19, 20…) before one of them is promoted.
+- Both are kept identical across the 3 targets — `cut-testflight.sh` bumps all three plists together so they can never drift.
+
+## Tags — `build/N` vs `vX.Y.Z`
+
+| | `build/N` | `vX.Y.Z` |
+| --- | --- | --- |
+| Created | every TestFlight build (by `cut-testflight.sh`) | only at App Store promotion (by `promote-to-appstore.sh`) |
+| Git type | lightweight | annotated (`-a`) |
+| GitHub Release | no | yes |
+| Points at | the `chore: bump…` commit on develop | the release merge commit on main |
+| Answers | "when/what was build N" + promotion anchor | "exactly what is in production" |
+
+Why two tiers: build tags give full per-build traceability **without** cluttering the GitHub Releases page (only the Tags page) — this is what CI systems do. Release tags stay rare and meaningful: each one is a real, shipped version. Runtime traceability is *also* covered independently by the git-SHA injected into every built Info.plist (a build phase writes `GitCommitSHA` + `GitBranch`), so even an untagged build is identifiable from the app's debug log.
+
+## TestFlight → App Store: promote, don't rebuild
+
+```
+develop ──(cut-testflight.sh)──► TestFlight build N      [tag build/N]
+                                       │
+                                       │  (validated by testers)
+                                       ▼
+main ◄──(promote-to-appstore.sh N, pins commit build/N)── tag vX.Y.Z + GitHub Release
+                                       │
+                                       ▼
+                                App Store: select build N (same binary), submit
+```
+
+- The binary submitted to the App Store is the **same** one testers ran on TestFlight — you select build N in App Store Connect, you do **not** archive again.
+- The promotion **pins the commit** behind build N, so develop can keep moving freely. See the worked example in [GIT_WORKFLOW.md](GIT_WORKFLOW.md#runbook-b--promote-a-build-to-the-app-store).
+
+## Runbooks (the only two deployment actions)
+
+### Cut a TestFlight build (from `develop`)
+
+```sh
+scripts/cut-testflight.sh          # build-number bump only (another beta of the same version)
+scripts/cut-testflight.sh 1.8.0    # also set the marketing version to 1.8.0
+```
+Then: Xcode → Product ▸ Archive (scheme DictusApp, from develop) → upload. That's it — no tag to remember, the script made `build/N`.
+
+### Promote a TestFlight build to the App Store
+
+```sh
+scripts/promote-to-appstore.sh 18  # ship the build/18 candidate
+```
+Opens the `develop`→`main` PR pinned to build 18's commit, waits for CI, admin-merges, tags `v1.8.0` + GitHub Release, **back-merges main→develop**, and prints the App Store Connect checklist (the only manual part).
 
 ## What shipped so far (historical — do not rewrite)
 
 | Tag | `CFBundleShortVersionString` | `CFBundleVersion` | Notes |
 | --- | --- | --- | --- |
-| `v1.6.0-beta.1` → `v1.6.0-beta.4` | `1.6.0` (frozen across 4 betas) | 10 → 11 → 12 → 13 | Pre-switch-to-semver. Kept as-is for TestFlight release-note continuity. |
-
-Next tag onward follows the rules below — we do **not** retro-rename `beta.1–4`.
-
-## The next tag
-
-Heuristic:
-
-1. Since `v1.6.0-beta.4`, is the incoming change a fix-only patch?
-   - Yes → `v1.6.1` (first clean-numbering patch after beta line).
-   - No → step 2.
-2. Is it a notable new feature (German layout, new model, visible UX)?
-   - Yes → `v1.7.0`.
-   - No → re-classify — probably patch.
-3. Is it App Store public launch or premium launch?
-   - Yes → `v2.0.0`.
-
-Planned near-term:
-- **`v1.7.0`** — German keyboard layout (new feature → MINOR).
-- Fix #134 (retain cycle) will likely land inside `v1.7.0` alongside other work, not a standalone patch, unless it ships first on its own.
-
-## TestFlight vs. App Store (Option A)
-
-We use a **single distribution line**. There is no `-beta` parallel to a stable version.
-
-```
-develop ───┬──> TestFlight (internal)
-           │
-main ──────┴──> TestFlight (external, when we have it)
-                └──> App Store (same build, promoted when validated)
-```
-
-- `develop` builds go to internal testers as they're uploaded.
-- When a build is stabilised and we want public release, we merge `develop → main`, tag `vX.Y.Z`, and **that same archive** is the one we submit to App Store review.
-- No "rebuild for production" — the tested bits are the shipped bits.
-
-This keeps version numbers honest: `v1.6.1` on TestFlight = `v1.6.1` on App Store. No `.beta` suffix to strip.
-
-## Release checklist
-
-When `develop` is ready to ship:
-
-1. Decide the tag per the heuristic above.
-2. Bump `CFBundleShortVersionString` in all three Info.plists (App / Keyboard / Widgets) to the new `X.Y.Z`.
-3. Bump `CFBundleVersion` by one across all three plists.
-4. Commit: `chore: bump to X.Y.Z (build N)`.
-5. Open PR `develop → main`, merge.
-6. `git checkout main && git pull`.
-7. `git tag -a vX.Y.Z -m "vX.Y.Z — short one-liner"` + `git push origin vX.Y.Z`.
-8. Archive in Xcode, upload to App Store Connect.
-9. Once accepted for TestFlight: `gh release create vX.Y.Z --title "..." --notes "..."` (use `--prerelease` only if the build is not intended for external TestFlight / App Store).
-10. Merge `main → develop` to keep branches in sync.
-11. **Sync `main` into `feature/premium`** — open a `sync/main-to-premium-vX.Y.Z` branch from `feature/premium`, `git merge origin/main --no-ff`, resolve any `.planning/` conflicts in favour of premium (`--ours`), open a PR into `feature/premium`, merge with `--merge` (never squash). Required as long as `feature/premium` is an active long-lived branch — drop this step if/when premium is retired or merged.
+| `v1.6.0-beta.1` → `v1.6.0-beta.4` | `1.6.0` (frozen across 4 betas) | 10 → 13 | Pre-semver-switch. Kept as-is for release-note continuity; we do **not** retro-rename. |
+| `v1.6.1` … `v1.7.1` | `1.6.1` … `1.7.1` | 14 → 17 | Clean single-line releases. `v1.7.1` (build 17) is the current production candidate. |
 
 ## Release-notes naming (GitHub + TestFlight)
 
-- GitHub release title: `vX.Y.Z — short summary` (e.g. `v1.7.0 — German layout + keyboard stability fix`).
-- TestFlight "What to Test" notes: user-facing bullets, English, no internal jargon, no issue numbers that testers can't click. Keep internal technical notes for the GitHub release body.
+- GitHub release title: `vX.Y.Z — short summary` (e.g. `v1.8.0 — Apple FM polish layer`).
+- TestFlight "What to Test": user-facing bullets, English, no internal jargon, no un-clickable issue numbers. Keep technical notes for the GitHub release body.
 
 ## Common mistakes to avoid
 
-- ❌ Re-using a version number for a re-upload — always bump `CFBundleVersion` at minimum.
-- ❌ Adding `-beta.N` to a new tag — obsolete convention, drops for all tags from `v1.6.1` onward.
-- ❌ Letting `CFBundleVersion` drift between targets (App=13, Keyboard=11, Widgets=12 style) — always bump all three together.
-- ❌ Tagging before the merge lands on `main` — the tag should point to a commit that is reachable from `main`.
+- ❌ Re-using a build number for a re-upload — always bump `CFBundleVersion`. (`cut-testflight.sh` enforces this and refuses a duplicate `build/N`.)
+- ❌ Adding `-beta.N` to a tag or to the marketing version — obsolete convention, dropped since `v1.6.1`.
+- ❌ Promoting "develop's current tip" instead of the pinned `build/N` commit — ships untested code. Always promote via `build/N`.
+- ❌ Forgetting the **main → develop** back-merge after a release — this is what caused the `v1.7.1` drift. The promote script does it automatically; if you release by hand, do it.
+- ❌ Letting `CFBundleVersion` drift between targets — always bump all three together.
+
+## Premium worktree sync (only while `feature/premium` is active)
+
+After a release lands on `main`, sync it into the long-lived premium branch: open a `sync/main-to-premium-vX.Y.Z` branch from `feature/premium`, `git merge origin/main --no-ff`, resolve any `.planning/` conflicts in favour of premium, PR into `feature/premium`, merge with `--merge` (never squash). Drop this step if/when premium is retired or merged.

--- a/scripts/cut-testflight.sh
+++ b/scripts/cut-testflight.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# cut-testflight.sh — prepare a TestFlight build from `develop`.
+#
+# What it does (deterministic, no room to forget a step):
+#   1. Verify we are on a clean `develop`, in sync with origin.
+#   2. Increment CFBundleVersion (build number) across the 3 Info.plists.
+#   3. Optionally set CFBundleShortVersionString (marketing version) if passed.
+#   4. Commit `chore: bump to X.Y.Z (build N)`.
+#   5. Create the lightweight `build/N` tag on that commit.
+#   6. Push develop + the tag.
+#
+# After this: archive from `develop` in Xcode and upload to App Store Connect.
+# The `build/N` tag is the anchor used later by promote-to-appstore.sh.
+#
+# Usage:
+#   scripts/cut-testflight.sh            # build-number bump only (same version)
+#   scripts/cut-testflight.sh 1.8.0      # also set marketing version to 1.8.0
+#
+# See docs/VERSIONING.md and docs/GIT_WORKFLOW.md for the full policy.
+set -eu
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+cd "$REPO_ROOT"
+
+PLISTS="DictusApp/Info.plist DictusKeyboard/Info.plist DictusWidgets/Info.plist"
+PB=/usr/libexec/PlistBuddy
+NEW_VERSION="${1:-}"
+
+# --- Safety gates -----------------------------------------------------------
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$BRANCH" != "develop" ]; then
+  echo "error: must be on 'develop' (currently on '$BRANCH'). Aborting." >&2
+  exit 1
+fi
+if [ -n "$(git status --porcelain)" ]; then
+  echo "error: working tree is not clean. Commit or stash first. Aborting." >&2
+  git status --short >&2
+  exit 1
+fi
+git fetch origin develop --quiet
+if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/develop)" ]; then
+  echo "error: local develop is not in sync with origin/develop. Pull/push first." >&2
+  exit 1
+fi
+
+# --- Compute the new build number -------------------------------------------
+CUR_BUILD=$($PB -c "Print :CFBundleVersion" DictusApp/Info.plist)
+case "$CUR_BUILD" in
+  ''|*[!0-9]*) echo "error: current build number '$CUR_BUILD' is not an integer." >&2; exit 1 ;;
+esac
+NEW_BUILD=$((CUR_BUILD + 1))
+
+# Guard: the build/N tag must not already exist (build numbers never repeat).
+if git rev-parse -q --verify "refs/tags/build/$NEW_BUILD" >/dev/null; then
+  echo "error: tag build/$NEW_BUILD already exists. Build numbers never repeat." >&2
+  exit 1
+fi
+
+# Marketing version: keep current unless an argument is given.
+CUR_VERSION=$($PB -c "Print :CFBundleShortVersionString" DictusApp/Info.plist)
+if [ -n "$NEW_VERSION" ]; then
+  case "$NEW_VERSION" in
+    [0-9]*.[0-9]*.[0-9]*|[0-9]*.[0-9]*) : ;;
+    *) echo "error: '$NEW_VERSION' is not a valid X.Y.Z marketing version." >&2; exit 1 ;;
+  esac
+  VERSION="$NEW_VERSION"
+else
+  VERSION="$CUR_VERSION"
+fi
+
+echo "→ version  : $CUR_VERSION -> $VERSION"
+echo "→ build    : $CUR_BUILD -> $NEW_BUILD"
+echo "→ plists   : $PLISTS"
+printf "Proceed? [y/N] "
+read -r ANSWER
+case "$ANSWER" in [yY]*) : ;; *) echo "Aborted."; exit 1 ;; esac
+
+# --- Apply to all three plists ----------------------------------------------
+for P in $PLISTS; do
+  $PB -c "Set :CFBundleVersion $NEW_BUILD" "$P"
+  $PB -c "Set :CFBundleShortVersionString $VERSION" "$P"
+done
+
+# --- Commit, tag, push ------------------------------------------------------
+git add $PLISTS
+git commit -m "chore: bump to $VERSION (build $NEW_BUILD)"
+git tag "build/$NEW_BUILD"
+git push origin develop "build/$NEW_BUILD"
+
+echo ""
+echo "✅ develop bumped to $VERSION (build $NEW_BUILD), tagged build/$NEW_BUILD, pushed."
+echo "   Next: Xcode → Product > Archive (scheme DictusApp, from develop) → upload to App Store Connect."
+echo "   To ship this build to the App Store later: scripts/promote-to-appstore.sh $NEW_BUILD"

--- a/scripts/promote-to-appstore.sh
+++ b/scripts/promote-to-appstore.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+# promote-to-appstore.sh — ship a TestFlight build to the App Store.
+#
+# Pins the release to the EXACT commit that produced build N (the `build/N`
+# tag), never to develop's current tip — so the bits users get are the bits
+# that were tested on TestFlight, even if develop has moved on since.
+#
+# What it does:
+#   1. Resolve the `build/N` tag -> commit C and marketing version X.Y.Z.
+#   2. Create an ephemeral `release/X.Y.Z` branch at C and open a PR to main.
+#   3. Wait for required checks (Build + SwiftLint), then merge with --admin.
+#   4. Tag `vX.Y.Z` (annotated) on main + push, create a GitHub Release.
+#   5. Back-merge main -> develop (the step that must never be forgotten).
+#   6. Print the App Store Connect checklist (the only manual part).
+#
+# The binary is NOT rebuilt: in App Store Connect you select build N (already
+# uploaded from TestFlight) and submit it. This script only moves source +
+# tags + the GitHub release.
+#
+# Usage:
+#   scripts/promote-to-appstore.sh 18
+#
+# See docs/VERSIONING.md and docs/GIT_WORKFLOW.md for the full policy.
+set -eu
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+cd "$REPO_ROOT"
+PB=/usr/libexec/PlistBuddy
+
+N="${1:-}"
+case "$N" in
+  ''|*[!0-9]*) echo "usage: scripts/promote-to-appstore.sh <build-number>" >&2; exit 1 ;;
+esac
+
+TAG="build/$N"
+if ! git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+  git fetch origin --tags --quiet
+  git rev-parse -q --verify "refs/tags/$TAG" >/dev/null || {
+    echo "error: tag $TAG not found. Was build $N cut with cut-testflight.sh?" >&2; exit 1; }
+fi
+
+COMMIT=$(git rev-parse "$TAG^{commit}")
+TMP=$(mktemp); trap 'rm -f "$TMP"' EXIT
+git show "$TAG:DictusApp/Info.plist" > "$TMP"
+VERSION=$($PB -c "Print :CFBundleShortVersionString" "$TMP")
+VTAG="v$VERSION"
+RELEASE_BRANCH="release/$VERSION"
+
+if git rev-parse -q --verify "refs/tags/$VTAG" >/dev/null; then
+  echo "error: tag $VTAG already exists — $VERSION looks already released." >&2; exit 1
+fi
+
+echo "→ build      : $N  (tag $TAG)"
+echo "→ commit     : $COMMIT"
+echo "→ version    : $VERSION  -> will tag $VTAG + GitHub Release"
+echo "→ PR         : $RELEASE_BRANCH -> main (admin merge after CI)"
+printf "Proceed with the App Store promotion of build %s? [y/N] " "$N"
+read -r ANSWER
+case "$ANSWER" in [yY]*) : ;; *) echo "Aborted."; exit 1 ;; esac
+
+# --- 1. Ephemeral release branch at the pinned commit -----------------------
+git branch -f "$RELEASE_BRANCH" "$COMMIT"
+git push -f origin "$RELEASE_BRANCH"
+
+# --- 2. PR to main ----------------------------------------------------------
+PR_URL=$(gh pr create --base main --head "$RELEASE_BRANCH" \
+  --title "release: $VTAG (build $N)" \
+  --body "Promote TestFlight build $N (\`$TAG\`, commit \`$COMMIT\`) to the App Store. Source-only; binary is promoted in App Store Connect.")
+echo "PR: $PR_URL"
+
+# --- 3. Wait for required checks, then admin-merge --------------------------
+echo "Waiting for required checks (Build + SwiftLint)…"
+gh pr checks "$PR_URL" --watch
+gh pr merge "$PR_URL" --merge --admin --delete-branch
+
+# --- 4. Tag + GitHub Release on main ----------------------------------------
+git checkout main
+git pull origin main --quiet
+git tag -a "$VTAG" -m "$VTAG (build $N)"
+git push origin "$VTAG"
+gh release create "$VTAG" --title "$VTAG" --notes "Build $N. Edit these notes with the user-facing changelog."
+
+# --- 5. Back-merge main -> develop (never forget) ---------------------------
+git checkout develop
+git pull origin develop --quiet
+git merge main --no-edit
+git push origin develop
+
+cat <<EOF
+
+✅ Source promoted: $VTAG tagged on main, GitHub Release created, main merged back into develop.
+
+📱 Now finish in App Store Connect (the manual part):
+   1. My Apps → Dictus → (create / open) the $VERSION App Store version.
+   2. Build section → select build $N (already uploaded from TestFlight).
+   3. Fill release notes / screenshots / metadata if not done.
+   4. Export compliance: ITSAppUsesNonExemptEncryption → already set in Info.plist.
+   5. Submit for Review.
+   6. Edit the GitHub Release notes ($VTAG) with the user-facing changelog.
+EOF


### PR DESCRIPTION
Formalizes how we ship, so every deployment does the same correct actions.

## Tagging (two-tier)
- `build/N` — lightweight git tag on every TestFlight build (traceability + promotion anchor). Not a GitHub Release.
- `vX.Y.Z` — annotated tag + GitHub Release, only at App Store promotion.

## Key rules
- A release is **pinned to the commit** behind `build/N`, never to develop's tip — develop can move on between a build and its release.
- `CFBundleVersion` always increments, never repeats; no `-beta` suffix anywhere.
- **main → develop back-merge** is owned by the promote script (this is the step whose omission caused the v1.7.1 drift).

## Scripts
- `scripts/cut-testflight.sh [X.Y.Z]` — bump 3 plists + commit + `build/N` + push.
- `scripts/promote-to-appstore.sh <N>` — PR→main pinned to `build/N`, CI, admin-merge, tag + Release, back-merge, ASC checklist.

## Also
- Drop `release/*` freeze branches (keep `hotfix/*`).
- `ITSAppUsesNonExemptEncryption=false` in the 3 Info.plists (offline app, exempt) → no export-compliance prompt on upload.

Docs: `docs/VERSIONING.md`, `docs/GIT_WORKFLOW.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)