### PR TITLE
chore: port patch-fluidaudio-swift5.sh from develop to main

### DIFF
--- a/scripts/patch-fluidaudio-swift5.sh
+++ b/scripts/patch-fluidaudio-swift5.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Re-apply the FluidAudio Swift-5-language-mode patch after an SPM cache reset.
+#
+# WHY: Xcode 26.4.1+/26.5 (Swift 6.x) flag FluidAudio 0.12.x streaming code with
+# `sending 'asrManager' risks causing data races` HARD errors (SE-0430 region
+# isolation). FluidAudio's fix is 0.12.6, which is incompatible with WhisperKit
+# 0.x (swift-transformers 1.1.x ceiling). Until we do the WhisperKit 1.0 +
+# FluidAudio 0.12.6 upgrade, we force the FluidAudio package to compile in
+# Swift 5 mode, where these errors don't exist. See ADR/ memory:
+# project_xcode_pin_fluidaudio.
+#
+# This edits the SPM CHECKOUT, which is wiped whenever Xcode re-resolves packages
+# ("Reset Package Caches", DerivedData deletion — and sometimes Archive). Re-run
+# this script after any such reset, then rebuild.
+set -euo pipefail
+
+FOUND=0
+while IFS= read -r PKG; do
+  FOUND=1
+  if grep -q "swiftLanguageModes: \[.v5\]" "$PKG"; then
+    echo "Already patched: $PKG"
+    continue
+  fi
+  # SPM checkouts can be read-only.
+  chmod u+w "$PKG"
+  # Insert swiftLanguageModes before cxxLanguageStandard (arg-order requirement).
+  python3 - "$PKG" <<'PY'
+import sys
+p = sys.argv[1]
+t = open(p).read()
+old = "    ],\n    cxxLanguageStandard: .cxx17\n)"
+new = "    ],\n    swiftLanguageModes: [.v5],\n    cxxLanguageStandard: .cxx17\n)"
+assert old in t, "anchor not found - FluidAudio Package.swift changed shape; patch manually."
+open(p, "w").write(t.replace(old, new))
+print("Patched:", p)
+PY
+done < <(find "$HOME/Library/Developer/Xcode/DerivedData" \
+  -path "*/SourcePackages/checkouts/FluidAudio/Package.swift" 2>/dev/null)
+
+if [ "$FOUND" -eq 0 ]; then
+  echo "FluidAudio checkout not found. Open the project in Xcode (resolve packages) first."
+  exit 1
+fi


### PR DESCRIPTION
Ports the FluidAudio Swift-5 patch script from develop to main, so the App Store hotfix workflow has the same one-command recovery after Xcode re-resolves SPM packages (this just broke a build-20 Archive attempt — the checkout patch was silently wiped).

Improvements over the develop version:
- `chmod u+w` before patching (SPM checkouts can be read-only)
- patches every DerivedData checkout found instead of only the first

Tested: ran the script locally — reports "Already patched" on the current checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKDjeFysVpTAn2jViZzi6m