### PR TITLE
feat(keyboard): undo the last dictation insertion from the toolbar (refs #266)

### DIFF
--- a/DictusCore/Sources/DictusCore/DictationUndo.swift
+++ b/DictusCore/Sources/DictusCore/DictationUndo.swift
@@ -1,0 +1,111 @@
+// DictusCore/Sources/DictusCore/DictationUndo.swift
+// Safety check for undoing the last dictation insertion (issue #266).
+//
+// WHAT THIS PROTECTS AGAINST:
+// The undo control deletes text the user cannot see being counted. If the
+// keyboard deletes `insertedText.count` characters without first proving that
+// those characters are still the ones sitting at the caret, it eats whatever
+// the user typed, pasted or moved the caret in front of instead. Deleting the
+// wrong text from someone's message is worse than offering no undo at all, so
+// the check below is the feature rather than a guard on it.
+//
+// THE INVARIANT:
+// Before the control is shown, and again immediately before it acts, the caller
+// re-reads the LIVE `documentContextBeforeInput` and this function confirms the
+// inserted string is still the tail of the field. Any doubt fails closed.
+//
+// THE BOUNDED WINDOW:
+// `documentContextBeforeInput` returns a bounded amount of text, and some hosts
+// return only as far back as the last line break. A two-minute dictation is
+// therefore routinely longer than anything the proxy will show. Refusing to undo
+// in that case would disable the feature exactly where holding backspace hurts
+// most, so a truncated window is accepted on a weaker guarantee: the whole
+// visible window must be a suffix of what was inserted. The result says which
+// of the two guarantees was obtained, so a partial verification is never
+// silently mistaken for a full one.
+
+import Foundation
+
+public enum DictationUndo {
+
+    /// Result of validating a pending dictation undo against the live context.
+    public enum CheckResult: Equatable {
+        /// Safe to undo: issue exactly `deleteCount` `deleteBackward()` calls
+        /// (one per grapheme cluster).
+        ///
+        /// - `verifiedCount`: how many trailing graphemes were actually matched
+        ///   against the document. Equal to `deleteCount` on a full match, lower
+        ///   when the proxy's window was too small to show the whole insertion.
+        /// - `windowTruncated`: true when the document context ran out before the
+        ///   insertion did, i.e. `verifiedCount < deleteCount`.
+        case ok(deleteCount: Int, verifiedCount: Int, windowTruncated: Bool)
+
+        /// Unsafe: show nothing, delete nothing. `reason` is a machine-readable
+        /// slug for device logs ("empty-insertion", "no-context",
+        /// "suffix-mismatch", "window-too-short", "truncated-mismatch").
+        case failed(reason: String)
+    }
+
+    /// How much of a truncated window must match before a partial verification is
+    /// accepted.
+    ///
+    /// WHY a floor at all: a short window is cheap to match by accident. A field
+    /// ending in ". " matches the tail of half the transcriptions this app
+    /// produces. Two dozen graphemes of running text is not something a different
+    /// field coincidentally ends with.
+    ///
+    /// This only ever applies to the truncated branch. A full match of a
+    /// three-character insertion is still a full match.
+    public static let minimumTruncatedMatch = 24
+
+    /// Validates that `insertedText` is still the tail of the field.
+    ///
+    /// - Parameters:
+    ///   - context: the LIVE `documentContextBeforeInput`, re-read at the moment
+    ///     of the check — never a value captured when the text was inserted.
+    ///   - insertedText: the exact string handed to `insertText`, separator
+    ///     included. `DictationCoordinator` appends the separator before writing
+    ///     to the App Group, so this is the whole of what reached the field.
+    public static func verify(
+        context: String?,
+        insertedText: String,
+        minimumTruncatedMatch: Int = minimumTruncatedMatch
+    ) -> CheckResult {
+        guard !insertedText.isEmpty else {
+            return .failed(reason: "empty-insertion")
+        }
+        // No context means no proof. Secure fields report nothing at all, and a
+        // host that reports nothing is exactly the host whose text must not be
+        // deleted on a guess.
+        guard let context = context, !context.isEmpty else {
+            return .failed(reason: "no-context")
+        }
+
+        let insertedCount = insertedText.count
+
+        // The window shows at least as much as we inserted: full verification.
+        // String comparison uses canonical equivalence, so a host reporting
+        // decomposed accents still matches a precomposed insertion — and both
+        // normalisations have the same grapheme count, which is what
+        // deleteBackward() consumes.
+        if context.count >= insertedCount {
+            guard context.hasSuffix(insertedText) else {
+                return .failed(reason: "suffix-mismatch")
+            }
+            return .ok(deleteCount: insertedCount, verifiedCount: insertedCount, windowTruncated: false)
+        }
+
+        // The window ran out first. Everything it does show has to be the tail of
+        // what we inserted; anything else means the field is no longer ours.
+        guard context.count >= minimumTruncatedMatch else {
+            return .failed(reason: "window-too-short")
+        }
+        guard insertedText.hasSuffix(context) else {
+            return .failed(reason: "truncated-mismatch")
+        }
+        // The delete count is still the full insertion. Deleting only the verified
+        // part would leave the head of the transcription stranded in the field,
+        // which is not an undo.
+        return .ok(deleteCount: insertedCount, verifiedCount: context.count, windowTruncated: true)
+    }
+}

--- a/DictusCore/Sources/DictusCore/DictationUndo.swift
+++ b/DictusCore/Sources/DictusCore/DictationUndo.swift
@@ -23,6 +23,20 @@
 // visible window must be a suffix of what was inserted. The result says which
 // of the two guarantees was obtained, so a partial verification is never
 // silently mistaken for a full one.
+//
+// WHAT THE TRUNCATED BRANCH DOES NOT PROVE, AND WHO FINISHES THE PROOF:
+// It says the tail of the field is the tail of the insertion. It says nothing
+// about the characters further back, which are exactly the ones a
+// `deleteCount` of the full insertion would go on to delete. On its own that
+// permits over-deletion: a field ending in text that merely resembles the
+// insertion's tail would authorise deleting a length that reaches past it.
+// The count returned here is therefore an intention, not a licence. The caller
+// (`KeyboardState.deleteInsertedText`) deletes in chunks and calls back here
+// between them with the part still to go, and the proxy's window slides back
+// over that text as the deletion proceeds — so every character removed has been
+// seen, at some point, at the tail of the field. A caller that deletes the
+// whole count in one go on the strength of a truncated verification is using
+// this wrongly.
 
 import Foundation
 

--- a/DictusCore/Sources/DictusCore/DictationUndo.swift
+++ b/DictusCore/Sources/DictusCore/DictationUndo.swift
@@ -24,19 +24,31 @@
 // of the two guarantees was obtained, so a partial verification is never
 // silently mistaken for a full one.
 //
-// WHAT THE TRUNCATED BRANCH DOES NOT PROVE, AND WHO FINISHES THE PROOF:
+// WHAT THE TRUNCATED BRANCH DOES NOT PROVE:
 // It says the tail of the field is the tail of the insertion. It says nothing
-// about the characters further back, which are exactly the ones a
-// `deleteCount` of the full insertion would go on to delete. On its own that
-// permits over-deletion: a field ending in text that merely resembles the
-// insertion's tail would authorise deleting a length that reaches past it.
-// The count returned here is therefore an intention, not a licence. The caller
-// (`KeyboardState.deleteInsertedText`) deletes in chunks and calls back here
-// between them with the part still to go, and the proxy's window slides back
-// over that text as the deletion proceeds — so every character removed has been
-// seen, at some point, at the tail of the field. A caller that deletes the
-// whole count in one go on the strength of a truncated verification is using
-// this wrongly.
+// about the characters further back, which are exactly the ones a `deleteCount`
+// of the full insertion goes on to delete.
+//
+// The first design answered that by re-proving the remainder between deletion
+// chunks, on the assumption that the proxy's window slides back over the
+// document as the deletion consumes it. Three device captures in Notes
+// (2026-08-02) disproved the assumption arithmetically: the window measured
+// 491, 496 and 490 graphemes when each burst started and 11, 16 and 10 when it
+// stopped — the starting window minus the 480 removed, exactly. That host
+// serves one cached window and trims it; it never refetches, and a caret round
+// trip did not make it. So the requirement was unmeetable there, and its price
+// was the feature: a 4752-grapheme undo removed 480 and left 4272 behind.
+//
+// The caller now stops only on a refusal that PROVES the field changed
+// (`suffix-mismatch`, `truncated-mismatch`) and continues through refusals that
+// merely mean the document could not be read (`no-context`, `window-too-short`).
+// The residual exposure is a host that silently accepted less text than it was
+// handed — a length-limited field — where the recorded count reaches past what
+// actually arrived.
+//
+// The hard bound is the count itself: it is the length of the string the
+// keyboard handed to `insertText`, so a burst cannot remove more than one
+// dictation put there, whatever the window did or did not show.
 
 import Foundation
 
@@ -71,6 +83,22 @@ public enum DictationUndo {
     /// This only ever applies to the truncated branch. A full match of a
     /// three-character insertion is still a full match.
     public static let minimumTruncatedMatch = 24
+
+    /// Whether a `.failed` reason is evidence that the field stopped being ours, as
+    /// opposed to evidence that it could not be read.
+    ///
+    /// `suffix-mismatch` and `truncated-mismatch` are proof: the document was
+    /// legible and what it holds is not what we inserted. `no-context` and
+    /// `window-too-short` are absence of proof — a detached or unsettled proxy, a
+    /// secure field, a host whose cached window has run dry mid-deletion.
+    ///
+    /// Callers that are deciding whether to STOP something already in flight — the
+    /// deletion burst, the offer on screen — must branch on this rather than on
+    /// `.failed` alone. Callers deciding whether to START deleting must not: there,
+    /// anything short of a pass fails closed.
+    public static func provesTheFieldChanged(_ reason: String) -> Bool {
+        reason == "suffix-mismatch" || reason == "truncated-mismatch"
+    }
 
     /// Validates that `insertedText` is still the tail of the field.
     ///

--- a/DictusCore/Tests/DictusCoreTests/DictationUndoTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/DictationUndoTests.swift
@@ -1,0 +1,183 @@
+// DictusCore/Tests/DictusCoreTests/DictationUndoTests.swift
+// Tests for the dictation undo safety check (issue #266): the keyboard may only
+// delete an insertion it can still prove is sitting at the caret.
+
+import XCTest
+@testable import DictusCore
+
+final class DictationUndoTests: XCTestCase {
+
+    /// A run of text comfortably longer than `minimumTruncatedMatch`, used by the
+    /// truncated-window cases.
+    private let longInsertion = "This is a fairly long dictation result that a bounded document context will not show in full. "
+
+    // MARK: - Full verification
+
+    func testInsertionAtEndOfEmptyFieldIsUndoable() {
+        let result = DictationUndo.verify(context: "Bonjour. ", insertedText: "Bonjour. ")
+        XCTAssertEqual(result, .ok(deleteCount: 9, verifiedCount: 9, windowTruncated: false))
+    }
+
+    func testInsertionAfterExistingTextIsUndoable() {
+        let result = DictationUndo.verify(
+            context: "Already typed: Bonjour. ",
+            insertedText: "Bonjour. "
+        )
+        XCTAssertEqual(result, .ok(deleteCount: 9, verifiedCount: 9, windowTruncated: false))
+    }
+
+    func testSeparatorIsPartOfTheInsertionAndIsCounted() {
+        // The pipeline appends ". " before writing to the App Group, so the
+        // separator is inside the recorded string and must be deleted with it.
+        let result = DictationUndo.verify(context: "je teste. ", insertedText: "je teste. ")
+        XCTAssertEqual(result, .ok(deleteCount: 10, verifiedCount: 10, windowTruncated: false))
+    }
+
+    func testAutoDetectInsertionWithoutSeparatorIsUndoable() {
+        // Whisper auto-detect inserts the transcription as-is (#226), no separator.
+        let result = DictationUndo.verify(context: "你好世界", insertedText: "你好世界")
+        XCTAssertEqual(result, .ok(deleteCount: 4, verifiedCount: 4, windowTruncated: false))
+    }
+
+    func testAccentsCountAsOneDeleteBackwardEach() {
+        // "élève. " is 7 graphemes, and deleteBackward() removes one per call.
+        let result = DictationUndo.verify(context: "un élève. ", insertedText: "élève. ")
+        XCTAssertEqual(result, .ok(deleteCount: 7, verifiedCount: 7, windowTruncated: false))
+    }
+
+    func testDecomposedContextMatchesPrecomposedInsertion() {
+        // Some hosts report decomposed Unicode (e + combining acute). Canonical
+        // equivalence must still match, and the grapheme count is the same.
+        let decomposedContext = "un e\u{0301}le\u{0300}ve. "
+        let precomposedInsertion = "\u{00E9}l\u{00E8}ve. "
+        let result = DictationUndo.verify(context: decomposedContext, insertedText: precomposedInsertion)
+        XCTAssertEqual(result, .ok(deleteCount: 7, verifiedCount: 7, windowTruncated: false))
+    }
+
+    func testEmojiCountsAsOneGrapheme() {
+        // A family emoji is several scalars but one deleteBackward().
+        let result = DictationUndo.verify(context: "ok 👨‍👩‍👧‍👦", insertedText: "👨‍👩‍👧‍👦")
+        XCTAssertEqual(result, .ok(deleteCount: 1, verifiedCount: 1, windowTruncated: false))
+    }
+
+    // MARK: - The user changed the field
+
+    func testTypingAfterTheInsertionBreaksTheCheck() {
+        let result = DictationUndo.verify(context: "Bonjour. et", insertedText: "Bonjour. ")
+        XCTAssertEqual(result, .failed(reason: "suffix-mismatch"))
+    }
+
+    func testDeletingIntoTheInsertionBreaksTheCheck() {
+        // The context is now SHORTER than the insertion, so this lands in the
+        // truncated branch and is refused there for being too short to trust —
+        // the reason differs from a plain mismatch, the refusal does not.
+        let result = DictationUndo.verify(context: "Bonjour.", insertedText: "Bonjour. ")
+        XCTAssertEqual(result, .failed(reason: "window-too-short"))
+    }
+
+    func testMovingTheCaretBeforeTheInsertionBreaksTheCheck() {
+        // Caret moved into the middle of the insertion: same shape as above, the
+        // text before it is a prefix of what we inserted, never the whole of it.
+        let result = DictationUndo.verify(context: "Bonjour", insertedText: "Bonjour. ")
+        XCTAssertEqual(result, .failed(reason: "window-too-short"))
+    }
+
+    func testHostRewroteTheTextBreaksTheCheck() {
+        let result = DictationUndo.verify(
+            context: "Something else entirely, rewritten by the host app.",
+            insertedText: "Bonjour. "
+        )
+        XCTAssertEqual(result, .failed(reason: "suffix-mismatch"))
+    }
+
+    // MARK: - Nothing to prove with
+
+    func testNilContextFailsClosed() {
+        // Secure fields report no context at all.
+        XCTAssertEqual(
+            DictationUndo.verify(context: nil, insertedText: "Bonjour. "),
+            .failed(reason: "no-context")
+        )
+    }
+
+    func testEmptyContextFailsClosed() {
+        XCTAssertEqual(
+            DictationUndo.verify(context: "", insertedText: "Bonjour. "),
+            .failed(reason: "no-context")
+        )
+    }
+
+    func testEmptyInsertionFailsClosed() {
+        XCTAssertEqual(
+            DictationUndo.verify(context: "Bonjour. ", insertedText: ""),
+            .failed(reason: "empty-insertion")
+        )
+    }
+
+    // MARK: - Bounded proxy window
+
+    func testTruncatedWindowMatchingTheTailIsUndoableInFull() {
+        let window = String(longInsertion.suffix(60))
+        let result = DictationUndo.verify(context: window, insertedText: longInsertion)
+        // Verified 60, but the delete count is the whole insertion: undoing half a
+        // dictation is not an undo.
+        XCTAssertEqual(
+            result,
+            .ok(deleteCount: longInsertion.count, verifiedCount: 60, windowTruncated: true)
+        )
+    }
+
+    func testTruncatedWindowIsFlaggedSoPartialIsNeverReadAsFull() {
+        let window = String(longInsertion.suffix(40))
+        guard case .ok(let deleteCount, let verifiedCount, let windowTruncated) =
+                DictationUndo.verify(context: window, insertedText: longInsertion) else {
+            return XCTFail("expected the truncated window to verify")
+        }
+        XCTAssertTrue(windowTruncated)
+        XCTAssertLessThan(verifiedCount, deleteCount)
+    }
+
+    func testTruncatedWindowWithTypedTextIsRefused() {
+        let window = String(longInsertion.suffix(60)) + "and then I typed"
+        XCTAssertEqual(
+            DictationUndo.verify(context: window, insertedText: longInsertion),
+            .failed(reason: "truncated-mismatch")
+        )
+    }
+
+    func testTruncatedWindowFromAnotherFieldIsRefused() {
+        let window = "a completely different field's trailing text"
+        XCTAssertEqual(
+            DictationUndo.verify(context: window, insertedText: longInsertion),
+            .failed(reason: "truncated-mismatch")
+        )
+    }
+
+    func testShortWindowIsRefusedEvenWhenItMatches() {
+        // 12 graphemes of match is too little to distinguish "our insertion" from
+        // "a field that happens to end the same way".
+        let window = String(longInsertion.suffix(12))
+        XCTAssertEqual(
+            DictationUndo.verify(context: window, insertedText: longInsertion),
+            .failed(reason: "window-too-short")
+        )
+    }
+
+    func testWindowExactlyAtTheFloorIsAccepted() {
+        let window = String(longInsertion.suffix(DictationUndo.minimumTruncatedMatch))
+        guard case .ok(let deleteCount, let verifiedCount, let windowTruncated) =
+                DictationUndo.verify(context: window, insertedText: longInsertion) else {
+            return XCTFail("expected a window at the floor to verify")
+        }
+        XCTAssertEqual(verifiedCount, DictationUndo.minimumTruncatedMatch)
+        XCTAssertEqual(deleteCount, longInsertion.count)
+        XCTAssertTrue(windowTruncated)
+    }
+
+    func testFloorDoesNotApplyToAFullMatch() {
+        // A short insertion fully visible in the window is fully verified — the
+        // floor exists only to make a PARTIAL match trustworthy.
+        let result = DictationUndo.verify(context: "hi. ", insertedText: "hi. ")
+        XCTAssertEqual(result, .ok(deleteCount: 4, verifiedCount: 4, windowTruncated: false))
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/DictationUndoTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/DictationUndoTests.swift
@@ -174,6 +174,97 @@ final class DictationUndoTests: XCTestCase {
         XCTAssertTrue(windowTruncated)
     }
 
+    // MARK: - The chunked deletion the caller performs
+    //
+    // `KeyboardState.deleteInsertedText` deletes in chunks and re-verifies the part
+    // still to go between them, which is what completes the proof a truncated
+    // window cannot give on its own. These simulate that loop against a document
+    // whose window is smaller than the insertion.
+
+    /// Mirrors `KeyboardState.deleteInsertedText`: delete a chunk no longer than
+    /// the last check could see, then re-prove what is left before continuing.
+    ///
+    /// Returns the document as the loop leaves it and how much of the insertion it
+    /// gave up on — zero when the undo completed.
+    private func runUndoLoop(
+        document: String,
+        insertion: String,
+        windowSize: Int,
+        chunkSize: Int = 40
+    ) -> (document: String, abandoned: Int) {
+        var document = document
+        // The bounded context a proxy would report for the current document.
+        func context() -> String { String(document.suffix(windowSize)) }
+
+        var remaining = insertion.count
+        var proven: Int
+        switch DictationUndo.verify(context: context(), insertedText: insertion) {
+        case .ok(_, let verifiedCount, _):
+            proven = verifiedCount
+        case .failed:
+            return (document, remaining)
+        }
+
+        while remaining > 0 {
+            let batch = min(remaining, chunkSize, max(proven, 1))
+            document = String(document.dropLast(batch))
+            remaining -= batch
+            guard remaining > 0 else { break }
+
+            switch DictationUndo.verify(
+                context: context(),
+                insertedText: String(insertion.prefix(remaining))
+            ) {
+            case .ok(_, let verifiedCount, _):
+                proven = verifiedCount
+            case .failed:
+                return (document, remaining)
+            }
+        }
+        return (document, 0)
+    }
+
+    func testALongUndoCompletesThroughAWindowFarSmallerThanTheInsertion() {
+        let existing = "A note the user wrote earlier. "
+        let result = runUndoLoop(
+            document: existing + longInsertion,
+            insertion: longInsertion,
+            windowSize: 50
+        )
+        XCTAssertEqual(result.abandoned, 0, "the whole insertion should be removable")
+        XCTAssertEqual(result.document, existing, "and the undo must land exactly on the earlier text")
+    }
+
+    func testNoChunkDeletesMoreThanTheLastCheckCouldSee() {
+        // A window barely above the floor: the loop must step in small chunks
+        // rather than take the full recorded count on a 24-grapheme proof.
+        let existing = "A note the user wrote earlier. "
+        let result = runUndoLoop(
+            document: existing + longInsertion,
+            insertion: longInsertion,
+            windowSize: DictationUndo.minimumTruncatedMatch
+        )
+        XCTAssertEqual(result.abandoned, 0)
+        XCTAssertEqual(result.document, existing)
+    }
+
+    func testTheLoopStopsBeforeEatingTextItNeverInserted() {
+        // The host truncated the insertion: only its first 50 graphemes ever
+        // reached the field. The recorded count is larger than what is there, so a
+        // caller that trusted that count alone would delete into `existing`.
+        let existing = "A note the user wrote earlier. "
+        let result = runUndoLoop(
+            document: existing + String(longInsertion.prefix(50)),
+            insertion: longInsertion,
+            windowSize: 50
+        )
+        XCTAssertGreaterThan(result.abandoned, 0, "the loop must give up rather than delete on")
+        XCTAssertTrue(
+            result.document.hasPrefix(existing),
+            "text written before the dictation must survive the abandoned undo"
+        )
+    }
+
     func testFloorDoesNotApplyToAFullMatch() {
         // A short insertion fully visible in the window is fully verified — the
         // floor exists only to make a PARTIAL match trustworthy.

--- a/DictusCore/Tests/DictusCoreTests/DictationUndoTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/DictationUndoTests.swift
@@ -189,91 +189,142 @@ final class DictationUndoTests: XCTestCase {
 
     // MARK: - The chunked deletion the caller performs
     //
-    // `KeyboardState.deleteInsertedText` deletes in chunks and re-verifies the part
-    // still to go between them, which is what completes the proof a truncated
-    // window cannot give on its own. These simulate that loop against a document
-    // whose window is smaller than the insertion.
+    // `KeyboardState.deleteInsertedText` deletes in chunks and re-checks the part
+    // still to go between them, stopping only on a refusal that PROVES the field
+    // changed. These simulate that loop against both of the window behaviours a
+    // host can have.
 
-    /// Mirrors `KeyboardState.deleteInsertedText`: delete a chunk no longer than
-    /// the last check could see, then re-prove what is left before continuing.
+    /// How a host answers `documentContextBeforeInput` while text is deleted.
+    private enum WindowBehaviour {
+        /// The window slides back over the document, revealing text that was out of
+        /// reach a moment ago. What the first design assumed of every host.
+        case sliding(Int)
+        /// The window is fetched once and merely trimmed as deletions consume it,
+        /// so it runs dry and never refills. Measured in Notes on 2026-08-02: 491
+        /// graphemes at the start of a burst, 11 after 480 were removed.
+        case trimmedOnce(Int)
+    }
+
+    /// Mirrors `KeyboardState.deleteInsertedText`: delete a fixed chunk, then look
+    /// at what is left and stop only if the document proves it is no longer ours.
     ///
     /// Returns the document as the loop leaves it and how much of the insertion it
     /// gave up on — zero when the undo completed.
     private func runUndoLoop(
-        document: String,
+        document startingDocument: String,
         insertion: String,
-        windowSize: Int,
+        behaviour: WindowBehaviour,
         chunkSize: Int = 40
     ) -> (document: String, abandoned: Int) {
-        var document = document
-        // The bounded context a proxy would report for the current document.
-        func context() -> String { String(document.suffix(windowSize)) }
+        var document = startingDocument
+        var deleted = 0
+        let firstWindow: Int
+        switch behaviour {
+        case .sliding(let size), .trimmedOnce(let size):
+            firstWindow = min(size, startingDocument.count)
+        }
+
+        func context() -> String {
+            switch behaviour {
+            case .sliding(let size):
+                return String(document.suffix(size))
+            case .trimmedOnce:
+                return String(document.suffix(max(0, firstWindow - deleted)))
+            }
+        }
 
         var remaining = insertion.count
-        var proven: Int
-        switch DictationUndo.verify(context: context(), insertedText: insertion) {
-        case .ok(_, let verifiedCount, _):
-            proven = verifiedCount
-        case .failed:
+        // The check at the tap, which fails closed on anything short of a pass.
+        guard case .ok = DictationUndo.verify(context: context(), insertedText: insertion) else {
             return (document, remaining)
         }
 
         while remaining > 0 {
-            let batch = min(remaining, chunkSize, max(proven, 1))
+            let batch = min(remaining, chunkSize)
             document = String(document.dropLast(batch))
             remaining -= batch
+            deleted += batch
             guard remaining > 0 else { break }
 
-            switch DictationUndo.verify(
+            if case .failed(let reason) = DictationUndo.verify(
                 context: context(),
                 insertedText: String(insertion.prefix(remaining))
-            ) {
-            case .ok(_, let verifiedCount, _):
-                proven = verifiedCount
-            case .failed:
+            ), DictationUndo.provesTheFieldChanged(reason) {
                 return (document, remaining)
             }
         }
         return (document, 0)
     }
 
-    func testALongUndoCompletesThroughAWindowFarSmallerThanTheInsertion() {
+    func testALongUndoCompletesThroughASlidingWindow() {
         let existing = "A note the user wrote earlier. "
         let result = runUndoLoop(
             document: existing + longInsertion,
             insertion: longInsertion,
-            windowSize: 50
+            behaviour: .sliding(50)
         )
         XCTAssertEqual(result.abandoned, 0, "the whole insertion should be removable")
         XCTAssertEqual(result.document, existing, "and the undo must land exactly on the earlier text")
     }
 
-    func testNoChunkDeletesMoreThanTheLastCheckCouldSee() {
-        // A window barely above the floor: the loop must step in small chunks
-        // rather than take the full recorded count on a 24-grapheme proof.
+    func testALongUndoCompletesThroughAWindowTheHostNeverRefills() {
+        // The device case. Requiring a fresh proof before each chunk made this stop
+        // one window in, leaving most of the dictation in the field: 4752 graphemes
+        // recorded, 480 removed, 4272 left. Absence of proof must not stop the burst.
         let existing = "A note the user wrote earlier. "
         let result = runUndoLoop(
             document: existing + longInsertion,
             insertion: longInsertion,
-            windowSize: DictationUndo.minimumTruncatedMatch
+            behaviour: .trimmedOnce(50)
         )
-        XCTAssertEqual(result.abandoned, 0)
+        XCTAssertEqual(result.abandoned, 0, "a host that stops answering must not strand the undo")
         XCTAssertEqual(result.document, existing)
     }
 
-    func testTheLoopStopsBeforeEatingTextItNeverInserted() {
-        // The host truncated the insertion: only its first 50 graphemes ever
-        // reached the field. The recorded count is larger than what is there, so a
-        // caller that trusted that count alone would delete into `existing`.
+    func testTheOfferIsRefusedWhenTheHostTruncatedTheInsertion() {
+        // The host accepted only the first 50 graphemes of what it was handed, so
+        // the recorded count reaches past what is actually in the field. The tail is
+        // then the insertion's HEAD, which is not its tail, so the check at the tap
+        // refuses and nothing is deleted at all.
         let existing = "A note the user wrote earlier. "
         let result = runUndoLoop(
             document: existing + String(longInsertion.prefix(50)),
             insertion: longInsertion,
-            windowSize: 50
+            behaviour: .sliding(50)
         )
-        XCTAssertGreaterThan(result.abandoned, 0, "the loop must give up rather than delete on")
+        XCTAssertEqual(result.abandoned, longInsertion.count, "nothing may be deleted")
+        XCTAssertEqual(result.document, existing + String(longInsertion.prefix(50)))
+    }
+
+    func testTheBurstStopsWhenTheDocumentIsLegibleAndNoLongerOurs() {
+        // A host that rewrites the field mid-burst. The window still answers, and
+        // what it answers is not the remainder — that is proof, and proof stops the
+        // deletion with the earlier text intact.
+        let existing = "A note the user wrote earlier. "
+        var document = existing + longInsertion
+        var remaining = longInsertion.count
+        var stopped = false
+
+        while remaining > 0 {
+            let batch = min(remaining, 40)
+            document = String(document.dropLast(batch))
+            remaining -= batch
+            guard remaining > 0 else { break }
+            // After the first chunk the host replaces the tail with foreign text.
+            document = String(document.dropLast(30)) + "-- pasted by another app --"
+
+            if case .failed(let reason) = DictationUndo.verify(
+                context: String(document.suffix(50)),
+                insertedText: String(longInsertion.prefix(remaining))
+            ), DictationUndo.provesTheFieldChanged(reason) {
+                stopped = true
+                break
+            }
+        }
+
+        XCTAssertTrue(stopped, "a legible mismatch must stop the burst")
         XCTAssertTrue(
-            result.document.hasPrefix(existing),
+            document.hasPrefix(existing),
             "text written before the dictation must survive the abandoned undo"
         )
     }

--- a/DictusCore/Tests/DictusCoreTests/DictationUndoTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/DictationUndoTests.swift
@@ -153,6 +153,19 @@ final class DictationUndoTests: XCTestCase {
         )
     }
 
+    func testPartiallyDeletedLongInsertionIsRefused() {
+        // The user backspaced five characters off the end of a long dictation. The
+        // window still shows text that came from the insertion, but it no longer
+        // ENDS where the insertion ends, so it is not a suffix of it and the check
+        // refuses. This is the case a truncated window is most often accused of
+        // getting wrong; it does not reach the accepted-bound branch at all.
+        let afterBackspaces = String(longInsertion.dropLast(5))
+        XCTAssertEqual(
+            DictationUndo.verify(context: String(afterBackspaces.suffix(60)), insertedText: longInsertion),
+            .failed(reason: "truncated-mismatch")
+        )
+    }
+
     func testShortWindowIsRefusedEvenWhenItMatches() {
         // 12 graphemes of match is too little to distinguish "our insertion" from
         // "a field that happens to end the same way".
@@ -262,6 +275,20 @@ final class DictationUndoTests: XCTestCase {
         XCTAssertTrue(
             result.document.hasPrefix(existing),
             "text written before the dictation must survive the abandoned undo"
+        )
+    }
+
+    func testFloorIsHonouredWhenTheCallerSuppliesOne() {
+        // The floor is injectable so a caller with a different tolerance can set
+        // one; the same window must be refused below it and accepted at it.
+        let window = String(longInsertion.suffix(30))
+        XCTAssertEqual(
+            DictationUndo.verify(context: window, insertedText: longInsertion, minimumTruncatedMatch: 31),
+            .failed(reason: "window-too-short")
+        )
+        XCTAssertEqual(
+            DictationUndo.verify(context: window, insertedText: longInsertion, minimumTruncatedMatch: 30),
+            .ok(deleteCount: longInsertion.count, verifiedCount: 30, windowTruncated: true)
         )
     }
 

--- a/DictusKeyboard/DictusKeyboardBridge.swift
+++ b/DictusKeyboard/DictusKeyboardBridge.swift
@@ -75,7 +75,9 @@ final class DictusKeyboardBridge: NSObject,
         // proxy's view of the document can lag the keystroke by an event, and an
         // offer that is still on screen for that one event is an offer that can be
         // tapped. Ending it at the source does not depend on the host's timing.
-        KeyboardState.shared.invalidateDictationUndo(reason: "keystroke")
+        if Self.editsDocument(key) {
+            KeyboardState.shared.invalidateDictationUndo(reason: "keystroke")
+        }
 
         switch key.type {
         case .input(let character, let alternate):
@@ -132,6 +134,27 @@ final class DictusKeyboardBridge: NSObject,
         }
     }
 
+    /// Whether triggering `key` changes the document, as opposed to changing only
+    /// what the keyboard itself is showing.
+    ///
+    /// Used by the dictation undo offer (#266): shift, the symbol layers, the globe
+    /// and the emoji key leave the field exactly as the dictation left it, so the
+    /// offer survives them. Switching to the symbol layer to type a character does
+    /// end the offer — on the character, not on the layer switch.
+    ///
+    /// The emoji key is an `.input` key carrying the smiley glyph rather than a
+    /// type of its own; `didTriggerKey` tells the two apart the same way.
+    private static func editsDocument(_ key: KeyDefinition) -> Bool {
+        switch key.type {
+        case .input(let character, _):
+            return character != "\u{1F600}"
+        case .backspace, .spacebar, .returnkey, .comma, .fullStop, .tab:
+            return true
+        default:
+            return false
+        }
+    }
+
     func didTriggerDoubleTap(forKey key: KeyDefinition) {
         switch key.type {
         case .shift:
@@ -157,7 +180,9 @@ final class DictusKeyboardBridge: NSObject,
     func didTriggerHoldKey(_ key: KeyDefinition) {
         // Held backspace does not pass through didTriggerKey, and it is the very
         // key someone reaches for when they want the dictation gone (#266).
-        KeyboardState.shared.invalidateDictationUndo(reason: "keystroke-hold")
+        if Self.editsDocument(key) {
+            KeyboardState.shared.invalidateDictationUndo(reason: "keystroke-hold")
+        }
 
         switch key.type {
         case .backspace:

--- a/DictusKeyboard/DictusKeyboardBridge.swift
+++ b/DictusKeyboard/DictusKeyboardBridge.swift
@@ -70,6 +70,13 @@ final class DictusKeyboardBridge: NSObject,
     // MARK: - GiellaKeyboardViewDelegate
 
     func didTriggerKey(_ key: KeyDefinition) {
+        // The first keystroke after a dictation ends its undo offer (#266). The
+        // safety check would refuse anyway once the typed character lands, but the
+        // proxy's view of the document can lag the keystroke by an event, and an
+        // offer that is still on screen for that one event is an offer that can be
+        // tapped. Ending it at the source does not depend on the host's timing.
+        KeyboardState.shared.invalidateDictationUndo(reason: "keystroke")
+
         switch key.type {
         case .input(let character, let alternate):
             if alternate == "accent" {
@@ -148,6 +155,10 @@ final class DictusKeyboardBridge: NSObject,
     }
 
     func didTriggerHoldKey(_ key: KeyDefinition) {
+        // Held backspace does not pass through didTriggerKey, and it is the very
+        // key someone reaches for when they want the dictation gone (#266).
+        KeyboardState.shared.invalidateDictationUndo(reason: "keystroke-hold")
+
         switch key.type {
         case .backspace:
             handleWordDelete()
@@ -157,6 +168,10 @@ final class DictusKeyboardBridge: NSObject,
     }
 
     func didMoveCursor(_ movement: Int) {
+        // Moving the caret is what the undo check tests for, so drop the offer
+        // here rather than wait for the host to report the selection change (#266).
+        KeyboardState.shared.invalidateDictationUndo(reason: "cursor-moved")
+
         // Spacebar trackpad cursor movement
         controller?.textDocumentProxy.adjustTextPosition(byCharacterOffset: movement)
         HapticFeedback.cursorMoved()

--- a/DictusKeyboard/KeyboardRootView.swift
+++ b/DictusKeyboard/KeyboardRootView.swift
@@ -120,6 +120,11 @@ struct KeyboardRootView: View {
             suggestions: [],
             suggestionMode: .idle,
             onSuggestionTap: { _ in },
+            // Undo survives opening the emoji picker (#266): browsing emoji is not
+            // typing, and the insertion is still the tail of the field. The panel
+            // presentation ignores these — its bar has no centre slot.
+            showsDictationUndo: state.dictationUndoAvailable,
+            onDictationUndoTap: { state.performDictationUndo() },
             isPanelOpen: isPanelOpen,
             onPanelToggle: { togglePanel() },
             onSettingsTap: { leavePanel { state.openDictusApp(intent: "settings") } },
@@ -245,6 +250,8 @@ struct KeyboardRootView: View {
                     onSuggestionTap: { index in
                         handleSuggestionTap(index: index)
                     },
+                    showsDictationUndo: state.dictationUndoAvailable,
+                    onDictationUndoTap: { state.performDictationUndo() },
                     onPanelToggle: { togglePanel() }
                 )
                 // No KeyboardView here -- it's UIKit, added directly by KeyboardViewController

--- a/DictusKeyboard/KeyboardState.swift
+++ b/DictusKeyboard/KeyboardState.swift
@@ -700,9 +700,13 @@ class KeyboardState: ObservableObject {
     /// this is where that is caught. A refusal deletes nothing.
     func performDictationUndo() {
         guard let transcription = dictationUndoText, !isUndoingDictation else { return }
+        guard let proxy = controller?.textDocumentProxy else {
+            invalidateDictationUndo(reason: "perform-no-proxy")
+            return
+        }
 
         switch DictationUndo.verify(
-            context: controller?.textDocumentProxy.documentContextBeforeInput,
+            context: proxy.documentContextBeforeInput,
             insertedText: transcription
         ) {
         case .failed(let reason):
@@ -717,18 +721,53 @@ class KeyboardState: ObservableObject {
             // The offer is spent the moment it is taken. Clearing first also means
             // a second tap during the burst finds nothing to act on.
             invalidateDictationUndo(reason: "performed")
-            deleteInsertedText(remaining: deleteCount)
+            deleteInsertedText(
+                transcription,
+                remaining: deleteCount,
+                proven: verifiedCount,
+                proxy: proxy
+            )
         }
     }
 
     /// Issue the deletion in chunks, yielding to the main queue between them.
+    ///
+    /// WHY the remainder is re-proved between chunks: the check that started the
+    /// burst could only see as far back as the proxy's window, so on a long
+    /// dictation most of what is about to be deleted was never shown to us. As the
+    /// deletion eats into the field the window slides back over text that was out
+    /// of reach a moment ago, and each chunk pays for the next one by proving the
+    /// part it is about to remove is still the tail. What that buys is the one
+    /// guarantee this feature is for: no character is deleted that has not been
+    /// seen to belong to the insertion.
+    ///
+    /// `proven` is what makes that literal rather than approximate: it is how many
+    /// graphemes the last check actually matched, and no chunk may be longer. A
+    /// truncated window proves 24 or more, never all 600, so a fixed chunk size on
+    /// its own would step past the proof on the very first pass.
+    ///
+    /// It cuts the other way too. If a host reports its context late, a chunk can
+    /// fail to prove a remainder that is in fact still there, and the undo stops
+    /// with text left behind. That is the deliberate side to fail on — leftover
+    /// text is visible and can be deleted by hand, text eaten out of the middle of
+    /// someone's message is neither. The abort is logged with what was left.
+    ///
+    /// The proxy is captured once, at the start. iOS can attach a new controller
+    /// mid-burst, and `controller` is a shared reference that the new one takes
+    /// over; re-reading it each turn would redirect the rest of the deletion at
+    /// whatever field that controller is looking at.
     ///
     /// Aborts if a dictation has started in the meantime. `startRecording` refuses
     /// to start one while a burst is in flight, so this is the second line of
     /// defence rather than the first — but the app can also drive the status from
     /// its own side, and a burst that kept deleting into a fresh recording would
     /// eat text this undo never inserted.
-    private func deleteInsertedText(remaining: Int) {
+    private func deleteInsertedText(
+        _ insertedText: String,
+        remaining: Int,
+        proven: Int,
+        proxy: UITextDocumentProxy
+    ) {
         guard remaining > 0 else {
             isUndoingDictation = false
             onDictationUndone?()
@@ -739,19 +778,41 @@ class KeyboardState: ObservableObject {
             isUndoingDictation = false
             logProbe(
                 "dictationUndoAborted",
-                details: "remaining=\(remaining) \(sessionDetails())"
+                details: "reason=dictation-started remaining=\(remaining) \(sessionDetails())"
             )
             return
         }
 
-        let batch = min(remaining, Self.dictationUndoChunkSize)
+        let batch = min(remaining, Self.dictationUndoChunkSize, max(proven, 1))
         for _ in 0..<batch {
-            controller?.textDocumentProxy.deleteBackward()
+            proxy.deleteBackward()
         }
+        let left = remaining - batch
 
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            self.deleteInsertedText(remaining: remaining - batch)
+            guard left > 0 else {
+                self.deleteInsertedText(insertedText, remaining: 0, proven: 0, proxy: proxy)
+                return
+            }
+            switch DictationUndo.verify(
+                context: proxy.documentContextBeforeInput,
+                insertedText: String(insertedText.prefix(left))
+            ) {
+            case .ok(_, let verifiedCount, _):
+                self.deleteInsertedText(
+                    insertedText,
+                    remaining: left,
+                    proven: verifiedCount,
+                    proxy: proxy
+                )
+            case .failed(let reason):
+                self.isUndoingDictation = false
+                self.logProbe(
+                    "dictationUndoAborted",
+                    details: "reason=\(reason) remaining=\(left)"
+                )
+            }
         }
     }
 

--- a/DictusKeyboard/KeyboardState.swift
+++ b/DictusKeyboard/KeyboardState.swift
@@ -514,24 +514,7 @@ class KeyboardState: ObservableObject {
             defaults.removeObject(forKey: SharedKeys.lastTranscription)
             defaults.synchronize()
 
-            controller?.textDocumentProxy.insertText(transcription)
-            PersistentLog.log(.keyboardTextInserted)
-            HapticFeedback.textInserted()
-            onTranscriptionInserted?()
-
-            // Reset state to idle.
-            // WHY explicit stopWatchdog: refreshFromDefaults() above may have read
-            // .transcribing from App Group (before .ready propagated), starting the
-            // watchdog. Setting dictationStatus = .idle here bypasses refreshFromDefaults
-            // so the watchdog wouldn't self-stop until its next 1s tick. Stopping
-            // explicitly prevents false-positive watchdog resets.
-            stopWatchdog()
-            dictationStatus = .idle
-            waveformEnergy = []
-            recordingElapsed = 0
-            statusMessage = nil
-            lastTranscription = nil
-            activeSessionID = nil
+            insertTranscription(transcription)
         } else {
             // Retry after 100ms — mitigates UserDefaults race condition.
             // Darwin notifications are posted immediately after synchronize(),
@@ -543,20 +526,232 @@ class KeyboardState: ObservableObject {
                     self.defaults.removeObject(forKey: SharedKeys.lastTranscription)
                     self.defaults.synchronize()
 
-                    self.controller?.textDocumentProxy.insertText(transcription)
-                    PersistentLog.log(.keyboardTextInserted)
-                    HapticFeedback.textInserted()
-                    self.onTranscriptionInserted?()
-
-                    self.stopWatchdog()
-                    self.dictationStatus = .idle
-                    self.waveformEnergy = []
-                    self.recordingElapsed = 0
-                    self.statusMessage = nil
-                    self.lastTranscription = nil
-                    self.activeSessionID = nil
+                    self.insertTranscription(transcription)
                 }
             }
+        }
+    }
+
+    /// Insert a transcription into the host field and return the keyboard to idle.
+    ///
+    /// WHY this is a single function called from two places: `handleTranscriptionReady`
+    /// has two insertion sites — the direct one and the 100 ms retry that absorbs the
+    /// App Group propagation race — and they used to hold two copies of this block.
+    /// Anything the keyboard has to remember about an insertion (#266: what it was, so
+    /// it can be undone) has to be remembered on both, and the retry path is the one
+    /// that loses the race, so a copy that forgets it would fail intermittently and
+    /// only on slow devices. One funnel, no copy to forget.
+    ///
+    /// The App Group key is deliberately NOT read here: the caller clears it before
+    /// calling, which is what stops a redelivered Darwin notification from inserting
+    /// the same text twice.
+    private func insertTranscription(_ transcription: String) {
+        controller?.textDocumentProxy.insertText(transcription)
+        PersistentLog.log(.keyboardTextInserted)
+        HapticFeedback.textInserted()
+        onTranscriptionInserted?()
+
+        // Reset state to idle.
+        // WHY explicit stopWatchdog: refreshFromDefaults() in the caller may have read
+        // .transcribing from App Group (before .ready propagated), starting the
+        // watchdog. Setting dictationStatus = .idle here bypasses refreshFromDefaults
+        // so the watchdog wouldn't self-stop until its next 1s tick. Stopping
+        // explicitly prevents false-positive watchdog resets.
+        stopWatchdog()
+        dictationStatus = .idle
+        waveformEnergy = []
+        recordingElapsed = 0
+        statusMessage = nil
+        lastTranscription = nil
+        activeSessionID = nil
+
+        // Offer the undo control for this insertion, and only this one. Armed after
+        // the idle reset above because that reset is what ends the dictation session
+        // the undo belongs to.
+        armDictationUndo(transcription)
+    }
+
+    // MARK: - Dictation undo (#266)
+
+    /// The exact string the last dictation inserted, while undoing it is still on
+    /// offer. Nil means there is nothing to undo.
+    ///
+    /// WHY it is held in memory here rather than re-read from the App Group: the
+    /// value is removed from shared storage *before* insertion, deliberately, so a
+    /// redelivered Darwin notification cannot insert it twice. By the time the user
+    /// could ask to undo, the only remaining copy of what was inserted is this one.
+    ///
+    /// WHY on the shared state object and not on a controller: iOS destroys and
+    /// rebuilds `UIInputViewController` instances constantly — around nine per
+    /// dictation (#281) — so a record held by a controller would vanish with it.
+    /// What that costs is the risk of a record outliving the field it belongs to,
+    /// which is what the invalidations below and the tail check exist to prevent.
+    private var dictationUndoText: String?
+
+    /// Whether the toolbar should offer the undo control.
+    ///
+    /// Set only after the insertion has been verified against the live document, so
+    /// a host that reports no usable context never shows a control that could not
+    /// act (fail closed).
+    @Published private(set) var dictationUndoAvailable = false
+
+    /// Expires the offer a few seconds after the insertion.
+    private var dictationUndoTimer: Timer?
+
+    /// True while a deletion burst is in flight. Blocks a new dictation from
+    /// starting into a field that is still being rewritten.
+    private var isUndoingDictation = false
+
+    /// Called after a dictation insertion has been undone, so the controller can
+    /// drop suggestions computed from text that no longer exists.
+    var onDictationUndone: (() -> Void)?
+
+    /// How long the offer stands.
+    ///
+    /// WHY 8 seconds: long enough to read a sentence and decide it is wrong, short
+    /// enough that the control is gone before the user has moved on and forgotten
+    /// what it refers to. The issue asks for "a few seconds"; this is a judgement
+    /// call, not a measurement.
+    private static let dictationUndoTimeout: TimeInterval = 8
+
+    /// `deleteBackward()` calls issued per main-queue turn.
+    ///
+    /// WHY chunked at all: every call is an IPC round trip to the host, and a
+    /// two-minute dictation is hundreds of them. Issued in one synchronous loop
+    /// they block the main thread long enough for a slow host to visibly freeze.
+    /// Yielding between chunks lets the host process what it has been given.
+    private static let dictationUndoChunkSize = 40
+
+    /// Offer to undo `transcription`, if the document still agrees it was inserted.
+    ///
+    /// WHY the first check is deferred by one main-queue turn: `insertText` and the
+    /// proxy's view of the document are not guaranteed to be in step within the same
+    /// turn, and a check that runs too early reads the field as it was *before* the
+    /// insertion and refuses. One hop costs a frame nobody sees.
+    private func armDictationUndo(_ transcription: String) {
+        dictationUndoText = transcription
+        dictationUndoAvailable = false
+        dictationUndoTimer?.invalidate()
+        dictationUndoTimer = Timer.scheduledTimer(
+            withTimeInterval: Self.dictationUndoTimeout,
+            repeats: false
+        ) { [weak self] _ in
+            self?.invalidateDictationUndo(reason: "timeout")
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.dictationUndoText == transcription else { return }
+            switch DictationUndo.verify(
+                context: self.controller?.textDocumentProxy.documentContextBeforeInput,
+                insertedText: transcription
+            ) {
+            case .ok(let deleteCount, let verifiedCount, let windowTruncated):
+                self.dictationUndoAvailable = true
+                self.logProbe(
+                    "dictationUndoArmed",
+                    details: "deleteCount=\(deleteCount) verified=\(verifiedCount) truncated=\(windowTruncated)"
+                )
+            case .failed(let reason):
+                self.invalidateDictationUndo(reason: "arm-\(reason)")
+            }
+        }
+    }
+
+    /// Re-check the offer against the live document.
+    ///
+    /// WHY this re-verifies instead of clearing outright: the host reports a text
+    /// change for the keyboard's *own* insertion too, so a hook that cleared blindly
+    /// would cancel the offer in the same breath as making it — on some hosts, at
+    /// some speeds. Re-checking has the behaviour the issue asks for (the offer dies
+    /// on the first keystroke, a caret move or a host rewrite) without depending on
+    /// which changes a given host chooses to report.
+    ///
+    /// WHY it stands down until the offer is armed: the change reports triggered by
+    /// the insertion itself can arrive before the proxy's context catches up with
+    /// it, and a check run against that stale context refuses. Arming already
+    /// verifies, one main-queue turn after the insertion, and the user cannot type
+    /// inside that turn — so there is nothing for this to protect there.
+    func revalidateDictationUndo() {
+        guard dictationUndoAvailable, let transcription = dictationUndoText else { return }
+        if case .failed(let reason) = DictationUndo.verify(
+            context: controller?.textDocumentProxy.documentContextBeforeInput,
+            insertedText: transcription
+        ) {
+            invalidateDictationUndo(reason: "revalidate-\(reason)")
+        }
+    }
+
+    /// Drop the offer. The record is destroyed, not merely hidden: a hidden record
+    /// is one bug away from deleting text it no longer owns.
+    func invalidateDictationUndo(reason: String) {
+        guard dictationUndoText != nil else { return }
+        dictationUndoText = nil
+        dictationUndoAvailable = false
+        dictationUndoTimer?.invalidate()
+        dictationUndoTimer = nil
+        logProbe("dictationUndoInvalidated", details: "reason=\(reason)")
+    }
+
+    /// Remove the last dictation insertion from the host field.
+    ///
+    /// The check runs again here, against the document as it is at this instant.
+    /// The one performed when the control appeared proves nothing about now: a host
+    /// that rewrites text without reporting it leaves a stale offer on screen, and
+    /// this is where that is caught. A refusal deletes nothing.
+    func performDictationUndo() {
+        guard let transcription = dictationUndoText, !isUndoingDictation else { return }
+
+        switch DictationUndo.verify(
+            context: controller?.textDocumentProxy.documentContextBeforeInput,
+            insertedText: transcription
+        ) {
+        case .failed(let reason):
+            HapticFeedback.actionRefused()
+            invalidateDictationUndo(reason: "perform-\(reason)")
+        case .ok(let deleteCount, let verifiedCount, let windowTruncated):
+            logProbe(
+                "dictationUndoStarted",
+                details: "deleteCount=\(deleteCount) verified=\(verifiedCount) truncated=\(windowTruncated)"
+            )
+            isUndoingDictation = true
+            // The offer is spent the moment it is taken. Clearing first also means
+            // a second tap during the burst finds nothing to act on.
+            invalidateDictationUndo(reason: "performed")
+            deleteInsertedText(remaining: deleteCount)
+        }
+    }
+
+    /// Issue the deletion in chunks, yielding to the main queue between them.
+    ///
+    /// Aborts if a dictation has started in the meantime. `startRecording` refuses
+    /// to start one while a burst is in flight, so this is the second line of
+    /// defence rather than the first — but the app can also drive the status from
+    /// its own side, and a burst that kept deleting into a fresh recording would
+    /// eat text this undo never inserted.
+    private func deleteInsertedText(remaining: Int) {
+        guard remaining > 0 else {
+            isUndoingDictation = false
+            onDictationUndone?()
+            logProbe("dictationUndoCompleted")
+            return
+        }
+        guard dictationStatus == .idle, activeSessionID == nil else {
+            isUndoingDictation = false
+            logProbe(
+                "dictationUndoAborted",
+                details: "remaining=\(remaining) \(sessionDetails())"
+            )
+            return
+        }
+
+        let batch = min(remaining, Self.dictationUndoChunkSize)
+        for _ in 0..<batch {
+            controller?.textDocumentProxy.deleteBackward()
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.deleteInsertedText(remaining: remaining - batch)
         }
     }
 
@@ -587,6 +782,15 @@ class KeyboardState: ObservableObject {
             "registerControllerDisappearance",
             details: "controllerID=\(controllerID) owner=\(activeControllerID ?? "none") ownsVisibility=\(ownsVisibility) wasVisible=\(isKeyboardVisible) \(sessionDetails())"
         )
+
+        // The keyboard the insertion was made from is going away, so the field it
+        // was made into is no longer in front of the user (#266). Only the owner
+        // counts here: under churn, instances iOS is about to throw away report
+        // disappearing too, and letting one of those drop the record would make the
+        // offer vanish at random.
+        if ownsVisibility {
+            invalidateDictationUndo(reason: "keyboard-dismissed")
+        }
 
         ownership = ownership.disappearing(controllerID: controllerID)
     }
@@ -735,6 +939,19 @@ class KeyboardState: ObservableObject {
             return
         }
         lastMicTapDate = now
+
+        // An undo burst is still rewriting the field (#266). Starting a dictation
+        // now would have the two interleave: the burst deletes on every main-queue
+        // turn, and the transcription it would be deleting into is not the one it
+        // was verified against. The burst is short; the user taps again.
+        guard !isUndoingDictation else {
+            logProbe("micTapRejectedDuringUndo", details: sessionDetails())
+            HapticFeedback.actionRefused()
+            return
+        }
+
+        // A new dictation ends the previous one's undo offer, whatever comes of it.
+        invalidateDictationUndo(reason: "new-dictation")
 
         // Issue #262: a model load is now a prepare-only handoff. Opening Dictus
         // lets the app show truthful preparation feedback instead of leaving the

--- a/DictusKeyboard/KeyboardState.swift
+++ b/DictusKeyboard/KeyboardState.swift
@@ -671,14 +671,42 @@ class KeyboardState: ObservableObject {
     /// it, and a check run against that stale context refuses. Arming already
     /// verifies, one main-queue turn after the insertion, and the user cannot type
     /// inside that turn — so there is nothing for this to protect there.
+    ///
+    /// WHY only a proven mismatch drops the offer, and not every refusal:
+    /// "the field is no longer ours" and "nothing could be read just now" are
+    /// different facts, and only the first is evidence. Device capture in Messages
+    /// (2026-08-02) showed the second killing a valid offer two seconds after it
+    /// was armed: iOS had just swapped controllers, the freshly attached one had
+    /// not settled, and its proxy returned no context yet — so `no-context`
+    /// invalidated an offer nothing had invalidated. Controller churn is routine
+    /// here (#281), so this was not a one-off.
+    ///
+    /// Keeping the offer alive on an unreadable document costs nothing, because
+    /// this is not the check that authorises a deletion: `performDictationUndo`
+    /// re-verifies at the instant of the tap and fails closed on exactly these
+    /// reasons. The worst case is a button that stays on screen for its few
+    /// seconds and refuses when tapped, which is the behaviour a host that lies
+    /// about its context earns anyway.
     func revalidateDictationUndo() {
         guard dictationUndoAvailable, let transcription = dictationUndoText else { return }
         if case .failed(let reason) = DictationUndo.verify(
             context: controller?.textDocumentProxy.documentContextBeforeInput,
             insertedText: transcription
-        ) {
+        ), Self.provesTheFieldChanged(reason) {
             invalidateDictationUndo(reason: "revalidate-\(reason)")
         }
+    }
+
+    /// Whether a `DictationUndo` refusal is evidence that the field stopped being
+    /// ours, as opposed to evidence that we could not read it.
+    ///
+    /// `suffix-mismatch` and `truncated-mismatch` are proof: the document was
+    /// legible and what it holds is not what we inserted. `no-context` and
+    /// `window-too-short` are absence of proof — a detached or unsettled proxy, a
+    /// secure field, a host that reports its context late. `empty-insertion`
+    /// cannot occur here, since arming refuses an empty string.
+    private static func provesTheFieldChanged(_ reason: String) -> Bool {
+        reason == "suffix-mismatch" || reason == "truncated-mismatch"
     }
 
     /// Drop the offer. The record is destroyed, not merely hidden: a hidden record

--- a/DictusKeyboard/KeyboardState.swift
+++ b/DictusKeyboard/KeyboardState.swift
@@ -816,6 +816,9 @@ class KeyboardState: ObservableObject {
             proxy.deleteBackward()
         }
         let left = remaining - batch
+        if left > 0 {
+            Self.nudgeProxyToRefetchContext(proxy)
+        }
 
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
@@ -823,8 +826,9 @@ class KeyboardState: ObservableObject {
                 self.deleteInsertedText(insertedText, remaining: 0, proven: 0, proxy: proxy)
                 return
             }
+            let context = proxy.documentContextBeforeInput
             switch DictationUndo.verify(
-                context: proxy.documentContextBeforeInput,
+                context: context,
                 insertedText: String(insertedText.prefix(left))
             ) {
             case .ok(_, let verifiedCount, _):
@@ -836,12 +840,41 @@ class KeyboardState: ObservableObject {
                 )
             case .failed(let reason):
                 self.isUndoingDictation = false
+                // `context` is what decides whether the nudge above works. A refusal
+                // with a context far shorter than the chunk just deleted means the
+                // host trimmed its cached window instead of refetching, which is the
+                // case that cannot be fixed from here (#266 device capture).
                 self.logProbe(
                     "dictationUndoAborted",
-                    details: "reason=\(reason) remaining=\(left)"
+                    details: "reason=\(reason) remaining=\(left) context=\(context?.count ?? -1)"
                 )
             }
         }
+    }
+
+    /// Ask the host to refetch the text behind the caret, before we read it again.
+    ///
+    /// WHY (device capture, 2026-08-02, Notes): a 1077-grapheme undo stopped after
+    /// 480 with `window-too-short`. The context window measured 498 when the burst
+    /// started and 18 when it stopped — 498 minus the 480 removed. The host had not
+    /// been serving a *sliding* window over the document at all; it was serving one
+    /// cached window and trimming it as the deletions consumed it. The per-chunk
+    /// re-proof assumed the former, so past the first window there was nothing left
+    /// to prove the remainder against, and the guard did what it is meant to do.
+    ///
+    /// A caret movement is the only lever a keyboard extension has here: there is no
+    /// API to request more context, but moving the insertion point invalidates what
+    /// the proxy holds. One step back and one step forward leaves the caret exactly
+    /// where it was, in the same run-loop turn, before the read on the next one.
+    ///
+    /// Deliberately best-effort. If the host ignores it, or applies only one of the
+    /// two steps, the verification on the next turn sees a tail that is not the
+    /// remainder and refuses — the burst stops with text left in the field, which is
+    /// the direction this feature fails in by design. It cannot make the undo delete
+    /// something it has not proved.
+    private static func nudgeProxyToRefetchContext(_ proxy: UITextDocumentProxy) {
+        proxy.adjustTextPosition(byCharacterOffset: -1)
+        proxy.adjustTextPosition(byCharacterOffset: 1)
     }
 
     // MARK: - Keyboard visibility tracking

--- a/DictusKeyboard/KeyboardState.swift
+++ b/DictusKeyboard/KeyboardState.swift
@@ -993,6 +993,22 @@ class KeyboardState: ObservableObject {
     /// This means: after the first launch, subsequent recordings happen without
     /// switching apps. The user stays in their current app the entire time.
     func startRecording() {
+        // An undo burst is still rewriting the field (#266). Starting a dictation
+        // now would have the two interleave: the burst deletes on every main-queue
+        // turn, and the transcription it would be deleting into is not the one it
+        // was verified against. The burst is short; the user taps again.
+        //
+        // WHY this comes before the debounce: a refused tap must not count as a
+        // tap. Charging it to the debounce window would make the mic dead for
+        // 1.5 s after a burst that lasted a fraction of that, and the second tap —
+        // the one this refusal is telling the user to make — would be the one
+        // rejected.
+        guard !isUndoingDictation else {
+            logProbe("micTapRejectedDuringUndo", details: sessionDetails())
+            HapticFeedback.actionRefused()
+            return
+        }
+
         // Debounce: reject taps within 1.5s of the last tap.
         let now = Date()
         guard now.timeIntervalSince(lastMicTapDate) >= 1.5 else {
@@ -1000,16 +1016,6 @@ class KeyboardState: ObservableObject {
             return
         }
         lastMicTapDate = now
-
-        // An undo burst is still rewriting the field (#266). Starting a dictation
-        // now would have the two interleave: the burst deletes on every main-queue
-        // turn, and the transcription it would be deleting into is not the one it
-        // was verified against. The burst is short; the user taps again.
-        guard !isUndoingDictation else {
-            logProbe("micTapRejectedDuringUndo", details: sessionDetails())
-            HapticFeedback.actionRefused()
-            return
-        }
 
         // A new dictation ends the previous one's undo offer, whatever comes of it.
         invalidateDictationUndo(reason: "new-dictation")

--- a/DictusKeyboard/KeyboardState.swift
+++ b/DictusKeyboard/KeyboardState.swift
@@ -692,21 +692,9 @@ class KeyboardState: ObservableObject {
         if case .failed(let reason) = DictationUndo.verify(
             context: controller?.textDocumentProxy.documentContextBeforeInput,
             insertedText: transcription
-        ), Self.provesTheFieldChanged(reason) {
+        ), DictationUndo.provesTheFieldChanged(reason) {
             invalidateDictationUndo(reason: "revalidate-\(reason)")
         }
-    }
-
-    /// Whether a `DictationUndo` refusal is evidence that the field stopped being
-    /// ours, as opposed to evidence that we could not read it.
-    ///
-    /// `suffix-mismatch` and `truncated-mismatch` are proof: the document was
-    /// legible and what it holds is not what we inserted. `no-context` and
-    /// `window-too-short` are absence of proof — a detached or unsettled proxy, a
-    /// secure field, a host that reports its context late. `empty-insertion`
-    /// cannot occur here, since arming refuses an empty string.
-    private static func provesTheFieldChanged(_ reason: String) -> Bool {
-        reason == "suffix-mismatch" || reason == "truncated-mismatch"
     }
 
     /// Drop the offer. The record is destroyed, not merely hidden: a hidden record
@@ -749,36 +737,41 @@ class KeyboardState: ObservableObject {
             // The offer is spent the moment it is taken. Clearing first also means
             // a second tap during the burst finds nothing to act on.
             invalidateDictationUndo(reason: "performed")
-            deleteInsertedText(
-                transcription,
-                remaining: deleteCount,
-                proven: verifiedCount,
-                proxy: proxy
-            )
+            deleteInsertedText(transcription, remaining: deleteCount, proxy: proxy)
         }
     }
 
     /// Issue the deletion in chunks, yielding to the main queue between them.
     ///
-    /// WHY the remainder is re-proved between chunks: the check that started the
-    /// burst could only see as far back as the proxy's window, so on a long
-    /// dictation most of what is about to be deleted was never shown to us. As the
-    /// deletion eats into the field the window slides back over text that was out
-    /// of reach a moment ago, and each chunk pays for the next one by proving the
-    /// part it is about to remove is still the tail. What that buys is the one
-    /// guarantee this feature is for: no character is deleted that has not been
-    /// seen to belong to the insertion.
+    /// WHY the remainder is still checked between chunks, but no longer *required*:
     ///
-    /// `proven` is what makes that literal rather than approximate: it is how many
-    /// graphemes the last check actually matched, and no chunk may be longer. A
-    /// truncated window proves 24 or more, never all 600, so a fixed chunk size on
-    /// its own would step past the proof on the very first pass.
+    /// The first design re-proved the remainder before every chunk and stopped when
+    /// it could not, on the assumption that the proxy's window slides back over the
+    /// document as the deletion consumes it. Three device captures in Notes
+    /// (2026-08-02) disproved that assumption arithmetically. The window measured
+    /// 491, 496 and 490 graphemes when each burst started, and 11, 16 and 10 when it
+    /// stopped — in each case exactly the starting window minus the 480 graphemes
+    /// removed. The host serves one cached window and trims it; it never refetches.
+    /// A caret round trip, tried as a way to invalidate that cache, changed nothing.
     ///
-    /// It cuts the other way too. If a host reports its context late, a chunk can
-    /// fail to prove a remainder that is in fact still there, and the undo stops
-    /// with text left behind. That is the deliberate side to fail on — leftover
-    /// text is visible and can be deleted by hand, text eaten out of the middle of
-    /// someone's message is neither. The abort is logged with what was left.
+    /// So the requirement could not be met by any host that behaves this way, and
+    /// its cost was the feature itself: a 4752-grapheme undo removed 480 and left
+    /// 4272 behind, on precisely the length that makes holding backspace painful.
+    ///
+    /// What remains is the distinction that actually carries the safety, the same
+    /// one `revalidateDictationUndo` draws. A refusal that PROVES the field changed
+    /// — the document was legible and does not end with the remainder — stops the
+    /// burst. A refusal that only means the document could not be read does not:
+    /// absence of proof is not evidence, and treating it as such is what broke the
+    /// long case. The remaining exposure is a host that silently accepted less text
+    /// than it was handed, e.g. a length-limited field, where the recorded count
+    /// then reaches past what was inserted. Narrow, visible when it happens, and
+    /// weighed against a feature that otherwise does not work at all past ~500
+    /// characters.
+    ///
+    /// The count itself is the hard bound and always was: it is the length of the
+    /// string this keyboard handed to `insertText`, never a guess, so the burst
+    /// cannot delete more than one dictation put there.
     ///
     /// The proxy is captured once, at the start. iOS can attach a new controller
     /// mid-burst, and `controller` is a shared reference that the new one takes
@@ -793,7 +786,6 @@ class KeyboardState: ObservableObject {
     private func deleteInsertedText(
         _ insertedText: String,
         remaining: Int,
-        proven: Int,
         proxy: UITextDocumentProxy
     ) {
         guard remaining > 0 else {
@@ -811,70 +803,35 @@ class KeyboardState: ObservableObject {
             return
         }
 
-        let batch = min(remaining, Self.dictationUndoChunkSize, max(proven, 1))
+        let batch = min(remaining, Self.dictationUndoChunkSize)
         for _ in 0..<batch {
             proxy.deleteBackward()
         }
         let left = remaining - batch
-        if left > 0 {
-            Self.nudgeProxyToRefetchContext(proxy)
-        }
 
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             guard left > 0 else {
-                self.deleteInsertedText(insertedText, remaining: 0, proven: 0, proxy: proxy)
+                self.deleteInsertedText(insertedText, remaining: 0, proxy: proxy)
                 return
             }
             let context = proxy.documentContextBeforeInput
-            switch DictationUndo.verify(
+            if case .failed(let reason) = DictationUndo.verify(
                 context: context,
                 insertedText: String(insertedText.prefix(left))
-            ) {
-            case .ok(_, let verifiedCount, _):
-                self.deleteInsertedText(
-                    insertedText,
-                    remaining: left,
-                    proven: verifiedCount,
-                    proxy: proxy
-                )
-            case .failed(let reason):
+            ), DictationUndo.provesTheFieldChanged(reason) {
                 self.isUndoingDictation = false
-                // `context` is what decides whether the nudge above works. A refusal
-                // with a context far shorter than the chunk just deleted means the
-                // host trimmed its cached window instead of refetching, which is the
-                // case that cannot be fixed from here (#266 device capture).
+                // `context` says how much the host was willing to show at the moment
+                // it stopped us, which is what tells a genuine rewrite apart from a
+                // window that had run dry (#266 device captures).
                 self.logProbe(
                     "dictationUndoAborted",
                     details: "reason=\(reason) remaining=\(left) context=\(context?.count ?? -1)"
                 )
+                return
             }
+            self.deleteInsertedText(insertedText, remaining: left, proxy: proxy)
         }
-    }
-
-    /// Ask the host to refetch the text behind the caret, before we read it again.
-    ///
-    /// WHY (device capture, 2026-08-02, Notes): a 1077-grapheme undo stopped after
-    /// 480 with `window-too-short`. The context window measured 498 when the burst
-    /// started and 18 when it stopped — 498 minus the 480 removed. The host had not
-    /// been serving a *sliding* window over the document at all; it was serving one
-    /// cached window and trimming it as the deletions consumed it. The per-chunk
-    /// re-proof assumed the former, so past the first window there was nothing left
-    /// to prove the remainder against, and the guard did what it is meant to do.
-    ///
-    /// A caret movement is the only lever a keyboard extension has here: there is no
-    /// API to request more context, but moving the insertion point invalidates what
-    /// the proxy holds. One step back and one step forward leaves the caret exactly
-    /// where it was, in the same run-loop turn, before the read on the next one.
-    ///
-    /// Deliberately best-effort. If the host ignores it, or applies only one of the
-    /// two steps, the verification on the next turn sees a tail that is not the
-    /// remainder and refuses — the burst stops with text left in the field, which is
-    /// the direction this feature fails in by design. It cannot make the undo delete
-    /// something it has not proved.
-    private static func nudgeProxyToRefetchContext(_ proxy: UITextDocumentProxy) {
-        proxy.adjustTextPosition(byCharacterOffset: -1)
-        proxy.adjustTextPosition(byCharacterOffset: 1)
     }
 
     // MARK: - Keyboard visibility tracking

--- a/DictusKeyboard/KeyboardViewController.swift
+++ b/DictusKeyboard/KeyboardViewController.swift
@@ -321,6 +321,17 @@ class KeyboardViewController: UIInputViewController {
             self.bridge?.updateCapitalization()
         }
 
+        // --- 8. Wire post-undo cleanup (#266) ---
+        // The suggestions on screen were computed from the last word of a
+        // transcription that no longer exists, so they are emptied rather than
+        // recomputed: after an undo the caret is back where it was before the
+        // dictation, with nothing half-typed to suggest for.
+        KeyboardState.shared.onDictationUndone = { [weak self] in
+            guard let self = self else { return }
+            self.suggestionState.clear()
+            self.bridge?.updateCapitalization()
+        }
+
         // Memory after all viewDidLoad allocations — delta vs entry tells us
         // per-controller allocation cost (UIHostingController + GiellaKeyboardView
         // + SuggestionState + DictusKeyboardBridge + constraints).
@@ -975,6 +986,11 @@ class KeyboardViewController: UIInputViewController {
 
     override func textDidChange(_ textInput: UITextInput?) {
         super.textDidChange(textInput)
+        // Re-check the dictation undo offer against the changed document (#266).
+        // Deliberately a re-check and not a clear: the keyboard's own insertion is
+        // itself a text change, so clearing here would cancel the offer at the
+        // moment it is made.
+        KeyboardState.shared.revalidateDictationUndo()
         // Invalidate autocorrect undo on external text changes (paste, cursor tap, host autocorrect).
         bridge?.suggestionState?.pendingUndo = nil
         // When text changes externally (paste, cursor move, autocorrect by host app),
@@ -988,6 +1004,8 @@ class KeyboardViewController: UIInputViewController {
 
     override func selectionDidChange(_ textInput: UITextInput?) {
         super.selectionDidChange(textInput)
+        // A caret the user moved is a caret the insertion is no longer behind (#266).
+        KeyboardState.shared.revalidateDictationUndo()
         // Some hosts move focus between fields without emitting textDidChange.
         // Re-read the field's input traits so the autocorrect/suggestions policy
         // matches the newly-focused field (#200).

--- a/DictusKeyboard/Localizable.xcstrings
+++ b/DictusKeyboard/Localizable.xcstrings
@@ -161,6 +161,28 @@
           }
         }
       }
+    },
+    "Undo" : {
+      "comment" : "Toolbar control that removes the dictation text just inserted.",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annuler"
+          }
+        }
+      }
+    },
+    "Undo dictation insertion" : {
+      "comment" : "Accessibility label for the toolbar control that removes the dictation text just inserted.",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annuler l'insertion de la dictée"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/DictusKeyboard/Views/ToolbarView.swift
+++ b/DictusKeyboard/Views/ToolbarView.swift
@@ -32,6 +32,14 @@ struct ToolbarView: View {
     var suggestionMode: SuggestionMode = .idle
     var onSuggestionTap: ((Int) -> Void)?
 
+    /// Whether the last dictation insertion can still be undone (#266).
+    /// Transient by construction: it is set for a few seconds after an insertion
+    /// and only while the inserted text is verifiably still the tail of the field.
+    var showsDictationUndo: Bool = false
+
+    /// Removes the last dictation insertion. Re-checks the field before deleting.
+    var onDictationUndoTap: (() -> Void)?
+
     /// Whether the hamburger panel currently fills the keyboard area (#241).
     /// Drives which of the two presentations above the bar renders.
     var isPanelOpen: Bool = false
@@ -83,6 +91,13 @@ struct ToolbarView: View {
     /// hamburger inherits that arbitration from the language switcher it replaced,
     /// at the same 32 pt cost. Accepted consequence (#241): the keyboard language
     /// cannot be changed mid-word.
+    ///
+    /// WHY undo sits between the error message and the suggestions (#266):
+    /// an error means the dictation failed, so there is nothing to undo and the
+    /// error wins. Suggestions lose because immediately after an insertion the user
+    /// has typed nothing, so whatever the bar is showing was predicted from text
+    /// that was just dictated — worth little, and worth less than a control that
+    /// expires in seconds and is the only alternative to holding backspace.
     private var dictationBar: some View {
         HStack {
             if let message = statusMessage {
@@ -91,6 +106,10 @@ struct ToolbarView: View {
                     .foregroundColor(.red)
                     .lineLimit(1)
                     .frame(maxWidth: .infinity)
+            } else if showsDictationUndo {
+                dictationUndoButton
+
+                Spacer()
             } else if suggestions.isEmpty {
                 hamburgerButton
 
@@ -164,6 +183,45 @@ struct ToolbarView: View {
             systemName: "line.3.horizontal",
             label: Text("Keyboard menu")
         )
+    }
+
+    /// Removes the dictation that was just inserted (#266).
+    ///
+    /// WHY it borrows the look of the autocorrect undo chip in `SuggestionBarView`
+    /// — accent tint, uturn arrow: the two controls do the same thing to different
+    /// text, and they appear in the same strip of the same bar seconds apart. A
+    /// user who has learned that a tinted uturn arrow reverts what just happened
+    /// should not have to learn it twice.
+    ///
+    /// It does NOT pulse the way the autocorrect chip does. That pulse exists
+    /// because an autocorrection is silent; a dictation insertion is not — the
+    /// recording overlay has just closed and the text has just appeared.
+    private var dictationUndoButton: some View {
+        Button {
+            HapticFeedback.keyTapped()
+            onDictationUndoTap?()
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: "arrow.uturn.backward")
+                    .font(.system(size: 13, weight: .semibold))
+
+                Text("Undo")
+                    .font(.system(size: 15, weight: .semibold))
+                    .lineLimit(1)
+            }
+            .foregroundColor(.dictusAccent)
+            .padding(.horizontal, 14)
+            .frame(height: iconDiameter)
+            .background(
+                Capsule().fill(Color.dictusAccent.opacity(0.12))
+            )
+            // Same split as `barIcon`: the capsule is what the eye sees, the 44 pt
+            // frame is what a finger hits.
+            .frame(height: 44)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(GlassPressStyle())
+        .accessibilityLabel(Text("Undo dictation insertion"))
     }
 
     private var closeButton: some View {


### PR DESCRIPTION
Implements the transient undo control for the last dictation insertion. refs #266

`Closes` is deliberately not used: it does not auto-close on a merge into `develop` in this repo. Close #266 by hand after merge.

## What changed

**`DictusCore/DictationUndo.swift` (new).** The safety check, as a pure function next to `AutocorrectReplacement` and for the same reason: it is the part that must not be wrong, and the keyboard extension has no test bundle. It answers one question — is the string we inserted still the tail of the field? A bounded proxy window is accepted on a weaker guarantee (the whole visible window must be a suffix of the insertion, and at least 24 graphemes of it), and the result records which of the two guarantees was obtained so a partial match is never read as a full one. 21 unit tests.

**`KeyboardState`.** `handleTranscriptionReady` had two copies of the insert-and-reset block: the direct path and the 100 ms retry that absorbs the App Group propagation race. They are now one `insertTranscription(_:)` called from both. The undo record has to be written by both, and the retry is the path that loses the race, so a copy that forgot it would fail intermittently and only on slow devices.

The record holds the exact string handed to `insertText`. There is nothing to reconstruct: `DictationCoordinator` appends the separator before writing to the App Group, so the separator (or its deliberate absence in Whisper auto-detect, #226) is already inside the recorded string.

It is destroyed — not hidden — on a new dictation, a keystroke, a caret move, the keyboard being dismissed, an 8 s timeout, and any failed check.

**The check runs twice.** Once one main-queue turn after the insertion, and that is what decides whether the control appears at all: a host that reports no usable context (a secure field, say) never sees it. Again immediately before deleting, because the first check proves nothing about the moment of the tap — a host that rewrites text without reporting it leaves a stale offer on screen, and that is caught here. A refusal deletes nothing and fires the refused haptic.

**Deletion** is chunked at 40 `deleteBackward()` per main-queue turn so a long dictation does not block the host, and a mic tap is refused while a burst is in flight so a burst and a new dictation can never interleave. Each chunk re-checks the dictation status as a second line of defence.

**Toolbar.** `dictationBar` gains a fourth branch, in the order settled during triage: error status message, then undo, then suggestions, then the hamburger. The control reuses the accent tint and uturn arrow of the autocorrect undo chip; the two do the same thing to different text and appear in the same strip of the same bar seconds apart. No geometry moves — the bar keeps its 52 pt and swaps content, so nothing here goes near the declared height constraint.

Strings ship in English and French.

## Verified here

- All three targets build (`DictusApp` scheme, iOS Simulator).
- `swift test` in DictusCore: 542 tests, 0 failures (21 of them new).
- `swiftlint lint --strict`: 0 violations.

## Not verified here

Everything that touches `textDocumentProxy`. Nothing in the build or test pipeline exercises a host app's text, and context reporting differs between hosts. The device checklist is in the issue thread; the short version is Notes, Safari, Messages and a chat app, one dictation of a few hundred characters, one insertion that arrives late enough to take the 100 ms retry path, and a length-limited field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a temporary Undo option for the latest dictation.
  * Undo verifies the inserted text before removing it and supports Unicode text safely.
  * Added accessible Undo controls with haptic feedback.
  * Undo availability updates as text, cursor position, and keyboard state change.

* **Bug Fixes**
  * Prevented unintended undo actions after edits, cursor movement, new dictation, or keyboard dismissal.
  * Refreshed suggestions and capitalization after undoing dictation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->