### PR TITLE
4.4.1 next-keyboard globe, resubmit: layout-loop root fix + long-press picker (#197, #202)

### DIFF
--- a/DictusKeyboard/DictusKeyboardBridge.swift
+++ b/DictusKeyboard/DictusKeyboardBridge.swift
@@ -166,9 +166,12 @@ final class DictusKeyboardBridge: NSObject,
     // MARK: - GiellaKeyboardViewKeyboardKeyDelegate
 
     @objc func didTriggerKeyboardButton(sender: UIView, forEvent event: UIEvent) {
-        // This is the accessibility/globe button callback from GiellaKeyboardView.
-        // It creates an invisible UIButton over the keyboard/globe key for VoiceOver.
-        controller?.advanceToNextInputMode()
+        // Globe key callback from GiellaKeyboardView's invisible overlay button.
+        // handleInputModeList is Apple's dedicated API for the input-switch key: it
+        // advances to the next keyboard on tap AND shows the keyboard picker menu on
+        // long-press (advanceToNextInputMode only covers the tap). It requires the full
+        // touch stream, hence .allTouchEvents on the button.
+        controller?.handleInputModeList(from: sender, with: event)
     }
 
     // MARK: - Key Action Handlers

--- a/DictusKeyboard/KeyboardLayouts.swift
+++ b/DictusKeyboard/KeyboardLayouts.swift
@@ -18,7 +18,7 @@ enum KeyboardLayouts {
     // MARK: - Public API
 
     /// AZERTY layout (default for French).
-    static func azerty(lang: SupportedLanguage = .active) -> KeyboardDefinition {
+    static func azerty(lang: SupportedLanguage = .active, needsGlobe: Bool) -> KeyboardDefinition {
         return KeyboardDefinition(
             name: lang.displayName,
             locale: lang.rawValue,
@@ -26,16 +26,16 @@ enum KeyboardLayouts {
             returnName: lang.returnName,
             longPress: longPressData,
             layout: KeyboardDefinition.Layout(
-                normal: azertyNormal(lang: lang),
-                shifted: azertyShifted(lang: lang),
-                symbols1: numbersPage(lang: lang),
-                symbols2: symbolsPage(lang: lang)
+                normal: azertyNormal(lang: lang, needsGlobe: needsGlobe),
+                shifted: azertyShifted(lang: lang, needsGlobe: needsGlobe),
+                symbols1: numbersPage(lang: lang, needsGlobe: needsGlobe),
+                symbols2: symbolsPage(lang: lang, needsGlobe: needsGlobe)
             )
         )
     }
 
     /// QWERTY layout (default for English and Spanish).
-    static func qwerty(lang: SupportedLanguage = .active) -> KeyboardDefinition {
+    static func qwerty(lang: SupportedLanguage = .active, needsGlobe: Bool) -> KeyboardDefinition {
         return KeyboardDefinition(
             name: lang.displayName + (lang == .french ? " (QWERTY)" : ""),
             locale: lang.rawValue,
@@ -43,26 +43,31 @@ enum KeyboardLayouts {
             returnName: lang.returnName,
             longPress: longPressData,
             layout: KeyboardDefinition.Layout(
-                normal: qwertyNormal(lang: lang),
-                shifted: qwertyShifted(lang: lang),
-                symbols1: numbersPage(lang: lang),
-                symbols2: symbolsPage(lang: lang)
+                normal: qwertyNormal(lang: lang, needsGlobe: needsGlobe),
+                shifted: qwertyShifted(lang: lang, needsGlobe: needsGlobe),
+                symbols1: numbersPage(lang: lang, needsGlobe: needsGlobe),
+                symbols2: symbolsPage(lang: lang, needsGlobe: needsGlobe)
             )
         )
     }
 
     /// Returns the layout matching the user's App Group preferences.
-    static func current() -> KeyboardDefinition {
+    ///
+    /// - Parameter needsGlobe: pass `UIInputViewController.needsInputModeSwitchKey`. When true
+    ///   (iPad, older iPhones) a next-keyboard globe is added; when false (recent iPhones where
+    ///   the system draws its own globe) the layout is unchanged. Required by App Store
+    ///   Guideline 4.4.1.
+    static func current(needsGlobe: Bool) -> KeyboardDefinition {
         let lang = SupportedLanguage.active
         switch LayoutType.active {
-        case .azerty: return azerty(lang: lang)
-        case .qwerty: return qwerty(lang: lang)
+        case .azerty: return azerty(lang: lang, needsGlobe: needsGlobe)
+        case .qwerty: return qwerty(lang: lang, needsGlobe: needsGlobe)
         }
     }
 
     // MARK: - AZERTY Letter Pages
 
-    private static func azertyNormal(lang: SupportedLanguage) -> [[KeyDefinition]] {
+    private static func azertyNormal(lang: SupportedLanguage, needsGlobe: Bool) -> [[KeyDefinition]] {
         [
             // Row 1: 10 keys
             inputRow("a", "z", "e", "r", "t", "y", "u", "i", "o", "p"),
@@ -76,11 +81,11 @@ enum KeyboardLayouts {
                 KeyDefinition(type: .backspace, size: CGSize(width: 1.5, height: 1)),
             ],
             // Row 4: 123 + emoji + space + return
-            lettersBottomRow(lang: lang),
+            bottomRow(lang: lang, needsGlobe: needsGlobe),
         ]
     }
 
-    private static func azertyShifted(lang: SupportedLanguage) -> [[KeyDefinition]] {
+    private static func azertyShifted(lang: SupportedLanguage, needsGlobe: Bool) -> [[KeyDefinition]] {
         [
             // Row 1: uppercase
             inputRow("A", "Z", "E", "R", "T", "Y", "U", "I", "O", "P"),
@@ -94,13 +99,13 @@ enum KeyboardLayouts {
                 KeyDefinition(type: .backspace, size: CGSize(width: 1.5, height: 1)),
             ],
             // Row 4: same as normal
-            lettersBottomRow(lang: lang),
+            bottomRow(lang: lang, needsGlobe: needsGlobe),
         ]
     }
 
     // MARK: - QWERTY Letter Pages
 
-    private static func qwertyNormal(lang: SupportedLanguage) -> [[KeyDefinition]] {
+    private static func qwertyNormal(lang: SupportedLanguage, needsGlobe: Bool) -> [[KeyDefinition]] {
         [
             // Row 1: 10 keys = 10 units
             inputRow("q", "w", "e", "r", "t", "y", "u", "i", "o", "p"),
@@ -116,12 +121,12 @@ enum KeyboardLayouts {
                 key("z"), key("x"), key("c"), key("v"), key("b"), key("n"), key("m"),
                 KeyDefinition(type: .backspace, size: CGSize(width: 1.5, height: 1)),
             ],
-            // Row 4: 123 + space + return
-            lettersBottomRow(lang: lang),
+            // Row 4: unified bottom row (123 + emoji + space + return)
+            bottomRow(lang: lang, needsGlobe: needsGlobe),
         ]
     }
 
-    private static func qwertyShifted(lang: SupportedLanguage) -> [[KeyDefinition]] {
+    private static func qwertyShifted(lang: SupportedLanguage, needsGlobe: Bool) -> [[KeyDefinition]] {
         [
             inputRow("Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P"),
             [
@@ -134,13 +139,13 @@ enum KeyboardLayouts {
                 key("Z"), key("X"), key("C"), key("V"), key("B"), key("N"), key("M"),
                 KeyDefinition(type: .backspace, size: CGSize(width: 1.5, height: 1)),
             ],
-            lettersBottomRow(lang: lang),
+            bottomRow(lang: lang, needsGlobe: needsGlobe),
         ]
     }
 
     // MARK: - Numbers Page (symbols1)
 
-    private static func numbersPage(lang: SupportedLanguage) -> [[KeyDefinition]] {
+    private static func numbersPage(lang: SupportedLanguage, needsGlobe: Bool) -> [[KeyDefinition]] {
         [
             // Row 1: digits
             inputRow("1", "2", "3", "4", "5", "6", "7", "8", "9", "0"),
@@ -149,17 +154,22 @@ enum KeyboardLayouts {
             // Row 3: #+= toggle + punctuation + delete
             [
                 KeyDefinition(type: .shiftSymbols, size: CGSize(width: 1.5, height: 1)),
-                key("."), key(","), key("?"), key("!"), key("'"),
+                // #+= and delete keep width 1.5 (identical to shift/delete on the letter pages).
+                // The 5 punctuation keys are widened to 1.2 with small 0.5 end spacers so the
+                // row totals 10 units and the cluster sits tighter -- matching Apple.
+                KeyDefinition(type: .spacer, size: CGSize(width: 0.5, height: 1)),
+                punct("."), punct(","), punct("?"), punct("!"), punct("'"),
+                KeyDefinition(type: .spacer, size: CGSize(width: 0.5, height: 1)),
                 KeyDefinition(type: .backspace, size: CGSize(width: 1.5, height: 1)),
             ],
-            // Row 4: ABC + space + return
-            symbolsBottomRow(lang: lang),
+            // Row 4: unified bottom row (ABC + emoji + space + return)
+            bottomRow(lang: lang, needsGlobe: needsGlobe),
         ]
     }
 
     // MARK: - Symbols Page (symbols2)
 
-    private static func symbolsPage(lang: SupportedLanguage) -> [[KeyDefinition]] {
+    private static func symbolsPage(lang: SupportedLanguage, needsGlobe: Bool) -> [[KeyDefinition]] {
         [
             // Row 1: brackets and math
             inputRow("[", "]", "{", "}", "#", "%", "^", "*", "+", "="),
@@ -168,34 +178,44 @@ enum KeyboardLayouts {
             // Row 3: 123 toggle + punctuation + delete
             [
                 KeyDefinition(type: .shiftSymbols, size: CGSize(width: 1.5, height: 1)),
-                key("."), key(","), key("?"), key("!"), key("'"),
+                // #+= and delete keep width 1.5 (identical to shift/delete on the letter pages).
+                // The 5 punctuation keys are widened to 1.2 with small 0.5 end spacers so the
+                // row totals 10 units and the cluster sits tighter -- matching Apple.
+                KeyDefinition(type: .spacer, size: CGSize(width: 0.5, height: 1)),
+                punct("."), punct(","), punct("?"), punct("!"), punct("'"),
+                KeyDefinition(type: .spacer, size: CGSize(width: 0.5, height: 1)),
                 KeyDefinition(type: .backspace, size: CGSize(width: 1.5, height: 1)),
             ],
-            // Row 4: ABC + space + return
-            symbolsBottomRow(lang: lang),
+            // Row 4: unified bottom row (ABC + emoji + space + return)
+            bottomRow(lang: lang, needsGlobe: needsGlobe),
         ]
     }
 
     // MARK: - Bottom Rows
 
-    /// Letters page bottom row: [123 2.0w] [emoji 1.5w] [space 4.5w] [return 2.0w]
-    /// Labels adapt to the active language (e.g., "espace" / "space" / "espacio").
-    private static func lettersBottomRow(lang: SupportedLanguage) -> [KeyDefinition] {
-        [
-            KeyDefinition(type: .symbols, size: CGSize(width: 2.0, height: 1)),
-            KeyDefinition(type: .input(key: "\u{1F600}", alternate: nil), size: CGSize(width: 1.5, height: 1)),
-            KeyDefinition(type: .spacebar(name: lang.spaceName), size: CGSize(width: 4.5, height: 1)),
-            KeyDefinition(type: .returnkey(name: lang.returnName), size: CGSize(width: 2.0, height: 1)),
-        ]
+    /// Next-keyboard (globe) key. Rendered as a globe icon and wired to
+    /// `advanceToNextInputMode()` by the vendored KeyView/bridge. Inserted only when the
+    /// system does not already provide its own globe (`needsInputModeSwitchKey == true`).
+    private static func globeKey() -> KeyDefinition {
+        KeyDefinition(type: .keyboard, size: CGSize(width: 1.0, height: 1))
     }
 
-    /// Symbols page bottom row: [ABC 2.5w] [space 5.0w] [return 2.5w]
-    private static func symbolsBottomRow(lang: SupportedLanguage) -> [KeyDefinition] {
-        [
-            KeyDefinition(type: .symbols, size: CGSize(width: 2.5, height: 1)),
-            KeyDefinition(type: .spacebar(name: lang.spaceName), size: CGSize(width: 5.0, height: 1)),
-            KeyDefinition(type: .returnkey(name: lang.returnName), size: CGSize(width: 2.5, height: 1)),
-        ]
+    /// Bottom row, IDENTICAL across the letters and symbols pages so nothing resizes when the
+    /// user toggles 123/ABC (Apple parity). The `.symbols` key auto-labels "123" on letter
+    /// pages and "ABC" on symbol pages, and the emoji key stays present on every page.
+    ///
+    /// [(🌐 1.0w) 123/ABC 1.5w] [emoji 1.5w] [space 5.0w/4.0w] [return 2.0w] = 10 units.
+    /// 123/ABC and emoji share the same small width; only the space bar changes width, shrinking
+    /// by 1.0 when the globe is prepended (needsInputModeSwitchKey, App Store 4.4.1).
+    private static func bottomRow(lang: SupportedLanguage, needsGlobe: Bool) -> [KeyDefinition] {
+        var row: [KeyDefinition] = needsGlobe ? [globeKey()] : []
+        row.append(contentsOf: [
+            KeyDefinition(type: .symbols, size: CGSize(width: 1.5, height: 1)),
+            KeyDefinition(type: .input(key: "\u{1F600}", alternate: nil), size: CGSize(width: 1.5, height: 1)),
+            KeyDefinition(type: .spacebar(name: lang.spaceName), size: CGSize(width: needsGlobe ? 4.0 : 5.0, height: 1)),
+            KeyDefinition(type: .returnkey(name: lang.returnName), size: CGSize(width: 2.0, height: 1)),
+        ])
+        return row
     }
 
     // MARK: - Long Press Accents
@@ -215,6 +235,12 @@ enum KeyboardLayouts {
     /// Create a standard 1x1 input key.
     private static func key(_ char: String) -> KeyDefinition {
         KeyDefinition(type: .input(key: char, alternate: nil))
+    }
+
+    /// Create a slightly wider (1.2) punctuation input key for the symbols pages' row 3,
+    /// so the 5 keys sit tighter together like Apple's keyboard.
+    private static func punct(_ char: String) -> KeyDefinition {
+        KeyDefinition(type: .input(key: char, alternate: nil), size: CGSize(width: 1.2, height: 1))
     }
 
     /// Create a row of standard input keys from variadic strings.

--- a/DictusKeyboard/KeyboardViewController.swift
+++ b/DictusKeyboard/KeyboardViewController.swift
@@ -22,6 +22,14 @@ class KeyboardViewController: UIInputViewController {
     /// sibling subview of kbInputView avoids this entirely.
     private var giellaKeyboard: GiellaKeyboardView?
 
+    /// The `needsInputModeSwitchKey` value used the last time the layout was built.
+    /// viewDidLoad runs before the host connection is established, so the flag read
+    /// there is inaccurate (UIKit logs a warning). We record what we built with and,
+    /// once the connection exists (viewWillAppear), rebuild only if the accurate
+    /// value now differs — so the next-keyboard globe (4.4.1) is never wrongly
+    /// shown or hidden. nil = never built yet.
+    private var builtNeedsGlobe: Bool?
+
     /// Delegate adapter that translates giellakbd-ios key events into Dictus actions.
     private var bridge: DictusKeyboardBridge?
 
@@ -101,7 +109,13 @@ class KeyboardViewController: UIInputViewController {
         kbInputView.isOpaque = false
 
         // --- 1. Create the giellakbd-ios UIKit keyboard ---
-        let definition = KeyboardLayouts.current()
+        // needsInputModeSwitchKey is false on recent iPhones (system draws its own globe)
+        // and true on iPad / older iPhones, where we must supply a next-keyboard key (4.4.1).
+        // NOTE: read here it is inaccurate (host connection not yet established); the value
+        // is re-checked and the layout rebuilt if needed in viewWillAppear.
+        let needsGlobe = needsInputModeSwitchKey
+        builtNeedsGlobe = needsGlobe
+        let definition = KeyboardLayouts.current(needsGlobe: needsGlobe)
         let theme = Theme.current(for: traitCollection)
         let keyboard = GiellaKeyboardView(definition: definition, theme: theme)
         keyboard.translatesAutoresizingMaskIntoConstraints = false
@@ -300,6 +314,23 @@ class KeyboardViewController: UIInputViewController {
         // Previously set from KeyboardRootView.onAppear, which held a strong ref → #134.
         KeyboardState.shared.controller = self
         hasAppeared = true
+
+        // 4.4.1 next-keyboard globe: the host connection now exists, so
+        // needsInputModeSwitchKey is finally accurate. If viewDidLoad built the
+        // layout with the wrong value (its early read is inaccurate and UIKit warns
+        // about it), rebuild once now so the globe matches reality. Skipped in the
+        // common case where the value already matched — reloadKeyboardLayout is a
+        // full ~200ms UICollectionView rebuild we don't want on every appearance.
+        let accurateNeedsGlobe = needsInputModeSwitchKey
+        if builtNeedsGlobe != accurateNeedsGlobe {
+            PersistentLog.log(.diagnosticProbe(
+                component: "KeyboardViewController",
+                instanceID: controllerID,
+                action: "globeMismatchReload",
+                details: "built=\(builtNeedsGlobe.map(String.init(describing:)) ?? "nil") accurate=\(accurateNeedsGlobe)"
+            ))
+            reloadKeyboardLayout()
+        }
 
         // (Re)subscribe to dictation status here, not in viewDidLoad.
         // WHY: iOS caches UIInputViewController instances across app-switches and
@@ -813,7 +844,11 @@ class KeyboardViewController: UIInputViewController {
         giellaKeyboard?.removeFromSuperview()
 
         // Create new keyboard with updated definition
-        let definition = KeyboardLayouts.current()
+        // needsInputModeSwitchKey is false on recent iPhones (system draws its own globe)
+        // and true on iPad / older iPhones, where we must supply a next-keyboard key (4.4.1).
+        let needsGlobe = needsInputModeSwitchKey
+        builtNeedsGlobe = needsGlobe
+        let definition = KeyboardLayouts.current(needsGlobe: needsGlobe)
         let theme = Theme.current(for: traitCollection)
         let keyboard = GiellaKeyboardView(definition: definition, theme: theme)
         keyboard.translatesAutoresizingMaskIntoConstraints = false

--- a/DictusKeyboard/Vendored/Views/KeyboardView.swift
+++ b/DictusKeyboard/Vendored/Views/KeyboardView.swift
@@ -80,32 +80,47 @@ final internal class GiellaKeyboardView: UIView,
 
     private var keyboardButtonFrame: CGRect? {
         didSet {
-            // `willDisplay` sets this to the globe cell's frame on every display pass.
-            // Rebuilding the overlay button (removeFromSuperview + addSubview) on each
-            // identical set triggers a layout invalidation that re-runs `willDisplay`,
-            // creating a layout feedback loop that pegs the CPU and gets the keyboard
-            // extension killed and relaunched by the host watchdog. Skip when unchanged.
+            // CRITICAL — never mutate the view hierarchy here (#202). This setter runs
+            // inside the collection view's layout pass (`willDisplay`), and `bounds.didSet`
+            // resets it to nil on every Auto Layout pass. The original giellakbd code
+            // tore down and re-added the overlay button on each change; addSubview /
+            // removeFromSuperview invalidate the parent's layout, which re-runs the pass,
+            // which fires this setter again → infinite layout loop. On device the loop
+            // allocates until the ~90 MB jetsam limit kills the extension (~4 s); on the
+            // simulator it spins forever and the keyboard renders as a blank grey area.
+            // Instead: create the button once, then only move/hide it — neither
+            // `frame` assignment nor `isHidden` invalidates the parent's layout.
             guard keyboardButtonFrame != oldValue else { return }
-            if let keyboardButtonExtraButton = keyboardButtonExtraButton {
-                keyboardButtonExtraButton.removeFromSuperview()
-                self.keyboardButtonExtraButton = nil
-            }
             if let keyboardButtonFrame = keyboardButtonFrame {
-                keyboardButtonExtraButton = UIButton(frame: keyboardButtonFrame)
-                keyboardButtonExtraButton?.backgroundColor = .clear
-                keyboardButtonExtraButton?.isAccessibilityElement = true
-                keyboardButtonExtraButton?.accessibilityLabel = NSLocalizedString("accessibility.nextKeyboard", comment: "")
-            }
-            if let keyboardButtonExtraButton = keyboardButtonExtraButton {
-                addSubview(keyboardButtonExtraButton)
-                // Fire once per tap: .allEvents would call advanceToNextInputMode() several
-                // times for a single gesture (touchDown + touchUpInside + ...), which can skip
-                // past the intended keyboard. .touchUpInside matches standard button semantics.
-                keyboardButtonExtraButton.addTarget(delegate,
-                                                    action: #selector(GiellaKeyboardViewKeyboardKeyDelegate.didTriggerKeyboardButton),
-                                                    for: UIControl.Event.touchUpInside)
+                let button = keyboardButtonExtraButton ?? makeKeyboardButton()
+                button.frame = keyboardButtonFrame
+                button.isHidden = false
+            } else {
+                keyboardButtonExtraButton?.isHidden = true
             }
         }
+    }
+
+    /// One-time creation of the invisible tap surface overlaying the globe cell.
+    /// Collection view cells are reused, so a stable UIButton on top of the cell is the
+    /// reliable way to catch taps for `advanceToNextInputMode()`. Called at most once
+    /// per keyboard view; the single `addSubview` happens before the first frame is
+    /// visible, so it cannot feed the layout loop described above.
+    private func makeKeyboardButton() -> UIButton {
+        let button = UIButton()
+        button.backgroundColor = .clear
+        button.isAccessibilityElement = true
+        button.accessibilityLabel = NSLocalizedString("accessibility.nextKeyboard", comment: "")
+        // .allTouchEvents is REQUIRED: the delegate forwards to UIInputViewController.
+        // handleInputModeList(from:with:), which needs the complete touch stream to
+        // distinguish tap (advance to next keyboard) from long-press (keyboard picker
+        // menu) and to support drag-selection inside the menu.
+        button.addTarget(delegate,
+                         action: #selector(GiellaKeyboardViewKeyboardKeyDelegate.didTriggerKeyboardButton),
+                         for: UIControl.Event.allTouchEvents)
+        addSubview(button)
+        keyboardButtonExtraButton = button
+        return button
     }
 
     private var keyboardButtonExtraButton: UIButton?
@@ -207,6 +222,17 @@ final internal class GiellaKeyboardView: UIView,
 
     override var bounds: CGRect {
         didSet {
+            // CRITICAL (#202): only rebuild when the geometry actually changed.
+            // Auto Layout re-assigns bounds (same value) on every layout pass. The
+            // unconditional update() -> reloadData() was harmless while nothing in a
+            // display pass dirtied the parent's layout, but the globe key's overlay
+            // button (frame/visibility updates during `willDisplay`) re-marks this view
+            // for layout on each pass: bounds re-set -> update() -> reloadData() ->
+            // willDisplay -> layout dirty -> bounds re-set... An infinite loop that
+            // allocates cells until jetsam kills the extension (measured: ~2200
+            // reloadData cycles, 75k cells, 1.8 GB before the kill). Guarding on a real
+            // change breaks the cycle at its root.
+            guard bounds != oldValue else { return }
             update()
         }
     }

--- a/DictusKeyboard/Vendored/Views/KeyboardView.swift
+++ b/DictusKeyboard/Vendored/Views/KeyboardView.swift
@@ -80,6 +80,12 @@ final internal class GiellaKeyboardView: UIView,
 
     private var keyboardButtonFrame: CGRect? {
         didSet {
+            // `willDisplay` sets this to the globe cell's frame on every display pass.
+            // Rebuilding the overlay button (removeFromSuperview + addSubview) on each
+            // identical set triggers a layout invalidation that re-runs `willDisplay`,
+            // creating a layout feedback loop that pegs the CPU and gets the keyboard
+            // extension killed and relaunched by the host watchdog. Skip when unchanged.
+            guard keyboardButtonFrame != oldValue else { return }
             if let keyboardButtonExtraButton = keyboardButtonExtraButton {
                 keyboardButtonExtraButton.removeFromSuperview()
                 self.keyboardButtonExtraButton = nil
@@ -92,9 +98,12 @@ final internal class GiellaKeyboardView: UIView,
             }
             if let keyboardButtonExtraButton = keyboardButtonExtraButton {
                 addSubview(keyboardButtonExtraButton)
+                // Fire once per tap: .allEvents would call advanceToNextInputMode() several
+                // times for a single gesture (touchDown + touchUpInside + ...), which can skip
+                // past the intended keyboard. .touchUpInside matches standard button semantics.
                 keyboardButtonExtraButton.addTarget(delegate,
                                                     action: #selector(GiellaKeyboardViewKeyboardKeyDelegate.didTriggerKeyboardButton),
-                                                    for: UIControl.Event.allEvents)
+                                                    for: UIControl.Event.touchUpInside)
             }
         }
     }


### PR DESCRIPTION
## Summary

Resubmission of the 4.4.1 next-keyboard globe fix (#198, reverted in #203), now with the root cause of the keyboard freeze/jetsam kill fixed and fully validated on simulators and physical devices.

## What's in here

1. **Reapply #198** (revert of the revert `c28c32b`): globe key gated on `needsInputModeSwitchKey`, Apple-matched key widths, unified bottom row, accurate flag re-read after host connection.
2. **`1e4b868` — fix(#202): break the layout feedback loop.** `bounds.didSet` called `update()` → `reloadData()` on every Auto Layout pass (identical bounds re-assigned each time), and the globe overlay button dirtied the parent's layout on every display pass, closing an infinite cycle. Instrumented and measured: ~2200 reloadData cycles, 75k cells created, 1.8 GB RSS. On the physical iPad this loop hit the 90 MB jetsam limit in ~4 s (the "memory bug" in #202). Fix: guard `bounds != oldValue` (root) + create the overlay button once and only move/hide it.
3. **`1f4265c` — feat(#197): long-press keyboard picker.** Replace `advanceToNextInputMode()` with `handleInputModeList(from:with:)` wired on `.allTouchEvents`: tap advances, long-press shows the keyboard selection menu.

## Validation (all four environments, user-verified)

| Environment | Result |
|---|---|
| iPad Pro 13" M5 simulator | keys render, globe visible, CPU 4%, memory stable 47-52 MB |
| iPhone 17 Pro simulator | no globe (system provides its own), typing OK |
| **Physical iPad Pro 11" (iPad8,1)** | **no jetsam kill** (was dying at ~4 s), globe tap + long-press OK |
| Physical iPhone 15 Pro Max | no globe, everything works |

## Why the merge strategy

`main` contains the original commits *and* their revert, so a plain merge of the old branch would silently drop the globe layout changes. This branch is `main` + revert-of-the-revert + the two new commits; its tree is byte-identical to the validated `fix/197-ipad-next-keyboard` tip.

Closes #202. Refs #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKDjeFysVpTAn2jViZzi6m