### PR TITLE
fix: neutral wording on mic permission button (propagate #195 to develop)

### DIFF
--- a/DictusApp/Localizable.xcstrings
+++ b/DictusApp/Localizable.xcstrings
@@ -145,16 +145,6 @@
         }
       }
     },
-    "Allow microphone" : {
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autoriser le micro"
-          }
-        }
-      }
-    },
     "Almost ready…" : {
       "comment" : "Cycling phrase shown during model RAM load (issue #144).",
       "localizations" : {

--- a/DictusApp/Onboarding/MicPermissionPage.swift
+++ b/DictusApp/Onboarding/MicPermissionPage.swift
@@ -61,9 +61,13 @@ struct MicPermissionPage: View {
 
             // Action button
             if permissionGranted == nil {
-                // Request permission button
+                // Request permission button.
+                // WHY neutral wording ("Continue", not "Allow microphone"):
+                // App Review guideline 5.1.1(iv) forbids priming buttons that direct
+                // the user toward granting a system permission. The button only advances
+                // to the OS prompt — iOS owns the actual allow/deny choice.
                 Button(action: requestPermission) {
-                    Text("Allow microphone")
+                    Text("Continue")
                         .font(.dictusSubheading)
                         .foregroundColor(.white)
                         .frame(maxWidth: .infinity)


### PR DESCRIPTION
Propagates the App Store 5.1.1(iv) wording fix from `main` (PR #195) into `develop`, so the next 1.8.x release doesn't reintroduce the rejected "Allow microphone" button.

Cherry-pick of the code-only commit (abb3760) — **no build-number bump**, since develop carries its own 1.8.0 versioning.

## Change
- `MicPermissionPage.swift`: button "Allow microphone" → "Continue".
- `Localizable.xcstrings`: removed orphaned "Allow microphone" key (the "Allow full access" keyboard key is unaffected).

Refs #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)