### PR TITLE
chore: bump build to 19 for 1.7.1 resubmission

### DIFF
--- a/DictusApp/Info.plist
+++ b/DictusApp/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>18</string>
+	<string>19</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusKeyboard/Info.plist
+++ b/DictusKeyboard/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.7.1</string>
 	<key>CFBundleVersion</key>
-	<string>18</string>
+	<string>19</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusWidgets/Info.plist
+++ b/DictusWidgets/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.7.1</string>
 	<key>CFBundleVersion</key>
-	<string>18</string>
+	<string>19</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
Build 18 was used by the rejected submission; marketing version stays 1.7.1. Prerequisite for the App Store resubmission archive.

Refs #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKDjeFysVpTAn2jViZzi6m