### PR TITLE
fix(keyboard): autocorrect trio — host field traits, boundary-safe replacement, proper-noun guard (#200, #191, #199)

### DIFF
--- a/Dictus.xcodeproj/project.pbxproj
+++ b/Dictus.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		CC00000E /* Audio.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC10000E /* Audio.swift */; };
 		CC00000F /* DeviceKit in Frameworks */ = {isa = PBXBuildFile; productRef = CC900001 /* DeviceKit */; };
 		CC000020 /* DictusKeyboardBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC100020 /* DictusKeyboardBridge.swift */; };
+		CC000040 /* HostInputTraits.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC100040 /* HostInputTraits.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -262,6 +263,7 @@
 		CC100030 /* KeyboardMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardMetrics.swift; sourceTree = "<group>"; };
 		CC100010 /* KeyboardLayouts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardLayouts.swift; sourceTree = "<group>"; };
 		CC100020 /* DictusKeyboardBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictusKeyboardBridge.swift; sourceTree = "<group>"; };
+		CC100040 /* HostInputTraits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostInputTraits.swift; sourceTree = "<group>"; };
 		CC100001 /* GiellaUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiellaUtils.swift; sourceTree = "<group>"; };
 		CC100002 /* KeyDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyDefinition.swift; sourceTree = "<group>"; };
 		CC100003 /* KeyboardDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardDefinition.swift; sourceTree = "<group>"; };
@@ -381,6 +383,7 @@
 				CC100030 /* KeyboardMetrics.swift */,
 				CC100010 /* KeyboardLayouts.swift */,
 				CC100020 /* DictusKeyboardBridge.swift */,
+				CC100040 /* HostInputTraits.swift */,
 				CC400001 /* Vendored */,
 				AA400005 /* Views */,
 				AA400006 /* Models */,
@@ -992,6 +995,7 @@
 				CC000030 /* KeyboardMetrics.swift in Sources */,
 				CC000010 /* KeyboardLayouts.swift in Sources */,
 				CC000020 /* DictusKeyboardBridge.swift in Sources */,
+				CC000040 /* HostInputTraits.swift in Sources */,
 				CC000001 /* GiellaUtils.swift in Sources */,
 				CC000002 /* KeyDefinition.swift in Sources */,
 				CC000003 /* KeyboardDefinition.swift in Sources */,

--- a/DictusCore/Sources/DictusCore/AutocorrectDebugLog.swift
+++ b/DictusCore/Sources/DictusCore/AutocorrectDebugLog.swift
@@ -128,6 +128,17 @@ public enum AutocorrectDebugLog {
         write("UNDO orig=\"\(original)\" rejected=\"\(rejected)\"")
     }
 
+    /// The host field's input traits changed the autocorrect/suggestions policy (#200).
+    /// Logged once per policy change (not per keystroke).
+    public static func hostPolicy(
+        autocorrectAllowed: Bool,
+        suggestionsAllowed: Bool,
+        reason: String
+    ) {
+        guard enabled else { return }
+        write("HOST-TRAITS autocorrect=\(autocorrectAllowed) suggestions=\(suggestionsAllowed) reason=\(reason)")
+    }
+
     /// Free-form note (use sparingly — prefer typed events above).
     public static func note(_ message: String) {
         guard enabled else { return }

--- a/DictusCore/Sources/DictusCore/AutocorrectDebugLog.swift
+++ b/DictusCore/Sources/DictusCore/AutocorrectDebugLog.swift
@@ -128,6 +128,34 @@ public enum AutocorrectDebugLog {
         write("UNDO orig=\"\(original)\" rejected=\"\(rejected)\"")
     }
 
+    /// A word replacement was aborted because the live context failed the
+    /// boundary-safety check (#191). This is the proxy-desync signature:
+    /// the pipeline decided on a correction but the document no longer ends
+    /// with the word it planned to replace.
+    public static func replacementAborted(word: String, reason: String, contextTail: String) {
+        guard enabled else { return }
+        write("AUTOCORRECT-ABORT word=\"\(word)\" reason=\(reason) ctx=\"\(contextTail)\"")
+    }
+
+    /// Snapshot of the live context right before an autocorrect replacement (#191).
+    public static func applyBefore(word: String, correction: String, prevWord: String?, contextTail: String) {
+        guard enabled else { return }
+        let prev = prevWord.map { "\"\($0)\"" } ?? "nil"
+        write("AUTOCORRECT-APPLY-BEFORE word=\"\(word)\" corr=\"\(correction)\" prev=\(prev) ctx=\"\(contextTail)\"")
+    }
+
+    /// Snapshot of the live context after the deletion pass of a replacement (#191).
+    public static func applyAfterDelete(contextTail: String) {
+        guard enabled else { return }
+        write("AUTOCORRECT-APPLY-AFTER-DELETE ctx=\"\(contextTail)\"")
+    }
+
+    /// Snapshot of the live context after inserting the correction + space (#191).
+    public static func applyAfterInsert(contextTail: String) {
+        guard enabled else { return }
+        write("AUTOCORRECT-APPLY-AFTER-INSERT ctx=\"\(contextTail)\"")
+    }
+
     /// The host field's input traits changed the autocorrect/suggestions policy (#200).
     /// Logged once per policy change (not per keystroke).
     public static func hostPolicy(

--- a/DictusCore/Sources/DictusCore/AutocorrectReplacement.swift
+++ b/DictusCore/Sources/DictusCore/AutocorrectReplacement.swift
@@ -1,0 +1,66 @@
+// DictusCore/Sources/DictusCore/AutocorrectReplacement.swift
+// Boundary-safe validation for autocorrect word replacement (issue #191).
+//
+// THE BUG THIS PREVENTS:
+// The keyboard used to replace a word by issuing `word.count` deleteBackward()
+// calls, trusting a word captured from an earlier proxy read. When the proxy's
+// reported context desyncs from the live document (rapid delete/retype produces
+// phantom duplicated-letter words like "quee"), the fixed count over-deletes
+// past the word into the preceding space: "pense quee" -> "penseque".
+//
+// THE INVARIANT:
+// Before deleting anything, the caller re-reads the live context and this check
+// confirms (a) the context actually ends with the word about to be replaced and
+// (b) the character before that word is a boundary (whitespace, punctuation,
+// symbol, or start-of-field). If either fails, the caller must skip the
+// replacement — never a destructive guess.
+
+import Foundation
+
+public enum AutocorrectReplacement {
+
+    /// Result of validating a pending word replacement against the live context.
+    public enum CheckResult: Equatable {
+        /// Safe to replace: delete exactly `deleteCount` characters
+        /// (grapheme clusters, matching one deleteBackward() call each).
+        case ok(deleteCount: Int)
+        /// Unsafe: skip the replacement. `reason` is a machine-readable slug
+        /// for DEBUG logs ("empty-word", "no-context", "suffix-mismatch",
+        /// "no-boundary-before").
+        case failed(reason: String)
+    }
+
+    /// Validates that `word` can be safely deleted from the end of `context`.
+    ///
+    /// - Parameters:
+    ///   - context: the LIVE documentContextBeforeInput, re-read immediately
+    ///     before applying the replacement (never a value captured earlier).
+    ///   - word: the word the correction pipeline intends to replace.
+    public static func check(context: String?, word: String) -> CheckResult {
+        guard !word.isEmpty else {
+            return .failed(reason: "empty-word")
+        }
+        guard let context = context, !context.isEmpty else {
+            return .failed(reason: "no-context")
+        }
+        // Swift String comparison uses canonical equivalence, so precomposed
+        // vs decomposed accents ("é" vs "e" + combining acute) still match here.
+        guard context.hasSuffix(word) else {
+            return .failed(reason: "suffix-mismatch")
+        }
+        // The character immediately before the word must be a boundary.
+        // Letters/digits mean the word is glued to the previous token — the
+        // word extraction disagreed with the raw text, deleting would merge words.
+        // nil = word is at start-of-field, which is a valid boundary.
+        // Punctuation is allowed: apostrophes ("l'ami" -> replacing "ami") and
+        // hyphens are legitimate intra-token boundaries.
+        if let preceding = context.dropLast(word.count).last,
+           preceding.isLetter || preceding.isNumber {
+            return .failed(reason: "no-boundary-before")
+        }
+        // Grapheme count of the verified suffix — canonically equivalent strings
+        // have the same grapheme count, and deleteBackward() removes one
+        // grapheme per call.
+        return .ok(deleteCount: word.count)
+    }
+}

--- a/DictusCore/Sources/DictusCore/HostFieldPolicy.swift
+++ b/DictusCore/Sources/DictusCore/HostFieldPolicy.swift
@@ -1,0 +1,128 @@
+// DictusCore/Sources/DictusCore/HostFieldPolicy.swift
+// Pure decision logic for issue #200: should autocorrect/suggestions run in the
+// current host text field, based on its UITextInputTraits?
+//
+// WHY in DictusCore (not DictusKeyboard):
+// DictusKeyboard has no test target, so any logic living there is untestable.
+// This type takes platform-neutral inputs (no UIKit import) and is unit-tested
+// in DictusCoreTests. DictusKeyboard maps UITextDocumentProxy traits to these
+// enums in HostInputTraits.swift.
+
+import Foundation
+
+/// Per-field policy derived from the host text field's input traits.
+///
+/// iOS disables autocorrection in fields where it does more harm than good:
+/// search bars, URL/email fields, username fields. Dictus mirrors that behavior:
+/// - `autocorrectAllowed == false`: never auto-apply a correction on space.
+/// - `suggestionsAllowed == false`: don't generate suggestion-bar content at all
+///   (an empty bar collapses to the language switcher, matching the native
+///   keyboard hiding its predictions in these fields).
+public struct HostFieldPolicy: Equatable {
+
+    /// Platform-neutral projection of UIKeyboardType.
+    /// Only the cases that affect the policy are distinguished; everything else
+    /// maps to `.standard`.
+    public enum KeyboardKind: String {
+        case standard
+        case asciiCapable
+        case url
+        case email
+        case webSearch
+        case twitter
+        case numeric
+        case phone
+        case namePhone
+    }
+
+    /// Platform-neutral projection of UITextContentType.
+    public enum ContentKind: String {
+        case none
+        case username
+        case password
+        case url
+        case email
+        case oneTimeCode
+        case other
+    }
+
+    public let autocorrectAllowed: Bool
+    public let suggestionsAllowed: Bool
+
+    /// Short machine-readable explanation for DEBUG logs
+    /// (e.g. "autocorrectionType.no", "keyboardType.webSearch").
+    public let reason: String
+
+    /// Default policy: everything enabled (normal prose field).
+    public static let allowed = HostFieldPolicy(
+        autocorrectAllowed: true,
+        suggestionsAllowed: true,
+        reason: "default"
+    )
+
+    public init(autocorrectAllowed: Bool, suggestionsAllowed: Bool, reason: String) {
+        self.autocorrectAllowed = autocorrectAllowed
+        self.suggestionsAllowed = suggestionsAllowed
+        self.reason = reason
+    }
+
+    /// Derives the policy from host field traits.
+    ///
+    /// Decision order (first match wins):
+    /// 1. Secure entry (passwords): disable everything.
+    /// 2. Host explicitly disabled autocorrection: disable everything.
+    ///    This is the strongest signal — Safari search and most social-app
+    ///    search fields set `autocorrectionType == .no`.
+    /// 3. Content type identifies a token field (username, URL, email, OTP):
+    ///    disable everything — these hold identifiers, not prose.
+    /// 4. Keyboard type implies a non-prose field (URL, email, web search,
+    ///    twitter handles/hashtags, number/phone pads): disable everything.
+    ///    `.asciiCapable` stays enabled — many normal fields use it.
+    /// 5. Host disabled spell checking only: keep completions/predictions but
+    ///    never auto-apply a correction.
+    public static func evaluate(
+        keyboard: KeyboardKind,
+        content: ContentKind,
+        autocorrectionDisabled: Bool,
+        spellCheckingDisabled: Bool,
+        isSecureEntry: Bool
+    ) -> HostFieldPolicy {
+        if isSecureEntry {
+            return HostFieldPolicy(
+                autocorrectAllowed: false, suggestionsAllowed: false,
+                reason: "secureTextEntry"
+            )
+        }
+        if autocorrectionDisabled {
+            return HostFieldPolicy(
+                autocorrectAllowed: false, suggestionsAllowed: false,
+                reason: "autocorrectionType.no"
+            )
+        }
+        switch content {
+        case .username, .password, .url, .email, .oneTimeCode:
+            return HostFieldPolicy(
+                autocorrectAllowed: false, suggestionsAllowed: false,
+                reason: "textContentType.\(content.rawValue)"
+            )
+        case .none, .other:
+            break
+        }
+        switch keyboard {
+        case .url, .email, .webSearch, .twitter, .numeric, .phone, .namePhone:
+            return HostFieldPolicy(
+                autocorrectAllowed: false, suggestionsAllowed: false,
+                reason: "keyboardType.\(keyboard.rawValue)"
+            )
+        case .standard, .asciiCapable:
+            break
+        }
+        if spellCheckingDisabled {
+            return HostFieldPolicy(
+                autocorrectAllowed: false, suggestionsAllowed: true,
+                reason: "spellCheckingType.no"
+            )
+        }
+        return .allowed
+    }
+}

--- a/DictusCore/Sources/DictusCore/ProperNounGuard.swift
+++ b/DictusCore/Sources/DictusCore/ProperNounGuard.swift
@@ -1,0 +1,71 @@
+// DictusCore/Sources/DictusCore/ProperNounGuard.swift
+// Conservative proper-noun detection for autocorrect (issue #199).
+//
+// WHY: for a keyboard, a false-positive correction is worse than a missed one.
+// Names, brands and acronyms are usually not in the dictionary, are edit-
+// distance-close to common words, and are typed once — so the correction
+// pipeline "fixes" them into dictionary words before user-learning can help
+// ("Mathilde" -> "matinée"-class corrections). An unknown capitalized word in
+// the middle of a sentence is far more likely an intentional name than a typo:
+// preserve it.
+//
+// WHAT THIS IS NOT: a general named-entity recognizer. The rules are pure
+// string analysis, deliberately conservative, and only consulted for words the
+// dictionary does not know (the caller checks validity/user-dictionary first).
+
+import Foundation
+
+public enum ProperNounGuard {
+
+    /// Whether an unknown word looks like an intentional proper noun / acronym
+    /// that autocorrect must preserve.
+    ///
+    /// Rules:
+    /// - Contains a digit or any non-letter character (apostrophes, hyphens):
+    ///   not our call — contraction/split branches own those tokens.
+    /// - ALL-CAPS with 2+ letters ("SNCF", "EDF", "GPT"): preserve regardless
+    ///   of sentence position — sentence-start capitalization never produces
+    ///   all-caps.
+    /// - Capitalized word (first letter uppercase, rest lowercase) of 3+
+    ///   letters in the MIDDLE of a sentence ("vu Mathilde", "avec Pivi"):
+    ///   preserve. At sentence start the capitalization is just autocap
+    ///   ("Jai faim" must still correct), so the rule is inactive there.
+    public static func isLikelyProperNoun(word: String, isAtSentenceStart: Bool) -> Bool {
+        guard !word.isEmpty else { return false }
+        guard word.allSatisfy({ $0.isLetter }) else { return false }
+
+        // All-caps acronym: position-independent.
+        if word.count >= 2 && word.allSatisfy({ $0.isUppercase }) {
+            return true
+        }
+
+        // Capitalized word: only meaningful mid-sentence.
+        guard !isAtSentenceStart else { return false }
+        guard word.count >= 3 else { return false }
+        guard let first = word.first, first.isUppercase else { return false }
+        guard word.dropFirst().allSatisfy({ $0.isLowercase }) else { return false }
+        return true
+    }
+
+    /// Whether `word` sits at the start of a sentence within `context`
+    /// (the text before the cursor, ending with `word`).
+    ///
+    /// Mirrors the autocapitalization rules: start-of-field, after a newline,
+    /// or after sentence-ending punctuation (. ! ? …) all count as sentence
+    /// start. Returns `true` (the conservative answer — proper-noun rule
+    /// stays inactive, corrections still allowed) when the context does not
+    /// end with the word, e.g. under proxy desync.
+    ///
+    /// KNOWN LIMITATION: abbreviation periods ("M. Dupont") read as sentence
+    /// ends, so the name after them is not protected by the mid-sentence rule.
+    public static func isAtSentenceStart(context: String, word: String) -> Bool {
+        guard !word.isEmpty, context.hasSuffix(word) else { return true }
+        let preceding = context.dropLast(word.count)
+        if preceding.isEmpty { return true }
+        if preceding.last == "\n" { return true }
+        let trimmed = preceding.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return true }
+        if let last = trimmed.last, ".!?…".contains(last) { return true }
+        return false
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/AutocorrectReplacementTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/AutocorrectReplacementTests.swift
@@ -1,0 +1,102 @@
+// DictusCore/Tests/DictusCoreTests/AutocorrectReplacementTests.swift
+// Tests for the boundary-safe replacement check (issue #191): autocorrect must
+// never delete the space (or other boundary) before the word it replaces.
+
+import XCTest
+@testable import DictusCore
+
+final class AutocorrectReplacementTests: XCTestCase {
+
+    // MARK: - Happy path: live context matches the word
+
+    func testWordAfterSpaceIsSafe() {
+        // Repro A from the issue: "pense quee" + space, correcting "quee".
+        let result = AutocorrectReplacement.check(context: "je pense quee", word: "quee")
+        XCTAssertEqual(result, .ok(deleteCount: 4))
+    }
+
+    func testWordAtStartOfFieldIsSafe() {
+        let result = AutocorrectReplacement.check(context: "quee", word: "quee")
+        XCTAssertEqual(result, .ok(deleteCount: 4))
+    }
+
+    func testAccentedWordIsSafeWithGraphemeCount() {
+        // Repro B: "la théori" — é must count as ONE deleteBackward call.
+        let result = AutocorrectReplacement.check(context: "la théori", word: "théori")
+        XCTAssertEqual(result, .ok(deleteCount: 6))
+    }
+
+    func testDecomposedAccentMatchesPrecomposedWord() {
+        // Some hosts report decomposed Unicode (e + combining acute).
+        // Swift's canonical equivalence must still match, and the grapheme
+        // count (5) is identical in both normalization forms.
+        let decomposedContext = "la the\u{0301}ori"      // "théori" decomposed, 9 graphemes
+        let precomposedWord = "th\u{00E9}ori"            // "théori" precomposed
+        let result = AutocorrectReplacement.check(context: decomposedContext, word: precomposedWord)
+        XCTAssertEqual(result, .ok(deleteCount: 6))
+    }
+
+    func testWordAfterApostropheIsSafe() {
+        // "l'ami": word extraction yields "ami", preceded by an apostrophe —
+        // a legitimate intra-token boundary, replacement stays within "ami".
+        let result = AutocorrectReplacement.check(context: "l'ami", word: "ami")
+        XCTAssertEqual(result, .ok(deleteCount: 3))
+    }
+
+    func testWordAfterNewlineIsSafe() {
+        let result = AutocorrectReplacement.check(context: "Bonjour,\nquee", word: "quee")
+        XCTAssertEqual(result, .ok(deleteCount: 4))
+    }
+
+    // MARK: - Desync: context no longer ends with the word
+
+    func testStaleWordLongerThanContextSuffixIsRejected() {
+        // Captured "quee" but the document actually ends with "que"
+        // (the phantom duplicated letter never landed in the host).
+        let result = AutocorrectReplacement.check(context: "je pense que", word: "quee")
+        XCTAssertEqual(result, .failed(reason: "suffix-mismatch"))
+    }
+
+    func testStaleWordShorterThanContextSuffixIsRejected() {
+        // Captured "que" but the user typed one more letter since.
+        let result = AutocorrectReplacement.check(context: "je pense quee", word: "que")
+        XCTAssertEqual(result, .failed(reason: "suffix-mismatch"))
+    }
+
+    func testCompletelyDifferentSuffixIsRejected() {
+        let result = AutocorrectReplacement.check(context: "je pense donc", word: "quee")
+        XCTAssertEqual(result, .failed(reason: "suffix-mismatch"))
+    }
+
+    // MARK: - Boundary violations: word glued to previous token
+
+    func testWordGluedToPreviousWordIsRejected() {
+        // The document already lost its space ("penseque"): word extraction
+        // may still claim the last word is "que", but deleting 3 chars and
+        // reinserting would silently ratify the merge. Reject.
+        let result = AutocorrectReplacement.check(context: "je penseque", word: "que")
+        XCTAssertEqual(result, .failed(reason: "no-boundary-before"))
+    }
+
+    func testWordPrecededByDigitIsRejected() {
+        let result = AutocorrectReplacement.check(context: "abc123que", word: "que")
+        XCTAssertEqual(result, .failed(reason: "no-boundary-before"))
+    }
+
+    // MARK: - Degenerate inputs
+
+    func testEmptyWordIsRejected() {
+        let result = AutocorrectReplacement.check(context: "je pense", word: "")
+        XCTAssertEqual(result, .failed(reason: "empty-word"))
+    }
+
+    func testNilContextIsRejected() {
+        let result = AutocorrectReplacement.check(context: nil, word: "que")
+        XCTAssertEqual(result, .failed(reason: "no-context"))
+    }
+
+    func testEmptyContextIsRejected() {
+        let result = AutocorrectReplacement.check(context: "", word: "que")
+        XCTAssertEqual(result, .failed(reason: "no-context"))
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/HostFieldPolicyTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/HostFieldPolicyTests.swift
@@ -1,0 +1,117 @@
+// DictusCore/Tests/DictusCoreTests/HostFieldPolicyTests.swift
+// Tests for the host-field traits policy (issue #200): autocorrect and
+// suggestions must be disabled in search/URL/email/username/secure fields.
+
+import XCTest
+@testable import DictusCore
+
+final class HostFieldPolicyTests: XCTestCase {
+
+    /// Shorthand: evaluate with permissive defaults, overriding one axis at a time.
+    private func evaluate(
+        keyboard: HostFieldPolicy.KeyboardKind = .standard,
+        content: HostFieldPolicy.ContentKind = .none,
+        autocorrectionDisabled: Bool = false,
+        spellCheckingDisabled: Bool = false,
+        isSecureEntry: Bool = false
+    ) -> HostFieldPolicy {
+        HostFieldPolicy.evaluate(
+            keyboard: keyboard,
+            content: content,
+            autocorrectionDisabled: autocorrectionDisabled,
+            spellCheckingDisabled: spellCheckingDisabled,
+            isSecureEntry: isSecureEntry
+        )
+    }
+
+    // MARK: - Normal prose fields stay enabled
+
+    func testDefaultFieldAllowsEverything() {
+        let policy = evaluate()
+        XCTAssertTrue(policy.autocorrectAllowed)
+        XCTAssertTrue(policy.suggestionsAllowed)
+        XCTAssertEqual(policy, .allowed)
+    }
+
+    func testAsciiCapableKeyboardStaysEnabled() {
+        // Many normal fields use .asciiCapable — it must NOT disable autocorrect.
+        let policy = evaluate(keyboard: .asciiCapable)
+        XCTAssertTrue(policy.autocorrectAllowed)
+        XCTAssertTrue(policy.suggestionsAllowed)
+    }
+
+    func testOtherContentTypeStaysEnabled() {
+        // Content types we don't special-case (e.g. .givenName) keep defaults.
+        let policy = evaluate(content: .other)
+        XCTAssertTrue(policy.autocorrectAllowed)
+        XCTAssertTrue(policy.suggestionsAllowed)
+    }
+
+    // MARK: - Explicit autocorrection opt-out (Safari search, social search bars)
+
+    func testAutocorrectionTypeNoDisablesEverything() {
+        let policy = evaluate(autocorrectionDisabled: true)
+        XCTAssertFalse(policy.autocorrectAllowed)
+        XCTAssertFalse(policy.suggestionsAllowed)
+        XCTAssertEqual(policy.reason, "autocorrectionType.no")
+    }
+
+    // MARK: - Keyboard types implying non-prose input
+
+    func testSearchAndTokenKeyboardTypesDisableEverything() {
+        let kinds: [HostFieldPolicy.KeyboardKind] = [
+            .url, .email, .webSearch, .twitter, .numeric, .phone, .namePhone
+        ]
+        for kind in kinds {
+            let policy = evaluate(keyboard: kind)
+            XCTAssertFalse(policy.autocorrectAllowed, "\(kind) should disable autocorrect")
+            XCTAssertFalse(policy.suggestionsAllowed, "\(kind) should disable suggestions")
+            XCTAssertEqual(policy.reason, "keyboardType.\(kind.rawValue)")
+        }
+    }
+
+    // MARK: - Content types identifying token fields
+
+    func testTokenContentTypesDisableEverything() {
+        let kinds: [HostFieldPolicy.ContentKind] = [
+            .username, .password, .url, .email, .oneTimeCode
+        ]
+        for kind in kinds {
+            let policy = evaluate(content: kind)
+            XCTAssertFalse(policy.autocorrectAllowed, "\(kind) should disable autocorrect")
+            XCTAssertFalse(policy.suggestionsAllowed, "\(kind) should disable suggestions")
+            XCTAssertEqual(policy.reason, "textContentType.\(kind.rawValue)")
+        }
+    }
+
+    // MARK: - Secure entry
+
+    func testSecureEntryDisablesEverything() {
+        let policy = evaluate(isSecureEntry: true)
+        XCTAssertFalse(policy.autocorrectAllowed)
+        XCTAssertFalse(policy.suggestionsAllowed)
+        XCTAssertEqual(policy.reason, "secureTextEntry")
+    }
+
+    func testSecureEntryWinsOverOtherSignals() {
+        // Precedence: secure entry is checked first even when other traits are set.
+        let policy = evaluate(keyboard: .webSearch, autocorrectionDisabled: true, isSecureEntry: true)
+        XCTAssertEqual(policy.reason, "secureTextEntry")
+    }
+
+    // MARK: - Spell checking opt-out (weakest signal)
+
+    func testSpellCheckingNoDisablesAutocorrectButKeepsSuggestions() {
+        let policy = evaluate(spellCheckingDisabled: true)
+        XCTAssertFalse(policy.autocorrectAllowed)
+        XCTAssertTrue(policy.suggestionsAllowed)
+        XCTAssertEqual(policy.reason, "spellCheckingType.no")
+    }
+
+    func testStrongerSignalWinsOverSpellChecking() {
+        // keyboardType beats spellCheckingType in the precedence order.
+        let policy = evaluate(keyboard: .webSearch, spellCheckingDisabled: true)
+        XCTAssertEqual(policy.reason, "keyboardType.webSearch")
+        XCTAssertFalse(policy.suggestionsAllowed)
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/ProperNounGuardTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/ProperNounGuardTests.swift
@@ -1,0 +1,109 @@
+// DictusCore/Tests/DictusCoreTests/ProperNounGuardTests.swift
+// Tests for the proper-noun preservation rules (issue #199): unknown
+// capitalized mid-sentence words and acronyms must not be autocorrected,
+// while sentence-start typos keep getting corrected.
+
+import XCTest
+@testable import DictusCore
+
+final class ProperNounGuardTests: XCTestCase {
+
+    // MARK: - isLikelyProperNoun — names mid-sentence (issue's example list)
+
+    func testFirstNamesMidSentenceArePreserved() {
+        for name in ["Mathilde", "Romain", "Pivi", "Sly"] {
+            XCTAssertTrue(
+                ProperNounGuard.isLikelyProperNoun(word: name, isAtSentenceStart: false),
+                "\(name) mid-sentence should be preserved"
+            )
+        }
+    }
+
+    func testAccentedCapitalizedWordIsPreserved() {
+        XCTAssertTrue(ProperNounGuard.isLikelyProperNoun(word: "Élodie", isAtSentenceStart: false))
+    }
+
+    // MARK: - isLikelyProperNoun — acronyms (position-independent)
+
+    func testAllCapsAcronymsArePreservedAnywhere() {
+        for acronym in ["SNCF", "EDF", "GPT"] {
+            XCTAssertTrue(
+                ProperNounGuard.isLikelyProperNoun(word: acronym, isAtSentenceStart: false),
+                "\(acronym) mid-sentence should be preserved"
+            )
+            XCTAssertTrue(
+                ProperNounGuard.isLikelyProperNoun(word: acronym, isAtSentenceStart: true),
+                "\(acronym) at sentence start should be preserved"
+            )
+        }
+    }
+
+    // MARK: - isLikelyProperNoun — words that must stay correctable
+
+    func testSentenceStartCapitalizedWordIsNotPreserved() {
+        // "Jai faim" — sentence-start capitalization is autocap, not a name:
+        // the contraction correction "Jai" -> "J'ai" must stay possible.
+        XCTAssertFalse(ProperNounGuard.isLikelyProperNoun(word: "Jai", isAtSentenceStart: true))
+        XCTAssertFalse(ProperNounGuard.isLikelyProperNoun(word: "Mathilde", isAtSentenceStart: true))
+    }
+
+    func testLowercaseWordIsNotPreserved() {
+        XCTAssertFalse(ProperNounGuard.isLikelyProperNoun(word: "sui", isAtSentenceStart: false))
+    }
+
+    func testShortCapitalizedWordIsNotPreserved() {
+        // 2-letter capitalized words ("Ca") stay correctable — the French
+        // "Ca" -> "Ça" language override must keep working.
+        XCTAssertFalse(ProperNounGuard.isLikelyProperNoun(word: "Ca", isAtSentenceStart: false))
+    }
+
+    func testWordWithDigitsIsNotPreserved() {
+        XCTAssertFalse(ProperNounGuard.isLikelyProperNoun(word: "Test123", isAtSentenceStart: false))
+    }
+
+    func testWordWithApostropheIsNotPreserved() {
+        // Contraction branches own apostrophe tokens ("J'ai", "C'est").
+        XCTAssertFalse(ProperNounGuard.isLikelyProperNoun(word: "J'ai", isAtSentenceStart: false))
+    }
+
+    func testMixedCaseWordIsNotPreserved() {
+        // Interior uppercase ("McDo", "MathildE") is outside the conservative
+        // capitalized-word rule.
+        XCTAssertFalse(ProperNounGuard.isLikelyProperNoun(word: "MathildE", isAtSentenceStart: false))
+    }
+
+    func testEmptyWordIsNotPreserved() {
+        XCTAssertFalse(ProperNounGuard.isLikelyProperNoun(word: "", isAtSentenceStart: false))
+    }
+
+    // MARK: - isAtSentenceStart
+
+    func testStartOfFieldIsSentenceStart() {
+        XCTAssertTrue(ProperNounGuard.isAtSentenceStart(context: "Jai", word: "Jai"))
+    }
+
+    func testAfterSentencePunctuationIsSentenceStart() {
+        XCTAssertTrue(ProperNounGuard.isAtSentenceStart(context: "Bonjour. Jai", word: "Jai"))
+        XCTAssertTrue(ProperNounGuard.isAtSentenceStart(context: "Quoi ? Mathilde", word: "Mathilde"))
+        XCTAssertTrue(ProperNounGuard.isAtSentenceStart(context: "Super ! Romain", word: "Romain"))
+    }
+
+    func testAfterNewlineIsSentenceStart() {
+        XCTAssertTrue(ProperNounGuard.isAtSentenceStart(context: "Bonjour,\nMathilde", word: "Mathilde"))
+    }
+
+    func testMidSentenceIsNotSentenceStart() {
+        XCTAssertFalse(ProperNounGuard.isAtSentenceStart(context: "J'ai vu Mathilde", word: "Mathilde"))
+        XCTAssertFalse(ProperNounGuard.isAtSentenceStart(context: "on va chez Sly", word: "Sly"))
+    }
+
+    func testAfterCommaIsNotSentenceStart() {
+        XCTAssertFalse(ProperNounGuard.isAtSentenceStart(context: "salut, Mathilde", word: "Mathilde"))
+    }
+
+    func testContextMismatchDefaultsToSentenceStart() {
+        // Conservative fallback: when the context doesn't end with the word
+        // (proxy desync), report sentence start so corrections stay enabled.
+        XCTAssertTrue(ProperNounGuard.isAtSentenceStart(context: "je pense que", word: "Mathilde"))
+    }
+}

--- a/DictusKeyboard/DictusKeyboardBridge.swift
+++ b/DictusKeyboard/DictusKeyboardBridge.swift
@@ -403,8 +403,6 @@ final class DictusKeyboardBridge: NSObject,
                isAtSentenceStart: atSentenceStart
            ),
            result.correction.lowercased() != freshWord.lowercased() {
-            let proxy = controller?.textDocumentProxy
-
             // Boundary-safe replacement (#191): re-read the LIVE context and
             // verify it still ends with the word we plan to replace, with a
             // proper boundary before it. Under proxy desync (rapid delete/retype
@@ -412,57 +410,16 @@ final class DictusKeyboardBridge: NSObject,
             // disagree with the document — a blind count-based delete would eat
             // the preceding space ("pense quee" -> "penseque"). On failure we
             // skip the correction and fall through to a normal space.
-            let liveContext = proxy?.documentContextBeforeInput
+            let liveContext = controller?.textDocumentProxy.documentContextBeforeInput
             switch AutocorrectReplacement.check(context: liveContext, word: freshWord) {
             case .ok(let deleteCount):
-                #if DEBUG
-                AutocorrectDebugLog.applyBefore(
-                    word: freshWord,
+                applyAutocorrect(
+                    state: state,
+                    freshWord: freshWord,
                     correction: result.correction,
-                    prevWord: previousWord,
-                    contextTail: Self.contextTail(liveContext)
+                    previousWord: previousWord,
+                    deleteCount: deleteCount
                 )
-                #endif
-
-                for _ in 0..<deleteCount {
-                    proxy?.deleteBackward()
-                }
-                #if DEBUG
-                AutocorrectDebugLog.applyAfterDelete(
-                    contextTail: Self.contextTail(proxy?.documentContextBeforeInput)
-                )
-                #endif
-
-                proxy?.insertText(result.correction)
-                proxy?.insertText(" ")
-                lastInsertedCharacter = " "
-
-                #if DEBUG
-                AutocorrectDebugLog.applyAfterInsert(
-                    contextTail: Self.contextTail(proxy?.documentContextBeforeInput)
-                )
-                AutocorrectDebugLog.autocorrectApplied(
-                    original: freshWord,
-                    corrected: result.correction,
-                    prevWord: previousWord
-                )
-                #endif
-
-                // Store undo state — user can tap suggestion bar to revert
-                state.pendingUndo = AutocorrectState(
-                    originalWord: freshWord,
-                    correctedWord: result.correction,
-                    insertedSpace: true
-                )
-                HapticFeedback.autocorrectApplied()
-                // Trigger n-gram predictions after autocorrection too.
-                // The corrected word + space is now in the proxy — predict what comes next.
-                state.clear()
-                state.rejectedWords.removeAll()
-                let correctedContext = controller?.textDocumentProxy.documentContextBeforeInput
-                state.updatePredictions(context: correctedContext)
-                updateCapitalization()
-                updateAccentKeyDisplay()
                 return
 
             case .failed(let reason):
@@ -682,6 +639,69 @@ final class DictusKeyboardBridge: NSObject,
         default:
             break
         }
+    }
+
+    /// Applies a validated autocorrection: deletes the typed word, inserts the
+    /// correction + trailing space, stores undo state and refreshes predictions.
+    /// Only called after AutocorrectReplacement.check confirmed the live context
+    /// ends with `freshWord` (#191) — `deleteCount` comes from that check.
+    private func applyAutocorrect(
+        state: SuggestionState,
+        freshWord: String,
+        correction: String,
+        previousWord: String?,
+        deleteCount: Int
+    ) {
+        let proxy = controller?.textDocumentProxy
+
+        #if DEBUG
+        AutocorrectDebugLog.applyBefore(
+            word: freshWord,
+            correction: correction,
+            prevWord: previousWord,
+            contextTail: Self.contextTail(proxy?.documentContextBeforeInput)
+        )
+        #endif
+
+        for _ in 0..<deleteCount {
+            proxy?.deleteBackward()
+        }
+        #if DEBUG
+        AutocorrectDebugLog.applyAfterDelete(
+            contextTail: Self.contextTail(proxy?.documentContextBeforeInput)
+        )
+        #endif
+
+        proxy?.insertText(correction)
+        proxy?.insertText(" ")
+        lastInsertedCharacter = " "
+
+        #if DEBUG
+        AutocorrectDebugLog.applyAfterInsert(
+            contextTail: Self.contextTail(proxy?.documentContextBeforeInput)
+        )
+        AutocorrectDebugLog.autocorrectApplied(
+            original: freshWord,
+            corrected: correction,
+            prevWord: previousWord
+        )
+        #endif
+
+        // Store undo state — user can tap suggestion bar to revert
+        state.pendingUndo = AutocorrectState(
+            originalWord: freshWord,
+            correctedWord: correction,
+            insertedSpace: true
+        )
+        HapticFeedback.autocorrectApplied()
+        // Trigger n-gram predictions after autocorrection too.
+        // The corrected word + space is now in the proxy — predict what comes next.
+        state.clear()
+        state.rejectedWords.removeAll()
+        let correctedContext = controller?.textDocumentProxy.documentContextBeforeInput
+        state.updatePredictions(context: correctedContext)
+        updateCapitalization()
+        updateAccentKeyDisplay()
     }
 
     /// Last ~30 characters of a context string, for DEBUG replacement logs.

--- a/DictusKeyboard/DictusKeyboardBridge.swift
+++ b/DictusKeyboard/DictusKeyboardBridge.swift
@@ -391,39 +391,80 @@ final class DictusKeyboardBridge: NSObject,
            !state.rejectedWords.contains(freshWord.lowercased()),
            let result = state.performSpellCheck(freshWord, previousWord: previousWord),
            result.correction.lowercased() != freshWord.lowercased() {
-            // Replace the misspelled word with the correction
             let proxy = controller?.textDocumentProxy
-            for _ in 0..<freshWord.count {
-                proxy?.deleteBackward()
+
+            // Boundary-safe replacement (#191): re-read the LIVE context and
+            // verify it still ends with the word we plan to replace, with a
+            // proper boundary before it. Under proxy desync (rapid delete/retype
+            // producing phantom words like "quee"), the captured freshWord can
+            // disagree with the document — a blind count-based delete would eat
+            // the preceding space ("pense quee" -> "penseque"). On failure we
+            // skip the correction and fall through to a normal space.
+            let liveContext = proxy?.documentContextBeforeInput
+            switch AutocorrectReplacement.check(context: liveContext, word: freshWord) {
+            case .ok(let deleteCount):
+                #if DEBUG
+                AutocorrectDebugLog.applyBefore(
+                    word: freshWord,
+                    correction: result.correction,
+                    prevWord: previousWord,
+                    contextTail: Self.contextTail(liveContext)
+                )
+                #endif
+
+                for _ in 0..<deleteCount {
+                    proxy?.deleteBackward()
+                }
+                #if DEBUG
+                AutocorrectDebugLog.applyAfterDelete(
+                    contextTail: Self.contextTail(proxy?.documentContextBeforeInput)
+                )
+                #endif
+
+                proxy?.insertText(result.correction)
+                proxy?.insertText(" ")
+                lastInsertedCharacter = " "
+
+                #if DEBUG
+                AutocorrectDebugLog.applyAfterInsert(
+                    contextTail: Self.contextTail(proxy?.documentContextBeforeInput)
+                )
+                AutocorrectDebugLog.autocorrectApplied(
+                    original: freshWord,
+                    corrected: result.correction,
+                    prevWord: previousWord
+                )
+                #endif
+
+                // Store undo state — user can tap suggestion bar to revert
+                state.pendingUndo = AutocorrectState(
+                    originalWord: freshWord,
+                    correctedWord: result.correction,
+                    insertedSpace: true
+                )
+                HapticFeedback.autocorrectApplied()
+                // Trigger n-gram predictions after autocorrection too.
+                // The corrected word + space is now in the proxy — predict what comes next.
+                state.clear()
+                state.rejectedWords.removeAll()
+                let correctedContext = controller?.textDocumentProxy.documentContextBeforeInput
+                state.updatePredictions(context: correctedContext)
+                updateCapitalization()
+                updateAccentKeyDisplay()
+                return
+
+            case .failed(let reason):
+                // Proxy desync detected — do NOT correct, do NOT delete.
+                // Fall through to the normal space path below so the user
+                // keeps their typed word and still gets a space.
+                #if DEBUG
+                AutocorrectDebugLog.replacementAborted(
+                    word: freshWord,
+                    reason: reason,
+                    contextTail: Self.contextTail(liveContext)
+                )
+                #endif
             }
-            proxy?.insertText(result.correction)
-            proxy?.insertText(" ")
-            lastInsertedCharacter = " "
-
-            #if DEBUG
-            AutocorrectDebugLog.autocorrectApplied(
-                original: freshWord,
-                corrected: result.correction,
-                prevWord: previousWord
-            )
-            #endif
-
-            // Store undo state — user can tap suggestion bar to revert
-            state.pendingUndo = AutocorrectState(
-                originalWord: freshWord,
-                correctedWord: result.correction,
-                insertedSpace: true
-            )
-            HapticFeedback.autocorrectApplied()
-            // Trigger n-gram predictions after autocorrection too.
-            // The corrected word + space is now in the proxy — predict what comes next.
-            state.clear()
-            state.rejectedWords.removeAll()
-            let correctedContext = controller?.textDocumentProxy.documentContextBeforeInput
-            state.updatePredictions(context: correctedContext)
-            updateCapitalization()
-            updateAccentKeyDisplay()
-            return
         }
 
         // Repetition learning: word was NOT corrected (user typed it as-is).
@@ -629,6 +670,13 @@ final class DictusKeyboardBridge: NSObject,
         default:
             break
         }
+    }
+
+    /// Last ~30 characters of a context string, for DEBUG replacement logs.
+    /// Keeps log lines short while showing the text around the replacement site.
+    static func contextTail(_ context: String?) -> String {
+        guard let context = context else { return "<nil>" }
+        return String(context.suffix(30))
     }
 
     // MARK: - Auto-full-stop

--- a/DictusKeyboard/DictusKeyboardBridge.swift
+++ b/DictusKeyboard/DictusKeyboardBridge.swift
@@ -385,11 +385,23 @@ final class DictusKeyboardBridge: NSObject,
         // the proxy read is cheap and this is the freshest possible signal.
         refreshHostPolicy()
 
+        // Sentence position for the proper-noun guard (#199): an unknown
+        // capitalized word mid-sentence is preserved; at sentence start the
+        // capitalization is just autocap, so corrections stay enabled there.
+        let atSentenceStart: Bool = {
+            guard let ctx = controller?.textDocumentProxy.documentContextBeforeInput else { return true }
+            return ProperNounGuard.isAtSentenceStart(context: ctx, word: freshWord)
+        }()
+
         if let state = suggestionState, state.autocorrectEnabled,
            state.hostPolicy.autocorrectAllowed,
            !freshWord.isEmpty,
            !state.rejectedWords.contains(freshWord.lowercased()),
-           let result = state.performSpellCheck(freshWord, previousWord: previousWord),
+           let result = state.performSpellCheck(
+               freshWord,
+               previousWord: previousWord,
+               isAtSentenceStart: atSentenceStart
+           ),
            result.correction.lowercased() != freshWord.lowercased() {
             let proxy = controller?.textDocumentProxy
 

--- a/DictusKeyboard/DictusKeyboardBridge.swift
+++ b/DictusKeyboard/DictusKeyboardBridge.swift
@@ -174,6 +174,36 @@ final class DictusKeyboardBridge: NSObject,
         controller?.handleInputModeList(from: sender, with: event)
     }
 
+    // MARK: - Host Field Policy (#200)
+
+    /// Re-reads the host field's input traits and updates the cached policy on
+    /// SuggestionState. Called whenever the focused field can have changed:
+    /// keyboard appearance, textDidChange/selectionDidChange, and before
+    /// autocorrect-on-space.
+    ///
+    /// WHY cached on SuggestionState: updateAsync/updatePredictions run on a
+    /// background queue and cannot read UITextDocumentProxy (main-thread only).
+    func refreshHostPolicy() {
+        guard let proxy = controller?.textDocumentProxy else { return }
+        let policy = HostInputTraits.policy(for: proxy)
+        guard policy != suggestionState?.hostPolicy else { return }
+
+        #if DEBUG
+        AutocorrectDebugLog.hostPolicy(
+            autocorrectAllowed: policy.autocorrectAllowed,
+            suggestionsAllowed: policy.suggestionsAllowed,
+            reason: policy.reason
+        )
+        #endif
+
+        suggestionState?.hostPolicy = policy
+        if !policy.suggestionsAllowed {
+            // Empty the bar immediately — stale suggestions from the previous
+            // field must not survive into a no-suggestions field.
+            suggestionState?.clear()
+        }
+    }
+
     // MARK: - Key Action Handlers
 
     /// Handle character input (letters, numbers, punctuation).
@@ -351,7 +381,12 @@ final class DictusKeyboardBridge: NSObject,
             return words[words.count - 2]
         }()
 
+        // Refresh the host-traits policy right before the apply decision (#200):
+        // the proxy read is cheap and this is the freshest possible signal.
+        refreshHostPolicy()
+
         if let state = suggestionState, state.autocorrectEnabled,
+           state.hostPolicy.autocorrectAllowed,
            !freshWord.isEmpty,
            !state.rejectedWords.contains(freshWord.lowercased()),
            let result = state.performSpellCheck(freshWord, previousWord: previousWord),

--- a/DictusKeyboard/HostInputTraits.swift
+++ b/DictusKeyboard/HostInputTraits.swift
@@ -1,0 +1,55 @@
+// DictusKeyboard/HostInputTraits.swift
+// Maps the host text field's UITextInputTraits (read from UITextDocumentProxy)
+// to the pure HostFieldPolicy decision in DictusCore (issue #200).
+//
+// WHY this split: UIKeyboardType/UITextContentType only exist in UIKit, but the
+// policy logic must be unit-testable in DictusCoreTests (no UIKit on macOS).
+// This file is the thin, untestable UIKit shim; the tested logic is in DictusCore.
+
+import UIKit
+import DictusCore
+
+enum HostInputTraits {
+
+    /// Reads the proxy's traits and evaluates the field policy.
+    ///
+    /// NOTE: traits are only accurate once the host connection exists
+    /// (viewWillAppear onward) — same caveat as needsInputModeSwitchKey.
+    /// UITextInputTraits members are optional ObjC requirements, hence the
+    /// optional chaining with permissive defaults (missing trait = normal field).
+    static func policy(for proxy: UITextDocumentProxy) -> HostFieldPolicy {
+        HostFieldPolicy.evaluate(
+            keyboard: keyboardKind(proxy.keyboardType),
+            content: contentKind(proxy.textContentType),
+            autocorrectionDisabled: proxy.autocorrectionType == .no,
+            spellCheckingDisabled: proxy.spellCheckingType == .no,
+            isSecureEntry: proxy.isSecureTextEntry ?? false
+        )
+    }
+
+    private static func keyboardKind(_ type: UIKeyboardType?) -> HostFieldPolicy.KeyboardKind {
+        switch type {
+        case .URL: return .url
+        case .emailAddress: return .email
+        case .webSearch: return .webSearch
+        case .twitter: return .twitter
+        case .numberPad, .decimalPad, .asciiCapableNumberPad: return .numeric
+        case .phonePad: return .phone
+        case .namePhonePad: return .namePhone
+        case .asciiCapable: return .asciiCapable
+        default: return .standard
+        }
+    }
+
+    private static func contentKind(_ type: UITextContentType?) -> HostFieldPolicy.ContentKind {
+        guard let type = type else { return .none }
+        switch type {
+        case .username: return .username
+        case .password, .newPassword: return .password
+        case .URL: return .url
+        case .emailAddress: return .email
+        case .oneTimeCode: return .oneTimeCode
+        default: return .other
+        }
+    }
+}

--- a/DictusKeyboard/KeyboardRootView.swift
+++ b/DictusKeyboard/KeyboardRootView.swift
@@ -359,14 +359,36 @@ struct KeyboardRootView: View {
     }
 
     /// Replaces the word currently being typed with a replacement string.
+    ///
+    /// Boundary-safe (#191): `currentWord` comes from SuggestionState's async
+    /// update and can be stale when the user typed fast between the suggestion
+    /// computation and the tap. Deleting a blind `currentWord.count` characters
+    /// could then eat into the preceding word. Validate against the live
+    /// context first; on mismatch, do nothing destructive — the suggestion bar
+    /// refreshes on the next keystroke.
     private func replaceCurrentWord(
         proxy: UITextDocumentProxy,
         currentWord: String,
         replacement: String,
         addSpace: Bool
     ) {
-        for _ in 0..<currentWord.count {
-            proxy.deleteBackward()
+        switch AutocorrectReplacement.check(
+            context: proxy.documentContextBeforeInput,
+            word: currentWord
+        ) {
+        case .ok(let deleteCount):
+            for _ in 0..<deleteCount {
+                proxy.deleteBackward()
+            }
+        case .failed(let reason):
+            #if DEBUG
+            AutocorrectDebugLog.replacementAborted(
+                word: currentWord,
+                reason: reason,
+                contextTail: DictusKeyboardBridge.contextTail(proxy.documentContextBeforeInput)
+            )
+            #endif
+            return
         }
         proxy.insertText(replacement)
         if addSpace {

--- a/DictusKeyboard/KeyboardViewController.swift
+++ b/DictusKeyboard/KeyboardViewController.swift
@@ -388,6 +388,10 @@ class KeyboardViewController: UIInputViewController {
         // until the view is about to appear. Calling in viewDidLoad would read stale data.
         bridge?.updateCapitalization()
 
+        // Read the host field's input traits now that the connection exists (#200).
+        // Search/URL/email fields disable autocorrect and suggestions.
+        bridge?.refreshHostPolicy()
+
         // Set default opening layer from user preference.
         // WHY here not viewDidLoad: viewWillAppear fires each time the keyboard appears,
         // allowing the user to change settings in the app and see the effect immediately.
@@ -768,6 +772,17 @@ class KeyboardViewController: UIInputViewController {
         // recheck autocapitalization. This ensures shift state stays correct even when
         // the user moves the cursor to a different position in the text.
         bridge?.updateCapitalization()
+        // The focused field may have changed (e.g. tapping another field in the
+        // same app) — re-read its input traits (#200).
+        bridge?.refreshHostPolicy()
+    }
+
+    override func selectionDidChange(_ textInput: UITextInput?) {
+        super.selectionDidChange(textInput)
+        // Some hosts move focus between fields without emitting textDidChange.
+        // Re-read the field's input traits so the autocorrect/suggestions policy
+        // matches the newly-focused field (#200).
+        bridge?.refreshHostPolicy()
     }
 
     // MARK: - Window Gesture Delay

--- a/DictusKeyboard/TextPrediction/SuggestionState.swift
+++ b/DictusKeyboard/TextPrediction/SuggestionState.swift
@@ -160,7 +160,11 @@ class SuggestionState: ObservableObject {
         // Check spell correction first (mirrors what handleSpace will do)
         if autocorrectEnabled,
            !rejectedWords.contains(partial.lowercased()),
-           let result = engine.spellCheck(partial, previousWord: previousWord),
+           let result = engine.spellCheck(
+               partial,
+               previousWord: previousWord,
+               isAtSentenceStart: ProperNounGuard.isAtSentenceStart(context: context, word: partial)
+           ),
            result.correction.lowercased() != partial.lowercased() {
             // Standard mobile layout: [original | correction (bold) | alternative]
             var correctionSuggestions = [partial, result.correction]
@@ -250,7 +254,11 @@ class SuggestionState: ObservableObject {
             let spellResult: (correction: String, alternatives: [String])?
             if self.autocorrectEnabled,
                !self.rejectedWords.contains(partial.lowercased()) {
-                spellResult = self.engine.spellCheck(partial, previousWord: previousWord)
+                spellResult = self.engine.spellCheck(
+                    partial,
+                    previousWord: previousWord,
+                    isAtSentenceStart: ProperNounGuard.isAtSentenceStart(context: context, word: partial)
+                )
             } else {
                 spellResult = nil
             }
@@ -303,8 +311,14 @@ class SuggestionState: ObservableObject {
 
     /// Spell check with optional previous word context for n-gram boosting.
     /// When previousWord is provided, correction candidates are reranked by bigram frequency.
-    func performSpellCheck(_ word: String, previousWord: String?) -> (correction: String, alternatives: [String])? {
-        return engine.spellCheck(word, previousWord: previousWord)
+    /// isAtSentenceStart drives the proper-noun guard (#199); defaults to true
+    /// (conservative — corrections stay enabled for callers without position info).
+    func performSpellCheck(
+        _ word: String,
+        previousWord: String?,
+        isAtSentenceStart: Bool = true
+    ) -> (correction: String, alternatives: [String])? {
+        return engine.spellCheck(word, previousWord: previousWord, isAtSentenceStart: isAtSentenceStart)
     }
 
     /// Resets the suggestion state to idle.

--- a/DictusKeyboard/TextPrediction/SuggestionState.swift
+++ b/DictusKeyboard/TextPrediction/SuggestionState.swift
@@ -64,6 +64,13 @@ class SuggestionState: ObservableObject {
     /// Cleared when the user starts typing a new word.
     var rejectedWords: Set<String> = []
 
+    /// Policy derived from the host field's input traits (#200).
+    /// Refreshed on the main thread by DictusKeyboardBridge/KeyboardViewController
+    /// whenever the field can have changed (appearance, text/selection change,
+    /// each keystroke). Cached here because updateAsync/updatePredictions run on
+    /// a background queue and cannot read UITextDocumentProxy themselves.
+    var hostPolicy: HostFieldPolicy = .allowed
+
     /// Shared engine — heavy resources (frequency dict, trie) are process-wide singletons
     /// to avoid the per-controller leak documented in #134.
     private let engine = TextPredictionEngine.shared
@@ -105,6 +112,13 @@ class SuggestionState: ObservableObject {
     /// center slot (bold) = what gets auto-applied on space. If the bar shows
     /// completions but space applies a different correction, that's confusing.
     func update(proxy: UITextDocumentProxy) {
+        // Host field traits gate (#200): search/URL/email fields get no suggestions.
+        hostPolicy = HostInputTraits.policy(for: proxy)
+        guard hostPolicy.suggestionsAllowed else {
+            clear()
+            return
+        }
+
         guard let context = proxy.documentContextBeforeInput, !context.isEmpty else {
             clear()
             return
@@ -179,6 +193,13 @@ class SuggestionState: ObservableObject {
     /// The synchronous update() is still used by delete/undo paths where fresh proxy
     /// context is needed immediately.
     func updateAsync(context: String?) {
+        // Host field traits gate (#200): reads the cached policy — this method
+        // dispatches to a background queue and cannot touch the proxy itself.
+        guard hostPolicy.suggestionsAllowed else {
+            clear()
+            return
+        }
+
         guard let context = context, !context.isEmpty else {
             clear()
             return
@@ -313,6 +334,12 @@ class SuggestionState: ObservableObject {
     /// word and running spell check, we extract the last 1-2 complete words and query
     /// the n-gram engine. The result is displayed in .predictions mode, not .corrections.
     func updatePredictions(context: String?) {
+        // Host field traits gate (#200): no next-word predictions in search/URL fields.
+        guard hostPolicy.suggestionsAllowed else {
+            clear()
+            return
+        }
+
         guard let context = context, !context.isEmpty else {
             clear()
             return

--- a/DictusKeyboard/TextPrediction/TextPredictionEngine.swift
+++ b/DictusKeyboard/TextPrediction/TextPredictionEngine.swift
@@ -104,7 +104,16 @@ class TextPredictionEngine {
     /// The trie walks candidates during lookup with keyboard proximity scoring,
     /// supporting 100K+ words in ~0.4 MiB per language via mmap. SymSpell pre-generated
     /// all edit-distance deletes, using 15 MiB for just 10K words.
-    func spellCheck(_ word: String) -> (correction: String, alternatives: [String])? {
+    /// - Parameter isAtSentenceStart: whether the word sits at a sentence start
+    ///   in the host document (start-of-field, after newline or after .!?).
+    ///   Drives the proper-noun guard (#199): mid-sentence capitalized unknown
+    ///   words are preserved. Defaults to `true`, the conservative value —
+    ///   callers without position info keep full correction behavior (only the
+    ///   position-independent acronym rule applies).
+    func spellCheck(
+        _ word: String,
+        isAtSentenceStart: Bool = true
+    ) -> (correction: String, alternatives: [String])? {
         guard !word.isEmpty else { return nil }
 
         // Language-specific overrides bypass everything — e.g., "ca" is never valid French.
@@ -178,6 +187,22 @@ class TextPredictionEngine {
         if aospTrieEngine.wordExists(wordToCheck) {
             #if DEBUG
             AutocorrectDebugLog.autocorrectSkipped(word: word, reason: "already-valid")
+            #endif
+            return nil
+        }
+
+        // Proper-noun guard (#199): only unknown words reach this point.
+        // An unknown capitalized word mid-sentence ("vu Mathilde") or an
+        // all-caps acronym ("SNCF") is most likely intentional — preserve it
+        // instead of forcing the closest dictionary word. Runs AFTER
+        // languageOverride/UserDictionary (explicit corrections and learned
+        // words still win) and after accent expansion (accent-only fixes like
+        // "Helene" -> "Hélène" are high-confidence and keep working). The
+        // preserved word is then learned via handleSpace's recordUsage path,
+        // protecting future occurrences even at sentence start.
+        if ProperNounGuard.isLikelyProperNoun(word: word, isAtSentenceStart: isAtSentenceStart) {
+            #if DEBUG
+            AutocorrectDebugLog.autocorrectSkipped(word: word, reason: "likely-proper-noun")
             #endif
             return nil
         }
@@ -302,8 +327,12 @@ class TextPredictionEngine {
     /// Strategy 2 is the key insight: instead of asking "what are the corrections for sui?"
     /// and hoping "suis" appears, we ask "what does the n-gram model predict after je?"
     /// and check if any prediction (like "suis") is close to what was typed ("sui").
-    func spellCheck(_ word: String, previousWord: String?) -> (correction: String, alternatives: [String])? {
-        let result = spellCheck(word)
+    func spellCheck(
+        _ word: String,
+        previousWord: String?,
+        isAtSentenceStart: Bool = true
+    ) -> (correction: String, alternatives: [String])? {
+        let result = spellCheck(word, isAtSentenceStart: isAtSentenceStart)
 
         // If no previous word context or n-grams not loaded, return standard result
         guard let prev = previousWord, !prev.isEmpty, aospTrieEngine.ngramsLoaded else {


### PR DESCRIPTION
## Summary

Fixes the autocorrect trio from the 2026-07-23 triage — three high-priority keyboard bugs sharing the same pipeline, one commit per issue:

- **#200 — Respect host field autocorrection traits.** New `HostFieldPolicy` (DictusCore, pure, 10 unit tests) maps the host field's `UITextInputTraits` to an autocorrect/suggestions policy with explicit precedence: `secureTextEntry` > `autocorrectionType == .no` > `textContentType` (username/password/URL/email/OTP) > `keyboardType` (URL/email/webSearch/twitter/number/phone pads) > `spellCheckingType == .no` (autocorrect off, suggestions kept). `HostInputTraits` (keyboard target) is the thin UIKit shim. The policy is cached on `SuggestionState` for the background suggestion queue, gated in `handleSpace` with a live read, and refreshed on `viewWillAppear` / `textDidChange` / new `selectionDidChange` override.

- **#191 — Boundary-safe replacement.** `handleSpace` used to delete `freshWord.count` characters blindly; under proxy desync (rapid delete/retype producing phantom words like `quee`) it ate the space before the word (`pense quee` → `penseque`). New `AutocorrectReplacement.check` (DictusCore, 14 unit tests incl. decomposed Unicode) re-validates the LIVE context right before deleting: suffix must match, preceding char must be a boundary. On failure the correction is skipped and a plain space inserted — never a destructive guess. The suggestion-bar tap path (`replaceCurrentWord`) had the same unverified loop on a staler word source and is now guarded identically.

- **#199 — Proper-noun guard.** New `ProperNounGuard` (DictusCore, 16 unit tests): unknown capitalized words (3+ letters) typed mid-sentence and all-caps acronyms (any position) are preserved instead of corrected. Sentence position mirrors the autocap rules and is threaded from `handleSpace` and both suggestion-preview paths (`isAtSentenceStart` param, defaulting to the conservative value). Ordering keeps `languageOverride` ("ca"→"ça"), UserDictionary and accent expansion ahead of the guard, so those still win; sentence-start typos ("Jai" → "J'ai") keep correcting. Preserved names are learned via the existing `recordUsage` path, protecting later occurrences everywhere.

## Validation done (agent)

- `swift test`: 359 tests, 0 failures (40 new).
- Full `xcodebuild` Debug build of DictusApp scheme (app + keyboard + widgets): **BUILD SUCCEEDED**.
- SwiftLint on touched files: no new violations beyond pre-existing size warnings (`handleSpace` was already near the function-length limit; the apply block is now extracted into `applyAutocorrect`).
- Simulator smoke test: DictusApp installs and launches cleanly on iPhone 17 and iPad Pro 11" (screenshots checked, no crash). Keyboard typing behavior itself cannot be driven headlessly — hence the device checklist below.

## Device validation checklist (Pierre — French keyboard, autocorrect ON)

**#191 — boundary safety** (enable Settings > debug autocorrect logging first)
- [x] Type `Oui je connais, mais je pense que`, edit the final `que` into `quee` (retype the `e`), press space → expect `... je pense que ` with the space intact.
- [x] Same with `je pense laa` + space → `je pense la ` (space intact).
- [x] Type `la théori` + space → `la théorie ` (accented replacement, space intact).
- [x] After an autocorrection, tap the suggestion bar undo slot → original word restored (undo still works).
- [x] In the debug log, look for `AUTOCORRECT-APPLY-BEFORE/AFTER-DELETE/AFTER-INSERT`; if you can reproduce the desync, `AUTOCORRECT-ABORT reason=suffix-mismatch` should appear INSTEAD of a merged word.

**#199 — proper nouns**
- [x] `J'ai vu Mathilde` + space → Mathilde preserved (log: `AUTOCORRECT-SKIP reason=likely-proper-noun`).
- [x] `Tu peux demander à Romain` + space → Romain preserved.
- [x] `Je bosse avec Pivi` + space → Pivi preserved.
- [x] `La SNCF est en grève` → SNCF preserved.
- [x] New sentence starting `Jai` + space → still corrected to `J'ai`.
- [x] `ca` / `Ca` → still corrected to `ça` / `Ça`.
- [x] Type a name once mid-sentence, then start a new sentence with that same name → preserved (learned).

**#200 — host field traits**
- [x] Safari address/search bar: suggestion bar empty (language switcher shows), typos NOT corrected on space.
- [x] Instagram / X / TikTok search field: same (no suggestions, no autocorrect).
- [x] An email or username login field: no autocorrect.
- [x] Messages / Notes / WhatsApp normal text field: suggestions + autocorrect work exactly as before.
- [x] Switch between a search field and a normal field in the same app → the bar disappears/reappears accordingly (log: `HOST-TRAITS ... reason=...`).

**Regression sweep (files touched: handleSpace, suggestion bar, engine)**
- [x] Normal typo correction on space still works (`bonjout` → `bonjour`).
- [x] Double-space → period + capital next word.
- [x] Word completions and next-word predictions still appear and insert correctly from the bar.
- [x] Dictation insert unaffected.
- [x] Quick iPad sim pass: keyboard opens, no layout loop.

## Known limitations (documented in code)
- `M. Dupont`: the abbreviation period reads as a sentence end, so `Dupont` is not protected by the mid-sentence rule (first occurrence only; learning covers the rest).
- Mixed-case tokens (`McDo`, `iPhone`-style) are outside the conservative capitalized-word rule.
- #191 makes replacement defensive against proxy desync; the root cause of the phantom duplicated-letter candidates remains a separate investigation (out of scope per the issue brief).

Fixes #191. Fixes #199. Fixes #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
