### PR TITLE
Hotfix #60: RecordingView X button orphaned the audio engine (silent background recording)

### DIFF
--- a/DictusApp/DictationCoordinator.swift
+++ b/DictusApp/DictationCoordinator.swift
@@ -50,6 +50,12 @@ class DictationCoordinator: ObservableObject {
     private var currentModelName: String?
     private var dictationTask: Task<Void, Never>?
 
+    /// Incremented each time a new dictation actually starts (issue #60).
+    /// Delayed UI closures (RecordingView dismiss/auto-advance) capture the current
+    /// value and bail out if a newer session started before they fire, so a stale
+    /// reset can never tear down a fresh recording.
+    private(set) var dictationGeneration = 0
+
     /// Set when cold start dictation is deferred because the app is .inactive.
     /// Cleared in didBecomeActive when the retry happens.
     private var pendingColdStartDictation = false
@@ -292,6 +298,9 @@ class DictationCoordinator: ObservableObject {
             return
         }
 
+        // New session supersedes any pending delayed reset (issue #60).
+        dictationGeneration += 1
+
         // WHY this early return (only for Darwin notification path, NOT URL scheme):
         // iOS forbids starting an audio engine from background. If the engine isn't
         // running and we're in background (Darwin notification from keyboard), attempting
@@ -528,7 +537,15 @@ class DictationCoordinator: ObservableObject {
     }
 
     /// Reset status to idle (e.g., after user returns to keyboard).
+    ///
+    /// Issue #60: a UI-only reset while the pipeline is active orphans the audio
+    /// engine (keeps capturing) and the Live Activity (stuck on REC), so an active
+    /// session must go through the real teardown instead.
     func resetStatus() {
+        if status == .recording || status == .transcribing || status == .requested {
+            cancelDictation()
+            return
+        }
         updateStatus(.idle)
         // Keep lastResult so HomeView can display the last transcription card.
     }
@@ -801,6 +818,24 @@ class DictationCoordinator: ObservableObject {
 
     /// Write dictation status to App Group so the keyboard can observe it.
     private func updateStatus(_ newStatus: DictationStatus) {
+        // Invariant (issue #60): entering .idle while the engine is still capturing
+        // means some path skipped the teardown. Stop capture (engine stays warm per
+        // #106), force the Live Activity out of .recording, and log the violation so
+        // any future recurrence of this class is one log line, not a silent
+        // background recording.
+        if newStatus == .idle && audioEngine.isRecording {
+            PersistentLog.log(.idleInvariantViolation(
+                from: status.rawValue,
+                engineRunning: audioEngine.isEngineRunning
+            ))
+            if #available(iOS 14.0, *) {
+                DictusLogger.app.fault("Invariant violation: entering .idle while engine is recording — forcing teardown")
+            }
+            _ = audioEngine.collectSamples()
+            Task { await LiveActivityManager.shared.returnToStandby() }
+            LiveActivityManager.shared.startRecordingWatchdog()
+        }
+
         let oldStatus = status
         PersistentLog.log(.statusChanged(from: oldStatus.rawValue, to: newStatus.rawValue, source: "coordinator"))
         status = newStatus

--- a/DictusApp/Info.plist
+++ b/DictusApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.1</string>
+	<string>1.7.2</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>20</string>
+	<string>22</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusApp/Views/RecordingView.swift
+++ b/DictusApp/Views/RecordingView.swift
@@ -61,8 +61,12 @@ struct RecordingView: View {
                             withAnimation(.easeOut(duration: 0.25)) {
                                 isDismissing = true
                             }
-                            // Step 2: after animation, reset status (no animation leak to HomeView)
+                            // Step 2: after animation, reset status (no animation leak to HomeView).
+                            // Generation guard (issue #60): if a new dictation started while the
+                            // dismiss animation ran, this stale reset must not tear it down.
+                            let generation = coordinator.dictationGeneration
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                                guard coordinator.dictationGeneration == generation else { return }
                                 coordinator.resetStatus()
                             }
                         } label: {
@@ -286,9 +290,13 @@ struct RecordingView: View {
                 // Auto-advance to success screen in onboarding mode
                 // Shows transcription result for 1.5s then triggers onComplete
                 if mode == .onboarding {
+                    // Generation guard (issue #60): if the user started a new dictation
+                    // during the 1.5s delay, this stale auto-advance must not fire.
+                    let generation = coordinator.dictationGeneration
                     Task {
                         try? await Task.sleep(for: .milliseconds(1500))
                         await MainActor.run {
+                            guard coordinator.dictationGeneration == generation else { return }
                             coordinator.resetStatus()
                             onComplete?()
                         }

--- a/DictusCore/Sources/DictusCore/LogEvent.swift
+++ b/DictusCore/Sources/DictusCore/LogEvent.swift
@@ -92,6 +92,8 @@ public enum LogEvent: Sendable {
     case overlayHidden(status: String)
     case statusChanged(from: String, to: String, source: String)
     case watchdogReset(source: String, staleState: String)
+    /// Issue #60: a path tried to enter .idle while the engine was still capturing.
+    case idleInvariantViolation(from: String, engineRunning: Bool)
     case rapidTapRejected
 
     // MARK: Engine Diagnostics (temporary — remove after debug)
@@ -179,7 +181,7 @@ public enum LogEvent: Sendable {
              .overlayBodyEvaluated, .overlayTimerStarted, .overlayTimerStopped, .overlayRecreated,
              .diagnosticProbe:
             return .keyboard
-        case .statusChanged, .watchdogReset:
+        case .statusChanged, .watchdogReset, .idleInvariantViolation:
             return .dictation
         case .engineWarmUpAttempt, .engineWarmUpSuccess, .engineWarmUpFailed,
              .engineStateSnapshot, .engineCollectResult, .engineDarwinStartReceived:
@@ -210,7 +212,7 @@ public enum LogEvent: Sendable {
         // Errors
         case .dictationFailed, .audioSessionFailed, .transcriptionFailed,
              .modelDownloadFailed, .modelDeleteFailed,
-             .liveActivityFailed:
+             .liveActivityFailed, .idleInvariantViolation:
             return .error
 
         // Warnings
@@ -323,6 +325,7 @@ public enum LogEvent: Sendable {
         case .overlayHidden: return "overlayHidden"
         case .statusChanged: return "statusChanged"
         case .watchdogReset: return "watchdogReset"
+        case .idleInvariantViolation: return "idleInvariantViolation"
         case .rapidTapRejected: return "rapidTapRejected"
         case .waveformAppeared: return "waveformAppeared"
         case .waveformDisappeared: return "waveformDisappeared"
@@ -486,6 +489,8 @@ public enum LogEvent: Sendable {
             return "from=\(from) to=\(to) source=\(source)"
         case .watchdogReset(let source, let staleState):
             return "source=\(source) staleState=\(staleState)"
+        case .idleInvariantViolation(let from, let engineRunning):
+            return "from=\(from) engineRunning=\(engineRunning)"
         case .rapidTapRejected:
             return ""
 

--- a/DictusKeyboard/Info.plist
+++ b/DictusKeyboard/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.1</string>
+	<string>1.7.2</string>
 	<key>CFBundleVersion</key>
-	<string>20</string>
+	<string>22</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>whatsapp</string>

--- a/DictusWidgets/Info.plist
+++ b/DictusWidgets/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.1</string>
+	<string>1.7.2</string>
 	<key>CFBundleVersion</key>
-	<string>20</string>
+	<string>22</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
## Problem

Fixes the most severe variant of #60, reproduced on production 1.7.1 (20): a real ~2m45 background recording while all first-party UI said idle, with the Dynamic Island stuck on REC as the only way to stop it.

Root cause (full analysis in the issue comments, 2026-07-24): the full-screen RecordingView close (X) button calls `DictationCoordinator.resetStatus()`, a UI-only reset that sets `.idle` without stopping capture, collecting samples, or ending the Live Activity. In standalone mode the X is tappable mid-recording, orphaning both the engine and the Live Activity. The keyboard overlay's cancel (Darwin → `cancelDictation()`) was always healthy; only the in-app X was broken.

## Fix — 3 layers

1. **`resetStatus()` is now defensive**: when a session is active (`.recording` / `.transcribing` / `.requested`) it delegates to `cancelDictation()` — the real teardown (cancels the task, collects samples, returns the Live Activity to standby, arms the watchdog). Covers all three call sites (RecordingView X, onboarding auto-advance, GlobeKeyTutorialPage).
2. **State-machine invariant** in `updateStatus(.idle)`: if the engine is still capturing, stop capture (engine stays warm per #106), force the Live Activity out of `.recording`, arm the watchdog, and log a new high-severity `idleInvariantViolation` event. Any future recurrence of this bug class becomes one log line instead of a silent background recording.
3. **Generation token** on RecordingView's delayed closures (X dismiss `asyncAfter`, onboarding auto-advance `Task.sleep`): a stale reset can never tear down a newer session.

## Scope

App-side only (DictusApp + DictusCore LogEvent) — no keyboard changes, no UI strings (no xcstrings conflict expected on the develop cherry-pick).

## Validation

- [x] Builds clean (DictusApp scheme, iOS Simulator)
- [ ] Device: app → New dictation → tap X while recording → log shows cancel path (`engineCollectResult`, `liveActivityTransition recording -> standby`), `engineStateSnapshot isRecording=false` on next foreground, iOS mic indicator off
- [ ] Device: X during transcription → same teardown
- [ ] Device: normal flow regression (record → stop → result; DI recording → transcribing → ready → standby)
- [ ] Onboarding auto-advance still completes

Do not merge before device validation.

After merge: cherry-pick to `develop`; release as 1.7.2 with next global build number per docs/VERSIONING.md.

Closes #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)