### PR TITLE
feat(premium): hide paywall entry points behind visibility flag

### DIFF
--- a/DictusApp/Subscription/SubscriptionManager.swift
+++ b/DictusApp/Subscription/SubscriptionManager.swift
@@ -4,6 +4,25 @@ import Foundation
 import StoreKit
 import DictusCore
 
+/// Compile-time visibility flags for premium UI (issue #236).
+///
+/// WHY a compile-time constant instead of remote config:
+/// No Pro feature exists yet (#79) and App Store Connect setup is pending (#215),
+/// so the paywall would render with empty prices. A single `static let` is enough
+/// to hide every entry point (Home banner, Settings Pro section, locked rows)
+/// while keeping all subscription code compiled and intact.
+///
+/// Re-enable: flip `paywallVisible` to `true` in the PR that ships the first
+/// real Pro feature, once #215 (ASC setup) is done. See #79/#215/#216.
+///
+/// WHY an enum with no cases: a caseless enum can never be instantiated,
+/// making it a pure namespace for static constants (common Swift pattern).
+enum PremiumFlags {
+    /// Controls whether users can see and reach the paywall.
+    /// `false` = the app looks like there is no subscription at all.
+    static let paywallVisible = false
+}
+
 /// Manages all StoreKit 2 interactions for the Dictus Pro subscription.
 ///
 /// WHY @MainActor:

--- a/DictusApp/Views/HomeView.swift
+++ b/DictusApp/Views/HomeView.swift
@@ -40,8 +40,12 @@ struct HomeView: View {
                 testDictationLink
             }
 
-            // Pro banner (hidden when subscribed)
-            ProBannerView()
+            // Pro banner (hidden when subscribed).
+            // Gated behind PremiumFlags.paywallVisible until the first Pro
+            // feature ships and ASC setup is done (#236, #79, #215).
+            if PremiumFlags.paywallVisible {
+                ProBannerView()
+            }
 
             Spacer()
         }

--- a/DictusApp/Views/SettingsView.swift
+++ b/DictusApp/Views/SettingsView.swift
@@ -72,20 +72,24 @@ struct SettingsView: View {
 
     var body: some View {
         List {
-            // Section 0: Dictus Pro — always first
-            Section {
-                NavigationLink {
-                    PaywallView()
-                } label: {
-                    HStack {
-                        Image(systemName: "crown.fill")
-                            .foregroundColor(.dictusAccent)
-                        Text("Dictus Pro")
-                        Spacer()
-                        if proStatus.isProActive {
-                            Image(systemName: "checkmark.circle.fill")
-                                .foregroundColor(.dictusSuccess)
-                                .accessibilityLabel("Pro active")
+            // Section 0: Dictus Pro — always first.
+            // Gated behind PremiumFlags.paywallVisible until the first Pro
+            // feature ships and ASC setup is done (#236, #79, #215).
+            if PremiumFlags.paywallVisible {
+                Section {
+                    NavigationLink {
+                        PaywallView()
+                    } label: {
+                        HStack {
+                            Image(systemName: "crown.fill")
+                                .foregroundColor(.dictusAccent)
+                            Text("Dictus Pro")
+                            Spacer()
+                            if proStatus.isProActive {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundColor(.dictusSuccess)
+                                    .accessibilityLabel("Pro active")
+                            }
                         }
                     }
                 }
@@ -175,44 +179,51 @@ struct SettingsView: View {
                 }
             }
 
-            // Section 3: Pro Features
-            Section("Pro Features") {
-                ForEach(ProFeature.allCases, id: \.self) { feature in
-                    if proStatus.isProActive {
-                        // Unlocked: show toggle
-                        Toggle(isOn: Binding(
-                            get: { AppGroup.defaults.bool(forKey: feature.settingsKey) },
-                            set: { AppGroup.defaults.set($0, forKey: feature.settingsKey) }
-                        )) {
-                            HStack(spacing: 8) {
-                                Image(systemName: feature.icon)
-                                    .foregroundColor(.dictusAccent)
-                                Text(LocalizedStringKey(feature.displayName))
+            // Section 3: Pro Features.
+            // Gated behind PremiumFlags.paywallVisible (#236): while hidden,
+            // the app must look like there is no subscription at all — no
+            // locked rows, no PRO pills, no navigation path to PaywallView.
+            // Pro toggles are also hidden: no user can be Pro while the
+            // paywall is unreachable (no ASC product exists yet, #215).
+            if PremiumFlags.paywallVisible {
+                Section("Pro Features") {
+                    ForEach(ProFeature.allCases, id: \.self) { feature in
+                        if proStatus.isProActive {
+                            // Unlocked: show toggle
+                            Toggle(isOn: Binding(
+                                get: { AppGroup.defaults.bool(forKey: feature.settingsKey) },
+                                set: { AppGroup.defaults.set($0, forKey: feature.settingsKey) }
+                            )) {
+                                HStack(spacing: 8) {
+                                    Image(systemName: feature.icon)
+                                        .foregroundColor(.dictusAccent)
+                                    Text(LocalizedStringKey(feature.displayName))
+                                }
                             }
-                        }
-                    } else {
-                        // Locked: show lock + PRO pill, tap opens paywall
-                        NavigationLink {
-                            PaywallView()
-                        } label: {
-                            HStack(spacing: 8) {
-                                Image(systemName: feature.icon)
-                                    .foregroundColor(.secondary)
-                                Text(LocalizedStringKey(feature.displayName))
-                                    .foregroundColor(.primary)
-                                Spacer()
-                                Image(systemName: "lock.fill")
-                                    .font(.caption)
-                                    .foregroundColor(.dictusAccent)
-                                    .accessibilityHidden(true)
-                                Text("PRO")
-                                    .font(.system(size: 10, weight: .bold))
-                                    .foregroundColor(.white)
-                                    .padding(.vertical, 2)
-                                    .padding(.horizontal, 6)
-                                    .background(Color.dictusAccent)
-                                    .clipShape(Capsule())
-                                    .accessibilityLabel("Pro feature")
+                        } else {
+                            // Locked: show lock + PRO pill, tap opens paywall
+                            NavigationLink {
+                                PaywallView()
+                            } label: {
+                                HStack(spacing: 8) {
+                                    Image(systemName: feature.icon)
+                                        .foregroundColor(.secondary)
+                                    Text(LocalizedStringKey(feature.displayName))
+                                        .foregroundColor(.primary)
+                                    Spacer()
+                                    Image(systemName: "lock.fill")
+                                        .font(.caption)
+                                        .foregroundColor(.dictusAccent)
+                                        .accessibilityHidden(true)
+                                    Text("PRO")
+                                        .font(.system(size: 10, weight: .bold))
+                                        .foregroundColor(.white)
+                                        .padding(.vertical, 2)
+                                        .padding(.horizontal, 6)
+                                        .background(Color.dictusAccent)
+                                        .clipShape(Capsule())
+                                        .accessibilityLabel("Pro feature")
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Closes #236

## Summary

develop ships the full paywall UI (#78) and StoreKit gating (#55), but no Pro feature exists yet (#79) and App Store Connect setup is pending (#215). This PR hides every paywall entry point behind a single compile-time flag so TestFlight builds can ship without advertising a subscription that cannot be purchased.

- New `PremiumFlags.paywallVisible` (caseless enum, `static let`, default `false`) in `DictusApp/Subscription/SubscriptionManager.swift` — the subscription domain file both views already reach, so no new file / pbxproj churn.
- Gated entry points:
  1. `HomeView` — the `ProBannerView()` on the home screen.
  2. `SettingsView` — the "Dictus Pro" section (crown icon, first section).
  3. `SettingsView` — the whole "Pro Features" section (locked rows with lock + PRO pill that push `PaywallView`; the unlocked toggles too, since no user can be Pro while the paywall is unreachable).
- Nothing deleted or commented out: `PaywallView`, `ProBannerView`, `SubscriptionManager`, `ProStatusManager` and all gating logic stay compiled and untouched. StoreKit launch checks remain silent background work (failures only go to `PersistentLog`, never to the UI).

## Re-enable procedure

Flip `PremiumFlags.paywallVisible` to `true` in `DictusApp/Subscription/SubscriptionManager.swift` (one line) — to be done in the PR that ships the first real Pro feature (#79), after ASC setup (#215) is complete. Related: #216 (Pro hub).

## How to test

- Home tab: no "Unlock Dictus Pro" banner.
- Settings: no "Dictus Pro" section at the top, no "Pro Features" section (no locked rows / PRO pills).
- No navigation path reaches `PaywallView` anywhere in the app.
- Flip the flag to `true` locally: today's behavior is restored exactly (banner, Pro section, locked rows).
- Build verified on iPhone 17 simulator in both flag states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjKuGKXuj5uT4K8Wb7UNiF