### PR TITLE
Cherry-pick #60 hotfix to develop: RecordingView X teardown

### DIFF
--- a/DictusApp/DictationCoordinator.swift
+++ b/DictusApp/DictationCoordinator.swift
@@ -55,6 +55,12 @@ class DictationCoordinator: ObservableObject {
     /// `schedulePolishPrewarm()`.
     private var polishPrewarmTask: Task<Void, Never>?
 
+    /// Incremented each time a new dictation actually starts (issue #60).
+    /// Delayed UI closures (RecordingView dismiss/auto-advance) capture the current
+    /// value and bail out if a newer session started before they fire, so a stale
+    /// reset can never tear down a fresh recording.
+    private(set) var dictationGeneration = 0
+
     /// Set when cold start dictation is deferred because the app is .inactive.
     /// Cleared in didBecomeActive when the retry happens.
     private var pendingColdStartDictation = false
@@ -323,6 +329,9 @@ class DictationCoordinator: ObservableObject {
             return
         }
 
+        // New session supersedes any pending delayed reset (issue #60).
+        dictationGeneration += 1
+
         // WHY this early return (only for Darwin notification path, NOT URL scheme):
         // iOS forbids starting an audio engine from background. If the engine isn't
         // running and we're in background (Darwin notification from keyboard), attempting
@@ -574,7 +583,15 @@ class DictationCoordinator: ObservableObject {
     }
 
     /// Reset status to idle (e.g., after user returns to keyboard).
+    ///
+    /// Issue #60: a UI-only reset while the pipeline is active orphans the audio
+    /// engine (keeps capturing) and the Live Activity (stuck on REC), so an active
+    /// session must go through the real teardown instead.
     func resetStatus() {
+        if status == .recording || status == .transcribing || status == .requested {
+            cancelDictation()
+            return
+        }
         updateStatus(.idle)
         // Keep lastResult so HomeView can display the last transcription card.
     }
@@ -847,6 +864,24 @@ class DictationCoordinator: ObservableObject {
 
     /// Write dictation status to App Group so the keyboard can observe it.
     private func updateStatus(_ newStatus: DictationStatus) {
+        // Invariant (issue #60): entering .idle while the engine is still capturing
+        // means some path skipped the teardown. Stop capture (engine stays warm per
+        // #106), force the Live Activity out of .recording, and log the violation so
+        // any future recurrence of this class is one log line, not a silent
+        // background recording.
+        if newStatus == .idle && audioEngine.isRecording {
+            PersistentLog.log(.idleInvariantViolation(
+                from: status.rawValue,
+                engineRunning: audioEngine.isEngineRunning
+            ))
+            if #available(iOS 14.0, *) {
+                DictusLogger.app.fault("Invariant violation: entering .idle while engine is recording — forcing teardown")
+            }
+            _ = audioEngine.collectSamples()
+            Task { await LiveActivityManager.shared.returnToStandby() }
+            LiveActivityManager.shared.startRecordingWatchdog()
+        }
+
         let oldStatus = status
         PersistentLog.log(.statusChanged(from: oldStatus.rawValue, to: newStatus.rawValue, source: "coordinator"))
         status = newStatus

--- a/DictusApp/Views/RecordingView.swift
+++ b/DictusApp/Views/RecordingView.swift
@@ -61,8 +61,12 @@ struct RecordingView: View {
                             withAnimation(.easeOut(duration: 0.25)) {
                                 isDismissing = true
                             }
-                            // Step 2: after animation, reset status (no animation leak to HomeView)
+                            // Step 2: after animation, reset status (no animation leak to HomeView).
+                            // Generation guard (issue #60): if a new dictation started while the
+                            // dismiss animation ran, this stale reset must not tear it down.
+                            let generation = coordinator.dictationGeneration
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                                guard coordinator.dictationGeneration == generation else { return }
                                 coordinator.resetStatus()
                             }
                         } label: {
@@ -286,9 +290,13 @@ struct RecordingView: View {
                 // Auto-advance to success screen in onboarding mode
                 // Shows transcription result for 1.5s then triggers onComplete
                 if mode == .onboarding {
+                    // Generation guard (issue #60): if the user started a new dictation
+                    // during the 1.5s delay, this stale auto-advance must not fire.
+                    let generation = coordinator.dictationGeneration
                     Task {
                         try? await Task.sleep(for: .milliseconds(1500))
                         await MainActor.run {
+                            guard coordinator.dictationGeneration == generation else { return }
                             coordinator.resetStatus()
                             onComplete?()
                         }

--- a/DictusCore/Sources/DictusCore/LogEvent.swift
+++ b/DictusCore/Sources/DictusCore/LogEvent.swift
@@ -92,6 +92,8 @@ public enum LogEvent: Sendable {
     case overlayHidden(status: String)
     case statusChanged(from: String, to: String, source: String)
     case watchdogReset(source: String, staleState: String)
+    /// Issue #60: a path tried to enter .idle while the engine was still capturing.
+    case idleInvariantViolation(from: String, engineRunning: Bool)
     case rapidTapRejected
 
     // MARK: Engine Diagnostics (temporary — remove after debug)
@@ -182,7 +184,7 @@ public enum LogEvent: Sendable {
              .overlayBodyEvaluated, .overlayTimerStarted, .overlayTimerStopped, .overlayRecreated,
              .diagnosticProbe:
             return .keyboard
-        case .statusChanged, .watchdogReset:
+        case .statusChanged, .watchdogReset, .idleInvariantViolation:
             return .dictation
         case .engineWarmUpAttempt, .engineWarmUpSuccess, .engineWarmUpFailed,
              .engineStateSnapshot, .engineCollectResult, .engineDarwinStartReceived:
@@ -215,7 +217,7 @@ public enum LogEvent: Sendable {
         // Errors
         case .dictationFailed, .audioSessionFailed, .transcriptionFailed,
              .modelDownloadFailed, .modelDeleteFailed,
-             .liveActivityFailed, .subscriptionError:
+             .liveActivityFailed, .subscriptionError, .idleInvariantViolation:
             return .error
 
         // Warnings
@@ -328,6 +330,7 @@ public enum LogEvent: Sendable {
         case .overlayHidden: return "overlayHidden"
         case .statusChanged: return "statusChanged"
         case .watchdogReset: return "watchdogReset"
+        case .idleInvariantViolation: return "idleInvariantViolation"
         case .rapidTapRejected: return "rapidTapRejected"
         case .waveformAppeared: return "waveformAppeared"
         case .waveformDisappeared: return "waveformDisappeared"
@@ -492,6 +495,8 @@ public enum LogEvent: Sendable {
             return "from=\(from) to=\(to) source=\(source)"
         case .watchdogReset(let source, let staleState):
             return "source=\(source) staleState=\(staleState)"
+        case .idleInvariantViolation(let from, let engineRunning):
+            return "from=\(from) engineRunning=\(engineRunning)"
         case .rapidTapRejected:
             return ""
 


### PR DESCRIPTION
Cherry-pick of `cd17362` from `hotfix/60-recording-x-teardown` (PR #219 to main).

develop was identically vulnerable to the #60 silent-background-recording bug (files byte-identical to prod at analysis time). See issue #60 for the full root cause and the device validation evidence (bug reproduced on the unfixed build, clean teardown on the fixed build).

Conflicts resolved (develop-only divergence, both sides kept):
- `DictationCoordinator.swift`: `polishPrewarmTask` (#141) + new `dictationGeneration` property
- `LogEvent.swift`: `.subscriptionError` (#55) + new `.idleInvariantViolation` in the error-level group

No version bump here — develop stays on 1.8.0 (21).

Refs #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)