### PR TITLE
Revert #198 (iPad next-keyboard globe) — merged without device validation

### DIFF
--- a/DictusKeyboard/KeyboardLayouts.swift
+++ b/DictusKeyboard/KeyboardLayouts.swift
@@ -18,7 +18,7 @@ enum KeyboardLayouts {
     // MARK: - Public API
 
     /// AZERTY layout (default for French).
-    static func azerty(lang: SupportedLanguage = .active, needsGlobe: Bool) -> KeyboardDefinition {
+    static func azerty(lang: SupportedLanguage = .active) -> KeyboardDefinition {
         return KeyboardDefinition(
             name: lang.displayName,
             locale: lang.rawValue,
@@ -26,16 +26,16 @@ enum KeyboardLayouts {
             returnName: lang.returnName,
             longPress: longPressData,
             layout: KeyboardDefinition.Layout(
-                normal: azertyNormal(lang: lang, needsGlobe: needsGlobe),
-                shifted: azertyShifted(lang: lang, needsGlobe: needsGlobe),
-                symbols1: numbersPage(lang: lang, needsGlobe: needsGlobe),
-                symbols2: symbolsPage(lang: lang, needsGlobe: needsGlobe)
+                normal: azertyNormal(lang: lang),
+                shifted: azertyShifted(lang: lang),
+                symbols1: numbersPage(lang: lang),
+                symbols2: symbolsPage(lang: lang)
             )
         )
     }
 
     /// QWERTY layout (default for English and Spanish).
-    static func qwerty(lang: SupportedLanguage = .active, needsGlobe: Bool) -> KeyboardDefinition {
+    static func qwerty(lang: SupportedLanguage = .active) -> KeyboardDefinition {
         return KeyboardDefinition(
             name: lang.displayName + (lang == .french ? " (QWERTY)" : ""),
             locale: lang.rawValue,
@@ -43,31 +43,26 @@ enum KeyboardLayouts {
             returnName: lang.returnName,
             longPress: longPressData,
             layout: KeyboardDefinition.Layout(
-                normal: qwertyNormal(lang: lang, needsGlobe: needsGlobe),
-                shifted: qwertyShifted(lang: lang, needsGlobe: needsGlobe),
-                symbols1: numbersPage(lang: lang, needsGlobe: needsGlobe),
-                symbols2: symbolsPage(lang: lang, needsGlobe: needsGlobe)
+                normal: qwertyNormal(lang: lang),
+                shifted: qwertyShifted(lang: lang),
+                symbols1: numbersPage(lang: lang),
+                symbols2: symbolsPage(lang: lang)
             )
         )
     }
 
     /// Returns the layout matching the user's App Group preferences.
-    ///
-    /// - Parameter needsGlobe: pass `UIInputViewController.needsInputModeSwitchKey`. When true
-    ///   (iPad, older iPhones) a next-keyboard globe is added; when false (recent iPhones where
-    ///   the system draws its own globe) the layout is unchanged. Required by App Store
-    ///   Guideline 4.4.1.
-    static func current(needsGlobe: Bool) -> KeyboardDefinition {
+    static func current() -> KeyboardDefinition {
         let lang = SupportedLanguage.active
         switch LayoutType.active {
-        case .azerty: return azerty(lang: lang, needsGlobe: needsGlobe)
-        case .qwerty: return qwerty(lang: lang, needsGlobe: needsGlobe)
+        case .azerty: return azerty(lang: lang)
+        case .qwerty: return qwerty(lang: lang)
         }
     }
 
     // MARK: - AZERTY Letter Pages
 
-    private static func azertyNormal(lang: SupportedLanguage, needsGlobe: Bool) -> [[KeyDefinition]] {
+    private static func azertyNormal(lang: SupportedLanguage) -> [[KeyDefinition]] {
         [
             // Row 1: 10 keys
             inputRow("a", "z", "e", "r", "t", "y", "u", "i", "o", "p"),
@@ -81,11 +76,11 @@ enum KeyboardLayouts {
                 KeyDefinition(type: .backspace, size: CGSize(width: 1.5, height: 1)),
             ],
             // Row 4: 123 + emoji + space + return
-            bottomRow(lang: lang, needsGlobe: needsGlobe),
+            lettersBottomRow(lang: lang),
         ]
     }
 
-    private static func azertyShifted(lang: SupportedLanguage, needsGlobe: Bool) -> [[KeyDefinition]] {
+    private static func azertyShifted(lang: SupportedLanguage) -> [[KeyDefinition]] {
         [
             // Row 1: uppercase
             inputRow("A", "Z", "E", "R", "T", "Y", "U", "I", "O", "P"),
@@ -99,13 +94,13 @@ enum KeyboardLayouts {
                 KeyDefinition(type: .backspace, size: CGSize(width: 1.5, height: 1)),
             ],
             // Row 4: same as normal
-            bottomRow(lang: lang, needsGlobe: needsGlobe),
+            lettersBottomRow(lang: lang),
         ]
     }
 
     // MARK: - QWERTY Letter Pages
 
-    private static func qwertyNormal(lang: SupportedLanguage, needsGlobe: Bool) -> [[KeyDefinition]] {
+    private static func qwertyNormal(lang: SupportedLanguage) -> [[KeyDefinition]] {
         [
             // Row 1: 10 keys = 10 units
             inputRow("q", "w", "e", "r", "t", "y", "u", "i", "o", "p"),
@@ -121,12 +116,12 @@ enum KeyboardLayouts {
                 key("z"), key("x"), key("c"), key("v"), key("b"), key("n"), key("m"),
                 KeyDefinition(type: .backspace, size: CGSize(width: 1.5, height: 1)),
             ],
-            // Row 4: unified bottom row (123 + emoji + space + return)
-            bottomRow(lang: lang, needsGlobe: needsGlobe),
+            // Row 4: 123 + space + return
+            lettersBottomRow(lang: lang),
         ]
     }
 
-    private static func qwertyShifted(lang: SupportedLanguage, needsGlobe: Bool) -> [[KeyDefinition]] {
+    private static func qwertyShifted(lang: SupportedLanguage) -> [[KeyDefinition]] {
         [
             inputRow("Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P"),
             [
@@ -139,13 +134,13 @@ enum KeyboardLayouts {
                 key("Z"), key("X"), key("C"), key("V"), key("B"), key("N"), key("M"),
                 KeyDefinition(type: .backspace, size: CGSize(width: 1.5, height: 1)),
             ],
-            bottomRow(lang: lang, needsGlobe: needsGlobe),
+            lettersBottomRow(lang: lang),
         ]
     }
 
     // MARK: - Numbers Page (symbols1)
 
-    private static func numbersPage(lang: SupportedLanguage, needsGlobe: Bool) -> [[KeyDefinition]] {
+    private static func numbersPage(lang: SupportedLanguage) -> [[KeyDefinition]] {
         [
             // Row 1: digits
             inputRow("1", "2", "3", "4", "5", "6", "7", "8", "9", "0"),
@@ -154,22 +149,17 @@ enum KeyboardLayouts {
             // Row 3: #+= toggle + punctuation + delete
             [
                 KeyDefinition(type: .shiftSymbols, size: CGSize(width: 1.5, height: 1)),
-                // #+= and delete keep width 1.5 (identical to shift/delete on the letter pages).
-                // The 5 punctuation keys are widened to 1.2 with small 0.5 end spacers so the
-                // row totals 10 units and the cluster sits tighter -- matching Apple.
-                KeyDefinition(type: .spacer, size: CGSize(width: 0.5, height: 1)),
-                punct("."), punct(","), punct("?"), punct("!"), punct("'"),
-                KeyDefinition(type: .spacer, size: CGSize(width: 0.5, height: 1)),
+                key("."), key(","), key("?"), key("!"), key("'"),
                 KeyDefinition(type: .backspace, size: CGSize(width: 1.5, height: 1)),
             ],
-            // Row 4: unified bottom row (ABC + emoji + space + return)
-            bottomRow(lang: lang, needsGlobe: needsGlobe),
+            // Row 4: ABC + space + return
+            symbolsBottomRow(lang: lang),
         ]
     }
 
     // MARK: - Symbols Page (symbols2)
 
-    private static func symbolsPage(lang: SupportedLanguage, needsGlobe: Bool) -> [[KeyDefinition]] {
+    private static func symbolsPage(lang: SupportedLanguage) -> [[KeyDefinition]] {
         [
             // Row 1: brackets and math
             inputRow("[", "]", "{", "}", "#", "%", "^", "*", "+", "="),
@@ -178,44 +168,34 @@ enum KeyboardLayouts {
             // Row 3: 123 toggle + punctuation + delete
             [
                 KeyDefinition(type: .shiftSymbols, size: CGSize(width: 1.5, height: 1)),
-                // #+= and delete keep width 1.5 (identical to shift/delete on the letter pages).
-                // The 5 punctuation keys are widened to 1.2 with small 0.5 end spacers so the
-                // row totals 10 units and the cluster sits tighter -- matching Apple.
-                KeyDefinition(type: .spacer, size: CGSize(width: 0.5, height: 1)),
-                punct("."), punct(","), punct("?"), punct("!"), punct("'"),
-                KeyDefinition(type: .spacer, size: CGSize(width: 0.5, height: 1)),
+                key("."), key(","), key("?"), key("!"), key("'"),
                 KeyDefinition(type: .backspace, size: CGSize(width: 1.5, height: 1)),
             ],
-            // Row 4: unified bottom row (ABC + emoji + space + return)
-            bottomRow(lang: lang, needsGlobe: needsGlobe),
+            // Row 4: ABC + space + return
+            symbolsBottomRow(lang: lang),
         ]
     }
 
     // MARK: - Bottom Rows
 
-    /// Next-keyboard (globe) key. Rendered as a globe icon and wired to
-    /// `advanceToNextInputMode()` by the vendored KeyView/bridge. Inserted only when the
-    /// system does not already provide its own globe (`needsInputModeSwitchKey == true`).
-    private static func globeKey() -> KeyDefinition {
-        KeyDefinition(type: .keyboard, size: CGSize(width: 1.0, height: 1))
+    /// Letters page bottom row: [123 2.0w] [emoji 1.5w] [space 4.5w] [return 2.0w]
+    /// Labels adapt to the active language (e.g., "espace" / "space" / "espacio").
+    private static func lettersBottomRow(lang: SupportedLanguage) -> [KeyDefinition] {
+        [
+            KeyDefinition(type: .symbols, size: CGSize(width: 2.0, height: 1)),
+            KeyDefinition(type: .input(key: "\u{1F600}", alternate: nil), size: CGSize(width: 1.5, height: 1)),
+            KeyDefinition(type: .spacebar(name: lang.spaceName), size: CGSize(width: 4.5, height: 1)),
+            KeyDefinition(type: .returnkey(name: lang.returnName), size: CGSize(width: 2.0, height: 1)),
+        ]
     }
 
-    /// Bottom row, IDENTICAL across the letters and symbols pages so nothing resizes when the
-    /// user toggles 123/ABC (Apple parity). The `.symbols` key auto-labels "123" on letter
-    /// pages and "ABC" on symbol pages, and the emoji key stays present on every page.
-    ///
-    /// [(🌐 1.0w) 123/ABC 1.5w] [emoji 1.5w] [space 5.0w/4.0w] [return 2.0w] = 10 units.
-    /// 123/ABC and emoji share the same small width; only the space bar changes width, shrinking
-    /// by 1.0 when the globe is prepended (needsInputModeSwitchKey, App Store 4.4.1).
-    private static func bottomRow(lang: SupportedLanguage, needsGlobe: Bool) -> [KeyDefinition] {
-        var row: [KeyDefinition] = needsGlobe ? [globeKey()] : []
-        row.append(contentsOf: [
-            KeyDefinition(type: .symbols, size: CGSize(width: 1.5, height: 1)),
-            KeyDefinition(type: .input(key: "\u{1F600}", alternate: nil), size: CGSize(width: 1.5, height: 1)),
-            KeyDefinition(type: .spacebar(name: lang.spaceName), size: CGSize(width: needsGlobe ? 4.0 : 5.0, height: 1)),
-            KeyDefinition(type: .returnkey(name: lang.returnName), size: CGSize(width: 2.0, height: 1)),
-        ])
-        return row
+    /// Symbols page bottom row: [ABC 2.5w] [space 5.0w] [return 2.5w]
+    private static func symbolsBottomRow(lang: SupportedLanguage) -> [KeyDefinition] {
+        [
+            KeyDefinition(type: .symbols, size: CGSize(width: 2.5, height: 1)),
+            KeyDefinition(type: .spacebar(name: lang.spaceName), size: CGSize(width: 5.0, height: 1)),
+            KeyDefinition(type: .returnkey(name: lang.returnName), size: CGSize(width: 2.5, height: 1)),
+        ]
     }
 
     // MARK: - Long Press Accents
@@ -235,12 +215,6 @@ enum KeyboardLayouts {
     /// Create a standard 1x1 input key.
     private static func key(_ char: String) -> KeyDefinition {
         KeyDefinition(type: .input(key: char, alternate: nil))
-    }
-
-    /// Create a slightly wider (1.2) punctuation input key for the symbols pages' row 3,
-    /// so the 5 keys sit tighter together like Apple's keyboard.
-    private static func punct(_ char: String) -> KeyDefinition {
-        KeyDefinition(type: .input(key: char, alternate: nil), size: CGSize(width: 1.2, height: 1))
     }
 
     /// Create a row of standard input keys from variadic strings.

--- a/DictusKeyboard/KeyboardViewController.swift
+++ b/DictusKeyboard/KeyboardViewController.swift
@@ -22,14 +22,6 @@ class KeyboardViewController: UIInputViewController {
     /// sibling subview of kbInputView avoids this entirely.
     private var giellaKeyboard: GiellaKeyboardView?
 
-    /// The `needsInputModeSwitchKey` value used the last time the layout was built.
-    /// viewDidLoad runs before the host connection is established, so the flag read
-    /// there is inaccurate (UIKit logs a warning). We record what we built with and,
-    /// once the connection exists (viewWillAppear), rebuild only if the accurate
-    /// value now differs — so the next-keyboard globe (4.4.1) is never wrongly
-    /// shown or hidden. nil = never built yet.
-    private var builtNeedsGlobe: Bool?
-
     /// Delegate adapter that translates giellakbd-ios key events into Dictus actions.
     private var bridge: DictusKeyboardBridge?
 
@@ -109,13 +101,7 @@ class KeyboardViewController: UIInputViewController {
         kbInputView.isOpaque = false
 
         // --- 1. Create the giellakbd-ios UIKit keyboard ---
-        // needsInputModeSwitchKey is false on recent iPhones (system draws its own globe)
-        // and true on iPad / older iPhones, where we must supply a next-keyboard key (4.4.1).
-        // NOTE: read here it is inaccurate (host connection not yet established); the value
-        // is re-checked and the layout rebuilt if needed in viewWillAppear.
-        let needsGlobe = needsInputModeSwitchKey
-        builtNeedsGlobe = needsGlobe
-        let definition = KeyboardLayouts.current(needsGlobe: needsGlobe)
+        let definition = KeyboardLayouts.current()
         let theme = Theme.current(for: traitCollection)
         let keyboard = GiellaKeyboardView(definition: definition, theme: theme)
         keyboard.translatesAutoresizingMaskIntoConstraints = false
@@ -314,23 +300,6 @@ class KeyboardViewController: UIInputViewController {
         // Previously set from KeyboardRootView.onAppear, which held a strong ref → #134.
         KeyboardState.shared.controller = self
         hasAppeared = true
-
-        // 4.4.1 next-keyboard globe: the host connection now exists, so
-        // needsInputModeSwitchKey is finally accurate. If viewDidLoad built the
-        // layout with the wrong value (its early read is inaccurate and UIKit warns
-        // about it), rebuild once now so the globe matches reality. Skipped in the
-        // common case where the value already matched — reloadKeyboardLayout is a
-        // full ~200ms UICollectionView rebuild we don't want on every appearance.
-        let accurateNeedsGlobe = needsInputModeSwitchKey
-        if builtNeedsGlobe != accurateNeedsGlobe {
-            PersistentLog.log(.diagnosticProbe(
-                component: "KeyboardViewController",
-                instanceID: controllerID,
-                action: "globeMismatchReload",
-                details: "built=\(builtNeedsGlobe.map(String.init(describing:)) ?? "nil") accurate=\(accurateNeedsGlobe)"
-            ))
-            reloadKeyboardLayout()
-        }
 
         // (Re)subscribe to dictation status here, not in viewDidLoad.
         // WHY: iOS caches UIInputViewController instances across app-switches and
@@ -844,11 +813,7 @@ class KeyboardViewController: UIInputViewController {
         giellaKeyboard?.removeFromSuperview()
 
         // Create new keyboard with updated definition
-        // needsInputModeSwitchKey is false on recent iPhones (system draws its own globe)
-        // and true on iPad / older iPhones, where we must supply a next-keyboard key (4.4.1).
-        let needsGlobe = needsInputModeSwitchKey
-        builtNeedsGlobe = needsGlobe
-        let definition = KeyboardLayouts.current(needsGlobe: needsGlobe)
+        let definition = KeyboardLayouts.current()
         let theme = Theme.current(for: traitCollection)
         let keyboard = GiellaKeyboardView(definition: definition, theme: theme)
         keyboard.translatesAutoresizingMaskIntoConstraints = false

--- a/DictusKeyboard/Vendored/Views/KeyboardView.swift
+++ b/DictusKeyboard/Vendored/Views/KeyboardView.swift
@@ -80,12 +80,6 @@ final internal class GiellaKeyboardView: UIView,
 
     private var keyboardButtonFrame: CGRect? {
         didSet {
-            // `willDisplay` sets this to the globe cell's frame on every display pass.
-            // Rebuilding the overlay button (removeFromSuperview + addSubview) on each
-            // identical set triggers a layout invalidation that re-runs `willDisplay`,
-            // creating a layout feedback loop that pegs the CPU and gets the keyboard
-            // extension killed and relaunched by the host watchdog. Skip when unchanged.
-            guard keyboardButtonFrame != oldValue else { return }
             if let keyboardButtonExtraButton = keyboardButtonExtraButton {
                 keyboardButtonExtraButton.removeFromSuperview()
                 self.keyboardButtonExtraButton = nil
@@ -98,12 +92,9 @@ final internal class GiellaKeyboardView: UIView,
             }
             if let keyboardButtonExtraButton = keyboardButtonExtraButton {
                 addSubview(keyboardButtonExtraButton)
-                // Fire once per tap: .allEvents would call advanceToNextInputMode() several
-                // times for a single gesture (touchDown + touchUpInside + ...), which can skip
-                // past the intended keyboard. .touchUpInside matches standard button semantics.
                 keyboardButtonExtraButton.addTarget(delegate,
                                                     action: #selector(GiellaKeyboardViewKeyboardKeyDelegate.didTriggerKeyboardButton),
-                                                    for: UIControl.Event.touchUpInside)
+                                                    for: UIControl.Event.allEvents)
             }
         }
     }


### PR DESCRIPTION
## Why

PR #198 was merged to main without functional validation. Testing on the iPad simulator afterwards shows the Dictus keyboard renders a blank grey area (no keys at all). Reverting to restore main to a known-good state while we diagnose.

The 6 commits remain on `fix/197-ipad-next-keyboard` for rework.

## Scope

Pure revert of merge commit 12f08fc (3 files: KeyboardLayouts.swift, KeyboardViewController.swift, Vendored/Views/KeyboardView.swift).

Refs #197, #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKDjeFysVpTAn2jViZzi6m