### PR TITLE
fix: neutral wording on mic permission button (App Store 5.1.1(iv))

### DIFF
--- a/DictusApp/Info.plist
+++ b/DictusApp/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>17</string>
+	<string>18</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusApp/Localizable.xcstrings
+++ b/DictusApp/Localizable.xcstrings
@@ -110,16 +110,6 @@
         }
       }
     },
-    "Allow microphone" : {
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autoriser le micro"
-          }
-        }
-      }
-    },
     "Almost ready…" : {
       "comment" : "Cycling phrase shown during model RAM load (issue #144).",
       "localizations" : {

--- a/DictusApp/Onboarding/MicPermissionPage.swift
+++ b/DictusApp/Onboarding/MicPermissionPage.swift
@@ -61,9 +61,13 @@ struct MicPermissionPage: View {
 
             // Action button
             if permissionGranted == nil {
-                // Request permission button
+                // Request permission button.
+                // WHY neutral wording ("Continue", not "Allow microphone"):
+                // App Review guideline 5.1.1(iv) forbids priming buttons that direct
+                // the user toward granting a system permission. The button only advances
+                // to the OS prompt — iOS owns the actual allow/deny choice.
                 Button(action: requestPermission) {
-                    Text("Allow microphone")
+                    Text("Continue")
                         .font(.dictusSubheading)
                         .foregroundColor(.white)
                         .frame(maxWidth: .infinity)

--- a/DictusKeyboard/Info.plist
+++ b/DictusKeyboard/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.7.1</string>
 	<key>CFBundleVersion</key>
-	<string>17</string>
+	<string>18</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusWidgets/Info.plist
+++ b/DictusWidgets/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.7.1</string>
 	<key>CFBundleVersion</key>
-	<string>17</string>
+	<string>18</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
Fixes the App Store rejection of v1.7.1 under **guideline 5.1.1(iv)**.

## Problem
The mic permission priming button read "Allow microphone", which App Review flagged as directing the user toward granting a system permission. Apple requires neutral wording ("Continue"/"Next").

## Changes
- `MicPermissionPage.swift`: button "Allow microphone" → "Continue" (with a comment explaining the 5.1.1(iv) constraint for future readers).
- `Localizable.xcstrings`: removed the now-orphaned "Allow microphone" key. The "Continue" key already exists (FR "Continuer"), so no new translation.
- Bumped build to **1.7.1 (18)** across the 3 Info.plists for resubmission (build 17 was rejected).

## Audit
Swept the whole app for system permission prompts — the microphone is the only in-app permission dialog. `KeyboardSetupPage` uses an "Open Settings" link for Full Access (granted in iOS Settings, not an in-app dialog), which Apple permits. No other changes needed.

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)