### PR TITLE
chore: add CodeRabbit configuration (refs #234)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,45 @@
+language: "en-US"
+
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  auto_review:
+    enabled: true
+    # The repo's default branch is main (App Store releases), but day-to-day
+    # PRs target develop (TestFlight) — review both.
+    base_branches:
+      - "main"
+      - "develop"
+  path_filters:
+    # Generated / mechanical files: no review value, lots of noise.
+    - "!Dictus.xcodeproj/**"
+    - "!**/*.xcstrings"
+    - "!.swiftlint-baseline.json"
+  path_instructions:
+    - path: "DictusKeyboard/**"
+      instructions: |
+        This is an iOS keyboard extension with a hard ~50MB memory budget and no
+        UIApplication.shared access. Flag anything that could grow resident
+        memory (large buffers, caches, retained images) or that calls app-only
+        APIs. The live keyboard layout system is the vendored
+        KeyboardLayouts.swift; Models/KeyboardLayout.swift is legacy dead code —
+        flag any change that touches the dead file expecting a behavior change.
+    - path: "**/*.swift"
+      instructions: |
+        Project conventions: no force unwraps (!) except with a justification
+        comment; code comments in English; user-facing strings must exist in
+        BOTH French and English in the xcstrings catalogs (flag hardcoded
+        user-facing literals). Style (whitespace, line length, trailing commas)
+        is enforced by SwiftLint in CI — do not comment on pure style.
+    - path: "DictusApp/**"
+      instructions: |
+        The app performs STT inference app-side (WhisperKit + FluidAudio/Parakeet)
+        because the keyboard extension cannot. Audio session handling and
+        background recording are fragile, historically bug-prone areas: review
+        AVAudioSession, Live Activity, and Darwin-notification changes with
+        extra care for state desync between the app and the keyboard extension.
+
+chat:
+  auto_reply: true


### PR DESCRIPTION
Adds `.coderabbit.yaml` implementing step 2 of the plan in #234.

## What it configures

- **Auto-review on `develop`** — CodeRabbit's default only reviews PRs targeting the default branch (`main`); this repo's day-to-day PRs target `develop` (see the skipped review on #237).
- **Chill profile**, no request-changes workflow, no poem.
- **Path filters**: skips `project.pbxproj`, `*.xcstrings`, `.swiftlint-baseline.json` (generated/mechanical noise).
- **Repo-convention instructions**: 50MB keyboard-extension memory budget + dead `Models/KeyboardLayout.swift` trap, no force unwraps without justification, FR+EN xcstrings requirement, style left to SwiftLint, audio-session/Live-Activity fragility in DictusApp.

## How to test

This PR itself should get a CodeRabbit auto-review (it reads the YAML from the PR branch) — that's the acceptance test. Signal/noise to be validated on the next 2-3 real PRs per #234's criteria.

Refs #234 (issue stays open until signal/noise is validated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjKuGKXuj5uT4K8Wb7UNiF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code review configuration with customized review behavior and reporting.
  * Enabled automatic replies for review conversations.
  * Added guidance for reviewing key application areas and excluded generated or mechanical files from review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->