### PR TITLE
chore: bump build to 20 for 1.7.1 App Store resubmission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ assets/reference/logs/**/*.log
 
 # Design sandbox
 designs/
+.playwright-mcp/

--- a/DictusApp/Info.plist
+++ b/DictusApp/Info.plist
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>19</string>
+	<string>20</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusKeyboard/Info.plist
+++ b/DictusKeyboard/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.7.1</string>
 	<key>CFBundleVersion</key>
-	<string>19</string>
+	<string>20</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusWidgets/Info.plist
+++ b/DictusWidgets/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.7.1</string>
 	<key>CFBundleVersion</key>
-	<string>19</string>
+	<string>20</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
Bumps CFBundleVersion to 20 in the three targets for the 1.7.1 resubmission (July 13 rejection response). Marketing version unchanged.

Carries the #207 download-progress fix, #174 auto-select, and the overlay layout fix (PR #209, merged).

Also adds `.playwright-mcp/` (local session artifacts) to .gitignore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKDjeFysVpTAn2jViZzi6m