### PR TITLE
feat(keyboard): remove autocorrect haptic, visual correction affordance in suggestion bar

### DIFF
--- a/DictusKeyboard/DictusKeyboardBridge.swift
+++ b/DictusKeyboard/DictusKeyboardBridge.swift
@@ -706,7 +706,12 @@ final class DictusKeyboardBridge: NSObject,
             correctedWord: correction,
             insertedSpace: true
         )
-        HapticFeedback.autocorrectApplied()
+        // No haptic on autocorrect (#224): the spacebar touchDown tick already fired
+        // ~100ms earlier, and stacking a second haptic reads as a keyboard glitch.
+        // Feedback is visual instead — the suggestion bar pulses its undo chip
+        // (SuggestionBarView). HapticFeedback.autocorrectApplied() is kept in
+        // DictusCore so re-adding is a one-line change if dogfooding shows
+        // silent correction hurts awareness.
         // Trigger n-gram predictions after autocorrection too.
         // The corrected word + space is now in the proxy — predict what comes next.
         state.clear()

--- a/DictusKeyboard/Views/SuggestionBarView.swift
+++ b/DictusKeyboard/Views/SuggestionBarView.swift
@@ -1,6 +1,7 @@
 // DictusKeyboard/Views/SuggestionBarView.swift
 // Displays up to 3 word/accent suggestions in a horizontal row within the toolbar.
 import SwiftUI
+import DictusCore
 
 /// A 3-slot suggestion bar that appears in the toolbar while the user is typing.
 ///
@@ -12,10 +13,24 @@ import SwiftUI
 /// WHY .frame(maxWidth: .infinity) per slot:
 /// This ensures all slots take equal width regardless of text length,
 /// matching Apple's native keyboard suggestion bar layout.
+///
+/// Visual states per mode:
+/// - completions: bold best completion in slot 1, others regular.
+/// - corrections: quoted original in slot 0, bold correction in slot 1.
+/// - predictions: all slots equal weight.
+/// - undoAvailable: slot 0 is the "undo chip" — accent-tinted with an
+///   undo arrow icon. It pulses briefly when a correction is applied (#224):
+///   autocorrect fires no haptic, so this pulse is the correction feedback.
+///   It says both "we corrected this" and "tap here to revert".
 struct SuggestionBarView: View {
     let suggestions: [String]
     let mode: SuggestionMode
     let onTap: (Int) -> Void
+
+    /// True during the brief flash of the undo chip right after a correction.
+    /// The chip rises to a stronger tint + slight scale, then eases back to
+    /// its resting tint (which persists while undo is available).
+    @State private var undoPulseActive = false
 
     var body: some View {
         if suggestions.isEmpty {
@@ -34,20 +49,7 @@ struct SuggestionBarView: View {
                     Button {
                         onTap(index)
                     } label: {
-                        // In correction mode:
-                        //   index 0 = original word in quotes (tapping keeps it as-is)
-                        //   index 1 = bold correction (auto-applied on space)
-                        //   index 2 = alternative correction
-                        // In completion mode:
-                        //   index 1 = bold (best completion)
-                        //   others = regular weight
-                        // In prediction mode:
-                        //   All equal weight -- no "auto-applied" word, all are suggestions
-                        // This matches standard iOS keyboard suggestion bar behavior.
-                        Text(displayText(suggestion, at: index))
-                            .font(.system(size: 15))
-                            .fontWeight(fontWeight(at: index))
-                            .foregroundColor(Color(.label))
+                        slotLabel(suggestion, at: index)
                             .frame(maxWidth: .infinity)
                             .frame(height: 36)
                             .contentShape(Rectangle())
@@ -57,6 +59,87 @@ struct SuggestionBarView: View {
             }
             .transition(.opacity)
             .animation(.easeInOut(duration: 0.15), value: suggestions)
+            // The bar leaves the hierarchy between correction and undoAvailable
+            // (suggestions are cleared, then repopulated async), so entry into
+            // undo mode is usually a fresh onAppear. onChange covers in-place
+            // transitions (e.g. predictions -> undoAvailable without emptying).
+            .onAppear {
+                if mode == .undoAvailable { triggerUndoPulse() }
+            }
+            .onChange(of: mode) { _, newMode in
+                if newMode == .undoAvailable { triggerUndoPulse() }
+            }
+        }
+    }
+
+    // MARK: - Slot rendering
+
+    /// Renders one suggestion slot. The undo chip (slot 0 in undo mode) gets
+    /// dedicated styling; all other slots are plain text.
+    @ViewBuilder
+    private func slotLabel(_ suggestion: String, at index: Int) -> some View {
+        if mode == .undoAvailable && index == 0 {
+            undoChip(word: suggestion)
+        } else {
+            // In correction mode:
+            //   index 0 = original word in quotes (tapping keeps it as-is)
+            //   index 1 = bold correction (auto-applied on space)
+            //   index 2 = alternative correction
+            // In completion mode:
+            //   index 1 = bold (best completion)
+            //   others = regular weight
+            // In prediction mode:
+            //   All equal weight -- no "auto-applied" word, all are suggestions
+            // This matches standard iOS keyboard suggestion bar behavior.
+            Text(displayText(suggestion, at: index))
+                .font(.system(size: 15))
+                .fontWeight(fontWeight(at: index))
+                .foregroundColor(Color(.label))
+        }
+    }
+
+    /// The undo chip: original word + undo arrow on an accent-tinted capsule.
+    ///
+    /// WHY a tinted chip instead of plain text (#224):
+    /// Autocorrect no longer fires a haptic, so the bar is the only surface
+    /// that signals "a word was just corrected". The persistent accent tint
+    /// keeps the revert action discoverable for as long as undo is available;
+    /// the entry pulse marks the moment of correction itself.
+    private func undoChip(word: String) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: "arrow.uturn.backward")
+                .font(.system(size: 12, weight: .semibold))
+            Text(word)
+                .font(.system(size: 15, weight: .semibold))
+                .lineLimit(1)
+        }
+        .foregroundColor(.dictusAccent)
+        .frame(maxWidth: .infinity)
+        .frame(height: 36)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.dictusAccent.opacity(undoPulseActive ? 0.35 : 0.12))
+                .padding(.horizontal, 4)
+                .padding(.vertical, 3)
+        )
+        .scaleEffect(undoPulseActive ? 1.05 : 1.0)
+    }
+
+    /// Flashes the undo chip: instant rise (reads as an event, not a fade-in),
+    /// then a ~0.45s ease back to the resting tint.
+    ///
+    /// WHY withTransaction for the rise:
+    /// The enclosing bar animates on `suggestions` changes; disabling animations
+    /// for the rise guarantees the flash starts at full strength immediately.
+    private func triggerUndoPulse() {
+        var rise = Transaction()
+        rise.disablesAnimations = true
+        withTransaction(rise) { undoPulseActive = true }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
+            withAnimation(.easeOut(duration: 0.45)) {
+                undoPulseActive = false
+            }
         }
     }
 
@@ -77,9 +160,6 @@ struct SuggestionBarView: View {
     private func displayText(_ suggestion: String, at index: Int) -> String {
         if mode == .corrections && index == 0 {
             return "\u{201C}\(suggestion)\u{201D}"
-        }
-        if mode == .undoAvailable && index == 0 {
-            return suggestion + " \u{21A9}"
         }
         return suggestion
     }


### PR DESCRIPTION
## Summary

Closes #224

Implements the locked decision from the UX discussion: autocorrect becomes silent (no haptic), and the suggestion bar takes over correction feedback visually.

### 1. Haptic removal
- `DictusKeyboardBridge.applyAutocorrect` no longer calls `HapticFeedback.autocorrectApplied()`. The haptic stacked with the spacebar touchDown tick (~100ms apart), which read as a keyboard glitch.
- The generator function stays in `DictusCore/HapticFeedback.swift`, so re-adding it after dogfooding is a one-line change.
- All key haptics are untouched.

### 2. Visual correction affordance (undo chip)
In `SuggestionBarView`, slot 0 in `undoAvailable` mode is now a dedicated undo chip:
- Accent-tinted rounded background (`dictusAccent` at 12% opacity, persistent while undo is available).
- `arrow.uturn.backward` SF Symbol + the original word in accent semibold (replaces the previous plain-text `word ↩`).
- At the moment of correction (bar entering `undoAvailable`), the chip pulses: instant rise to a 35% tint + 1.05 scale, then ~0.45s ease back to the resting tint. The pulse marks "we corrected this" and points at "tap here to revert".

Tap behavior is unchanged: slot 0 reverts the correction, slots 1-2 accept completions/predictions. No new user-facing strings (icon only), no new files.

## How to test

On device (and iPad simulator for layout):
1. Enable autocorrect, type a misspelled word (e.g. `bonjuor`) and press space.
2. Expect: NO haptic at correction time beyond the normal spacebar tick; the corrected word is inserted; the suggestion bar shows the undo chip (accent tint + undo arrow + original word) in slot 0, with a brief flash/scale pulse right as the correction lands.
3. Tap the chip: the correction reverts to the original word, as before.
4. Keep typing instead: the chip stays tinted (discoverable) until the undo window closes (next space/word).
5. Regression: normal key taps, spacebar, delete still produce their usual haptics; completions/corrections/predictions modes render as before (quoted original + bold correction, etc.).
6. iPad: check the toolbar/suggestion bar renders correctly and the chip pulse does not disturb layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjKuGKXuj5uT4K8Wb7UNiF
