### PR TITLE
Guard the Foundation Models context ceiling: estimate before calling (refs #270)

### DIFF
--- a/DictusApp/Polish/PolishDebugExporter.swift
+++ b/DictusApp/Polish/PolishDebugExporter.swift
@@ -97,7 +97,8 @@ enum PolishDebugExporter {
 
         var outcomes: [String: Int] = [
             "success": 0, "rejectedGuardrail": 0, "skipped": 0,
-            "skippedShort": 0, "skippedAutoMode": 0, "cancelled": 0, "engineFailed": 0
+            "skippedShort": 0, "skippedAutoMode": 0, "cancelled": 0, "engineFailed": 0,
+            "exceededContextBudget": 0
         ]
         for e in entries {
             outcomes[e.metrics.outcome.rawValue, default: 0] += 1

--- a/DictusApp/Polish/PolishDebugView.swift
+++ b/DictusApp/Polish/PolishDebugView.swift
@@ -286,7 +286,8 @@ private struct PolishExportShareSheet: UIViewControllerRepresentable {
 
 private extension PolishMetrics.Outcome {
     static var allDisplayCases: [PolishMetrics.Outcome] {
-        [.success, .rejectedGuardrail, .skipped, .skippedShort, .skippedAutoMode, .cancelled, .engineFailed]
+        [.success, .rejectedGuardrail, .skipped, .skippedShort, .skippedAutoMode,
+         .cancelled, .engineFailed, .exceededContextBudget]
     }
 
     var shortLabel: String {
@@ -298,13 +299,17 @@ private extension PolishMetrics.Outcome {
         case .skippedAutoMode: return "auto"
         case .cancelled: return "cancelled"
         case .engineFailed: return "failed"
+        case .exceededContextBudget: return "too long"
         }
     }
 
     var tintColor: Color {
         switch self {
         case .success: return .green
-        case .rejectedGuardrail, .skipped, .skippedShort, .skippedAutoMode: return .orange
+        // Orange, not red: an overflow is a refusal, not a breakage — the
+        // engine was never called and the user still got their text (#270).
+        case .rejectedGuardrail, .skipped, .skippedShort, .skippedAutoMode,
+             .exceededContextBudget: return .orange
         case .cancelled, .engineFailed: return .red
         }
     }

--- a/DictusCore/Sources/DictusCore/Polish/AppleFoundationModelsPolishEngine.swift
+++ b/DictusCore/Sources/DictusCore/Polish/AppleFoundationModelsPolishEngine.swift
@@ -106,6 +106,31 @@ public final class AppleFoundationModelsPolishEngine: PolishEngineProtocol, Send
         session.prewarm()
     }
 
+    // MARK: - Context ceiling (#270)
+
+    /// The window this engine has to fit into. See `PolishContextBudget` for
+    /// how the numbers were measured; the ceiling itself is the same 4096-token
+    /// one the session lifecycle above already had to work around.
+    public static let contextBudget = PolishContextBudget.appleFoundationModels
+
+    /// Price the call before making it: the RESOLVED instructions for
+    /// `(mode, targetLanguage)` — which is what the session was or will be
+    /// created with, including any harness override — plus the input, plus a
+    /// reserve for the generated output. Instruction length varies by a factor
+    /// of two across the prompt set, and the measurement showed instructions
+    /// and input trade one-for-one inside the window, so a fixed instruction
+    /// allowance would under-estimate exactly where it matters most.
+    /// The arguments below are the ones `polish()` itself passes to
+    /// `resolvedInstructions`, so what is priced is exactly what is sent.
+    public func contextFit(input: String,
+                           targetLanguage: SupportedLanguage,
+                           mode: PolishMode) -> PolishContextFit {
+        Self.contextBudget.fit(
+            instructions: resolvedInstructions(mode: mode, language: targetLanguage),
+            input: input
+        )
+    }
+
     // MARK: - Instruction routing
 
     /// Returns the system prompt for `(mode, language)`. All four supported

--- a/DictusCore/Sources/DictusCore/Polish/PolishContextBudget.swift
+++ b/DictusCore/Sources/DictusCore/Polish/PolishContextBudget.swift
@@ -1,0 +1,191 @@
+// DictusCore/Sources/DictusCore/Polish/PolishContextBudget.swift
+import Foundation
+
+/// Verdict of the pre-call context check (#270): does one polish call fit
+/// inside its engine's context window?
+///
+/// Returned by `PolishEngineProtocol.contextFit(...)` so the pipeline can refuse
+/// an oversized call WITHOUT knowing any engine's numbers — the ceiling belongs
+/// to the backend, not to the transform around it. Engines with no ceiling
+/// (`PassthroughPolishEngine`, and any future streaming backend) never return
+/// `.exceeds`.
+public enum PolishContextFit: Sendable, Equatable {
+    /// The engine has no ceiling, or the estimate fits under it.
+    case fits
+    /// The estimate exceeds the ceiling. Carries both numbers so logs and
+    /// metrics can say *how far* over, which is what tells a "one long
+    /// dictation" apart from "our estimate is systematically wrong".
+    case exceeds(estimatedTokens: Int, budgetTokens: Int)
+}
+
+/// The context ceiling of a polish backend, and the cheap estimator that
+/// decides whether one call fits under it (#270).
+///
+/// WHY this exists: Apple's on-device model has a single context window that
+/// covers **instructions + input + generated output together**. Overflow throws
+/// `exceededContextWindowSize` mid-call, which `PolishPipeline` could only
+/// record as a generic `.engineFailed` — indistinguishable from a crash or a
+/// timeout. Estimating first turns a silent, unattributable failure into an
+/// explicit, named refusal.
+///
+/// Lives here rather than inside `AppleFoundationModelsPolishEngine` because
+/// that type is behind `#if canImport(FoundationModels)`; the budget arithmetic
+/// is plain Swift and must stay unit-testable on every toolchain.
+public struct PolishContextBudget: Sendable, Equatable {
+
+    /// Total tokens the window holds — instructions, input and output together.
+    public let contextWindowTokens: Int
+
+    /// Tokens the backend spends on framing we do not control or measure: the
+    /// engine's own Input/Output prompt wrapper plus whatever chat template the
+    /// session prepends (role headers, BOS).
+    public let scaffoldingTokens: Int
+
+    /// Output allowance, as a multiple of the estimated input size. Polish is a
+    /// rewrite, so the output is roughly as long as the input; the extra 10%
+    /// covers Repair mode, where reconstructing intent in another language
+    /// expands the text (EN→FR runs ~15% longer).
+    public let outputReserveRatio: Double
+
+    /// Multiplier applied to the whole estimate before comparing it to the
+    /// window.
+    ///
+    /// The constants below were measured on fluent, common-word prose (see
+    /// `latinCharsPerToken`). Real STT output is messier — proper nouns,
+    /// digits, mistranscribed fragments — and all of those tokenize less
+    /// efficiently than the sentences we measured. The margin covers that gap,
+    /// plus the fact that generated output length is not knowable in advance.
+    ///
+    /// WHY only 20%, when the brief is to err toward over-estimating: the two
+    /// errors are not symmetric, but neither is catastrophic. Under-estimating
+    /// lets the engine throw, which lands on exactly today's behaviour — the
+    /// user still receives the deterministic floor, we just lose the named
+    /// reason. Over-estimating refuses a call that would have worked, taking
+    /// polish away from a dictation that works today. So the margin is real but
+    /// deliberately modest: enough to absorb tokenizer variance, not enough to
+    /// halve the length a user may dictate.
+    public let safetyMargin: Double
+
+    public init(contextWindowTokens: Int,
+                scaffoldingTokens: Int,
+                outputReserveRatio: Double,
+                safetyMargin: Double) {
+        self.contextWindowTokens = contextWindowTokens
+        self.scaffoldingTokens = scaffoldingTokens
+        self.outputReserveRatio = outputReserveRatio
+        self.safetyMargin = safetyMargin
+    }
+
+    /// Apple's on-device Foundation Model, as used by
+    /// `AppleFoundationModelsPolishEngine`.
+    ///
+    /// MEASURED, not assumed (#270, 2026-08-01, macOS 26.5.1, Apple
+    /// Intelligence on): a session was given a one-word instruction and
+    /// increasingly long inputs with `maximumResponseTokens: 1`, and the
+    /// largest input that did not throw `exceededContextWindowSize` was
+    /// binary-searched. The window came out at 4096 tokens — the number the
+    /// engine's own comments already documented — and the same probe produced
+    /// the characters-per-token ratios below.
+    ///
+    /// A second run confirmed instructions and input really do share one pool:
+    /// swapping the one-word instruction for a 5000-character one (~977 tokens)
+    /// cost 4800 characters of French input (~972 tokens). Instruction text and
+    /// input text are interchangeable inside the window, one token for one
+    /// token — which is why the estimate has to price the resolved prompt.
+    public static let appleFoundationModels = PolishContextBudget(
+        contextWindowTokens: 4096,
+        // The engine's wrapper ("Polish this text… Input: … Polished output:")
+        // is ~25 tokens; the session's chat template adds a few dozen more.
+        scaffoldingTokens: 64,
+        outputReserveRatio: 1.1,
+        safetyMargin: 1.2
+    )
+
+    // MARK: - Fit
+
+    /// Estimated total token cost of one call: instructions + scaffolding +
+    /// input + the output reserve, all multiplied by the safety margin.
+    public func estimatedTokens(instructions: String, input: String) -> Int {
+        let inputTokens = Self.estimatedTokens(in: input)
+        let outputReserve = Int((Double(inputTokens) * outputReserveRatio).rounded(.up))
+        let subtotal = Self.estimatedTokens(in: instructions)
+            + scaffoldingTokens
+            + inputTokens
+            + outputReserve
+        return Int((Double(subtotal) * safetyMargin).rounded(.up))
+    }
+
+    /// Whether one call fits. `instructions` must be the **resolved** system
+    /// prompt for the mode and language actually being run — the prompts differ
+    /// by a factor of two in length (the language-agnostic Auto prompt is the
+    /// longest, the English Repair prompt the shortest), so a fixed allowance
+    /// would under-estimate on exactly the modes with the most to lose.
+    public func fit(instructions: String, input: String) -> PolishContextFit {
+        let total = estimatedTokens(instructions: instructions, input: input)
+        guard total > contextWindowTokens else { return .fits }
+        return .exceeds(estimatedTokens: total, budgetTokens: contextWindowTokens)
+    }
+
+    // MARK: - Estimator
+
+    /// Characters per token for alphabetic scripts.
+    ///
+    /// MEASURED against the real model (see `appleFoundationModels`): French
+    /// 4.94, English 5.12, German 5.42 characters per token on fluent prose.
+    /// The lowest of the three is used, so the estimate is already the
+    /// least favourable of our four Latin-script languages before the safety
+    /// margin applies.
+    private static let latinCharsPerToken = 4.9
+
+    /// Tokens per ideographic character (Han, Kana, Hangul).
+    ///
+    /// MEASURED at 1.80 characters per token — i.e. 0.56 tokens per character,
+    /// roughly nine times denser per character than Latin script. Auto-detect
+    /// mode (#239) accepts the whole long tail of languages, so a single
+    /// Latin-tuned ratio would badly under-count a Chinese or Japanese
+    /// dictation. Rounded up to 0.6.
+    private static let tokensPerIdeographicChar = 0.6
+
+    /// Cheap, deliberately approximate token count for `text`.
+    ///
+    /// One pass over the Unicode scalars, splitting them into ideographic and
+    /// everything-else and applying the measured ratio to each. No tokenizer,
+    /// no allocation, no table lookup — this runs on every dictation, and a
+    /// costly estimator would tax the common case to protect the rare one.
+    /// Exactness is not the goal: `fit(instructions:input:)` only ever compares
+    /// the result against a ceiling that already carries a safety margin.
+    public static func estimatedTokens(in text: String) -> Int {
+        var alphabetic = 0
+        var ideographic = 0
+        for scalar in text.unicodeScalars {
+            if isIdeographic(scalar) {
+                ideographic += 1
+            } else {
+                alphabetic += 1
+            }
+        }
+        let tokens = Double(alphabetic) / latinCharsPerToken
+            + Double(ideographic) * tokensPerIdeographicChar
+        return Int(tokens.rounded(.up))
+    }
+
+    /// Han ideographs, Japanese kana, Hangul and the CJK punctuation/full-width
+    /// blocks that travel with them. Deliberately a short list of ranges rather
+    /// than a `CharacterSet`: the check runs per scalar on every dictation, and
+    /// range comparisons cost nothing.
+    private static func isIdeographic(_ scalar: Unicode.Scalar) -> Bool {
+        switch scalar.value {
+        case 0x3000...0x303F,   // CJK symbols and punctuation
+             0x3040...0x30FF,   // Hiragana + Katakana
+             0x3400...0x4DBF,   // CJK Unified Ideographs Extension A
+             0x4E00...0x9FFF,   // CJK Unified Ideographs
+             0xAC00...0xD7AF,   // Hangul syllables
+             0xF900...0xFAFF,   // CJK compatibility ideographs
+             0xFF00...0xFFEF,   // Half-width and full-width forms
+             0x20000...0x2FA1F: // CJK Unified Ideographs Extensions B–F
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/DictusCore/Sources/DictusCore/Polish/PolishContextBudget.swift
+++ b/DictusCore/Sources/DictusCore/Polish/PolishContextBudget.swift
@@ -41,29 +41,36 @@ public struct PolishContextBudget: Sendable, Equatable {
     /// session prepends (role headers, BOS).
     public let scaffoldingTokens: Int
 
-    /// Output allowance, as a multiple of the estimated input size. Polish is a
-    /// rewrite, so the output is roughly as long as the input; the extra 10%
-    /// covers Repair mode, where reconstructing intent in another language
-    /// expands the text (EN→FR runs ~15% longer).
+    /// Output allowance, as a multiple of the estimated input size.
+    ///
+    /// This is the term that carries the uncertainty, and the one the
+    /// measurement reshaped. The overflow does not happen on prefill — it
+    /// happens **during generation**, fifteen to twenty seconds into the call.
+    /// On a successful call the model emits about 0.5 tokens per input token;
+    /// on a failing one it runs away and emits past 2.3×. Which of the two
+    /// happens is not knowable in advance, so the reserve is not "the expected
+    /// output" — it is the lever that sets where a call stops being worth
+    /// making. See `appleFoundationModels` for the data it was set from.
     public let outputReserveRatio: Double
 
     /// Multiplier applied to the whole estimate before comparing it to the
     /// window.
     ///
-    /// The constants below were measured on fluent, common-word prose (see
-    /// `latinCharsPerToken`). Real STT output is messier — proper nouns,
-    /// digits, mistranscribed fragments — and all of those tokenize less
-    /// efficiently than the sentences we measured. The margin covers that gap,
-    /// plus the fact that generated output length is not knowable in advance.
+    /// The character-per-token ratios below were measured on fluent,
+    /// common-word prose. Real STT output is messier — proper nouns, digits,
+    /// mistranscribed fragments — and all of those tokenize less efficiently
+    /// than the sentences we measured. This margin covers that gap and nothing
+    /// else; the generation-length uncertainty lives in `outputReserveRatio`,
+    /// where it belongs and where it can be retuned on its own.
     ///
-    /// WHY only 20%, when the brief is to err toward over-estimating: the two
-    /// errors are not symmetric, but neither is catastrophic. Under-estimating
-    /// lets the engine throw, which lands on exactly today's behaviour — the
-    /// user still receives the deterministic floor, we just lose the named
-    /// reason. Over-estimating refuses a call that would have worked, taking
-    /// polish away from a dictation that works today. So the margin is real but
-    /// deliberately modest: enough to absorb tokenizer variance, not enough to
-    /// halve the length a user may dictate.
+    /// WHY the two are kept separate and both modest: the errors are not
+    /// symmetric, but neither is catastrophic. Under-estimating lets the engine
+    /// throw, which lands on exactly today's behaviour — the user still gets
+    /// the deterministic floor, we just lose the named reason. Over-estimating
+    /// refuses a call that might have worked, taking polish away from a
+    /// dictation that works today. And no static estimate can eliminate the
+    /// throw: generation length is the model's choice, so the `.engineFailed`
+    /// path stays the backstop it always was.
     public let safetyMargin: Double
 
     public init(contextWindowTokens: Int,
@@ -92,13 +99,49 @@ public struct PolishContextBudget: Sendable, Equatable {
     /// cost 4800 characters of French input (~972 tokens). Instruction text and
     /// input text are interchangeable inside the window, one token for one
     /// token — which is why the estimate has to price the resolved prompt.
+    ///
+    /// A third run drove the real French Natural prompt through the real engine
+    /// at increasing input lengths, repeated per length, on varied French
+    /// dictation text. It found no clean threshold, and that result is the most
+    /// important thing on this page:
+    ///
+    ///     3 000 chars  ok / ok / ok
+    ///     3 600 chars  threw / ok / ok
+    ///     4 150 chars  ok / ok / ok / threw
+    ///     4 400 chars  ok / threw
+    ///     4 700 chars  ok / ok
+    ///     5 000 chars  threw / ok
+    ///     5 200 chars  threw / threw
+    ///
+    /// Two things follow, and both shape the numbers below.
+    ///
+    /// **The failure is probabilistic, not a cliff.** The same input can throw
+    /// on one call and succeed on the next, because the model sometimes runs
+    /// away during generation. Its probability climbs steeply with input length
+    /// but never becomes a clean line. So no static estimate can eliminate the
+    /// throw, and this guard does not pretend to: the `.engineFailed` path
+    /// stays exactly the backstop it always was, for the runaway that happens
+    /// under any threshold.
+    ///
+    /// **Above ~4 500 characters the call is not worth making anyway.** Every
+    /// successful run in the sweep returned about 2 300 characters regardless
+    /// of how much went in — the model truncates rather than polishing the
+    /// whole text. Against `PolishGuardrail`'s 0.5 length-ratio floor in
+    /// Natural mode, a 4 700-character input polished down to 2 300 is rejected
+    /// on arrival. Past that point the engine call costs ten seconds to produce
+    /// something the pipeline will throw away.
+    ///
+    /// The constants therefore put the refusal at ~4 160 characters for the
+    /// French Natural prompt (~690 words, ~4½ minutes of speech), which is
+    /// where the two curves meet: below it the call usually succeeds and the
+    /// output is usable, above it neither holds reliably.
     public static let appleFoundationModels = PolishContextBudget(
         contextWindowTokens: 4096,
         // The engine's wrapper ("Polish this text… Input: … Polished output:")
         // is ~25 tokens; the session's chat template adds a few dozen more.
         scaffoldingTokens: 64,
-        outputReserveRatio: 1.1,
-        safetyMargin: 1.2
+        outputReserveRatio: 1.8,
+        safetyMargin: 1.15
     )
 
     // MARK: - Fit

--- a/DictusCore/Sources/DictusCore/Polish/PolishEngineProtocol.swift
+++ b/DictusCore/Sources/DictusCore/Polish/PolishEngineProtocol.swift
@@ -24,8 +24,31 @@ public protocol PolishEngineProtocol: Sendable {
     /// (#239). Default implementation is a no-op for engines that have
     /// nothing to warm.
     func prewarm(mode: PolishMode, targetLanguage: SupportedLanguage) async
+
+    /// Whether a `polish(raw:targetLanguage:mode:)` call with this exact input
+    /// would fit inside the backend's context window (#270).
+    ///
+    /// Asked by `PolishPipeline` immediately before the call, so an overflow is
+    /// an explicit, named refusal instead of a mid-call throw the pipeline can
+    /// only record as a generic engine failure. The engine answers because the
+    /// ceiling is a property of the backend — its window size, its system
+    /// prompt for `(mode, targetLanguage)`, its prompt scaffolding. No caller
+    /// hardcodes a number.
+    ///
+    /// `input` is the string that will be passed as `raw`, i.e. already through
+    /// the newline-marker encode — the markers cost tokens too.
+    ///
+    /// Default implementation returns `.fits`: an engine with no ceiling is
+    /// valid and stays unaffected.
+    func contextFit(input: String,
+                    targetLanguage: SupportedLanguage,
+                    mode: PolishMode) -> PolishContextFit
 }
 
 public extension PolishEngineProtocol {
     func prewarm(mode: PolishMode, targetLanguage: SupportedLanguage) async {}
+
+    func contextFit(input: String,
+                    targetLanguage: SupportedLanguage,
+                    mode: PolishMode) -> PolishContextFit { .fits }
 }

--- a/DictusCore/Sources/DictusCore/Polish/PolishMetrics.swift
+++ b/DictusCore/Sources/DictusCore/Polish/PolishMetrics.swift
@@ -46,6 +46,14 @@ public struct PolishMetrics: Sendable, Codable {
         case skippedAutoMode
         case cancelled
         case engineFailed
+        /// Refused BEFORE the engine call (#270): the estimated token cost of
+        /// the resolved instructions + input + output reserve exceeds the
+        /// backend's context window. Deliberately distinct from
+        /// `engineFailed` — nothing failed and nothing was attempted, the input
+        /// simply does not fit. Keeping the two apart is what lets a caller say
+        /// "that was too long" instead of "something went wrong", and what lets
+        /// the metrics tell a length problem from a backend problem.
+        case exceededContextBudget
     }
 
     public let engine: String              // polish engine id, e.g. "apple-fm"
@@ -91,6 +99,20 @@ public struct PolishMetrics: Sendable, Codable {
         self.sttEngine = sttEngine
         self.sttModelID = sttModelID
         self.timings = timings
+    }
+
+    /// Emit one line for a pre-call context refusal (#270). The metrics event
+    /// that follows records the outcome but not the arithmetic behind it, and
+    /// the arithmetic is what tells "one genuinely enormous dictation" apart
+    /// from "our safety margin is mis-tuned" when reading a debug log.
+    public static func logContextOverflow(estimatedTokens: Int,
+                                          budgetTokens: Int,
+                                          mode: PolishMode) {
+        if #available(iOS 14.0, macOS 11.0, *) {
+            PolishLog.logger.info(
+                "📊 polish context-overflow mode=\(mode.rawValue, privacy: .public) estimatedTokens=\(estimatedTokens, privacy: .public) budgetTokens=\(budgetTokens, privacy: .public) — engine not called"
+            )
+        }
     }
 
     /// Emit one line to the `polish` os_log category. Prefixed with `📊 polish`

--- a/DictusCore/Sources/DictusCore/Polish/PolishPipeline.swift
+++ b/DictusCore/Sources/DictusCore/Polish/PolishPipeline.swift
@@ -12,7 +12,8 @@ public enum PolishPipeline {
     /// Outcome of one engine-facing transform. Mirrors what `PolishCoordinator`
     /// records in metrics. `engineOutput` is the decoded polished text — present
     /// even when the guardrail rejected it (so callers can inspect what was
-    /// rejected), `nil` only when the engine threw or was cancelled.
+    /// rejected), `nil` when the engine threw, was cancelled, or was never
+    /// called at all (`.exceededContextBudget`).
     public struct Result: Sendable {
         public let engineOutput: String?
         public let outcome: PolishMetrics.Outcome
@@ -49,6 +50,22 @@ public enum PolishPipeline {
         // ", " + capital — see `PolishPostpass`. Sub-millisecond, kept out of the
         // engine timing below.
         let engineInput = PolishPostpass.encodeForEngine(preprocessed)
+        // Context guard (#270). The backend answers whether this exact input,
+        // with the instructions it will resolve for `(mode, target)`, fits its
+        // window. Engines with no ceiling answer `.fits` by default, so this is
+        // a no-op for them. Deliberately placed BEFORE `engineStart`: it costs
+        // a single pass over the strings (tens of microseconds), and folding it
+        // into `engineMs` would pollute the one number that measures the LLM.
+        if case .exceeds(let estimated, let budget) = engine.contextFit(
+            input: engineInput, targetLanguage: target, mode: mode
+        ) {
+            // The engine is NOT called. `resolvedOutput` returns the
+            // deterministic floor for this outcome exactly as it does for an
+            // engine failure — the user's text is never at risk here, only
+            // the polish is.
+            PolishMetrics.logContextOverflow(estimatedTokens: estimated, budgetTokens: budget, mode: mode)
+            return Result(engineOutput: nil, outcome: .exceededContextBudget, engineMs: 0, postprocessMs: 0)
+        }
         let engineStart = Date()
         do {
             let polishedRaw = try await engine.polish(
@@ -109,8 +126,9 @@ public enum PolishPipeline {
     /// The string the user actually receives, given a transform `Result` and the
     /// deterministic pre-pass output. On `.success` it's the accepted engine
     /// output; on EVERY other outcome (gibberish-skip, engine failure, guardrail
-    /// rejection, cancellation) it's the deterministic floor — the pre-pass text
-    /// with newline markers decoded and target-language typography applied.
+    /// rejection, cancellation, context overflow) it's the deterministic floor —
+    /// the pre-pass text with newline markers decoded and target-language
+    /// typography applied.
     ///
     /// Crucially it is NEVER the literal `raw`: a non-success must not throw away
     /// the free, deterministic verbal-punctuation work (otherwise the user sees

--- a/DictusCore/Tests/DictusCoreTests/Polish/PolishContextBudgetTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/Polish/PolishContextBudgetTests.swift
@@ -1,0 +1,353 @@
+// DictusCore/Tests/DictusCoreTests/Polish/PolishContextBudgetTests.swift
+import XCTest
+@testable import DictusCore
+
+/// Coverage of the pre-call context guard (#270): the budget arithmetic itself,
+/// and the `PolishPipeline` behaviour it drives. Everything here is
+/// deterministic and runs without Apple Foundation Models, except the clearly
+/// marked section that prices the real shipping prompts.
+final class PolishContextBudgetTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// A budget with every multiplier neutralised, so a test can reason about
+    /// the arithmetic without the safety margin or the output reserve in the
+    /// way. Production numbers live in `PolishContextBudget.appleFoundationModels`.
+    private func plainBudget(window: Int) -> PolishContextBudget {
+        PolishContextBudget(contextWindowTokens: window,
+                            scaffoldingTokens: 0,
+                            outputReserveRatio: 0,
+                            safetyMargin: 1.0)
+    }
+
+    /// Largest input length, in characters, that `budget` still accepts.
+    /// Binary-searched through the public API so the boundary tests below stay
+    /// correct if the estimator's constants are ever retuned.
+    private func largestAcceptedLength(budget: PolishContextBudget,
+                                       instructions: String) -> Int {
+        var accepted = 0
+        var refused = 200_000
+        while refused - accepted > 1 {
+            let mid = (accepted + refused) / 2
+            if case .fits = budget.fit(instructions: instructions,
+                                       input: String(repeating: "a", count: mid)) {
+                accepted = mid
+            } else {
+                refused = mid
+            }
+        }
+        return accepted
+    }
+
+    // MARK: - Estimator
+
+    /// Ideographic scripts pack far more tokens into the same character count.
+    /// A single Latin-tuned ratio would wave a long Chinese dictation straight
+    /// into an overflow, which is the failure auto mode (#239) makes reachable.
+    func testIdeographicTextIsPricedFarAboveLatinTextOfTheSameLength() {
+        let latin = String(repeating: "a", count: 600)
+        let han = String(repeating: "字", count: 600)
+        let latinTokens = PolishContextBudget.estimatedTokens(in: latin)
+        let hanTokens = PolishContextBudget.estimatedTokens(in: han)
+        XCTAssertGreaterThan(hanTokens, latinTokens * 2)
+    }
+
+    func testEmptyTextCostsNothing() {
+        XCTAssertEqual(PolishContextBudget.estimatedTokens(in: ""), 0)
+    }
+
+    /// The estimator must over-count, never under-count, against the ratios
+    /// measured on the real model (French 4.94 characters per token, the least
+    /// favourable of the four Latin-script languages).
+    func testLatinEstimateIsConservativeAgainstTheMeasuredRatio() {
+        let text = String(repeating: "une phrase de dictée tout à fait ordinaire ", count: 100)
+        let measuredTokens = Double(text.count) / 4.94
+        XCTAssertGreaterThanOrEqual(Double(PolishContextBudget.estimatedTokens(in: text)),
+                                    measuredTokens)
+    }
+
+    // MARK: - Fit: the four length bands
+
+    func testComfortablyUnderBudgetFits() {
+        let budget = plainBudget(window: 1000)
+        let fit = budget.fit(instructions: "short prompt", input: "a normal length dictation")
+        XCTAssertEqual(fit, .fits)
+    }
+
+    func testFarOverBudgetIsRefused() {
+        let budget = plainBudget(window: 1000)
+        let fit = budget.fit(instructions: "short prompt",
+                             input: String(repeating: "a", count: 200_000))
+        guard case .exceeds(let estimated, let window) = fit else {
+            return XCTFail("expected .exceeds, got \(fit)")
+        }
+        XCTAssertEqual(window, 1000)
+        XCTAssertGreaterThan(estimated, 10_000)
+    }
+
+    /// The boundary is exact and inclusive: an estimate equal to the window
+    /// fits, one token more does not.
+    func testBoundaryIsInclusiveOfTheWindow() {
+        let instructions = String(repeating: "b", count: 500)
+        let input = String(repeating: "a", count: 2000)
+        // Any window works to compute the estimate — `estimatedTokens` does not
+        // consult it.
+        let estimate = plainBudget(window: 1).estimatedTokens(instructions: instructions,
+                                                              input: input)
+        XCTAssertEqual(plainBudget(window: estimate).fit(instructions: instructions, input: input),
+                       .fits,
+                       "an estimate exactly on the window must fit")
+        XCTAssertEqual(plainBudget(window: estimate - 1).fit(instructions: instructions, input: input),
+                       .exceeds(estimatedTokens: estimate, budgetTokens: estimate - 1),
+                       "one token over the window must be refused")
+    }
+
+    /// Just under and just over, expressed in input length rather than tokens —
+    /// the dimension the user actually varies.
+    func testJustUnderFitsAndJustOverIsRefused() {
+        let budget = PolishContextBudget.appleFoundationModels
+        let instructions = String(repeating: "instruction line. ", count: 300)
+        let limit = largestAcceptedLength(budget: budget, instructions: instructions)
+        XCTAssertGreaterThan(limit, 0, "the prompt alone must not exhaust the window")
+        XCTAssertEqual(budget.fit(instructions: instructions,
+                                  input: String(repeating: "a", count: limit)),
+                       .fits)
+        if case .fits = budget.fit(instructions: instructions,
+                                   input: String(repeating: "a", count: limit + 1)) {
+            XCTFail("one character past the limit must be refused")
+        }
+    }
+
+    // MARK: - Fit: the instructions are part of the bill
+
+    /// The criterion the whole design turns on: an input that fits on its own
+    /// stops fitting once the resolved prompt is priced with it. Measurement
+    /// showed instruction tokens and input tokens trade one for one inside the
+    /// window, so a fixed instruction allowance would under-estimate on exactly
+    /// the modes with the longest prompts.
+    func testInputUnderBudgetAloneIsRefusedOnceInstructionsAreAdded() {
+        let budget = plainBudget(window: 500)
+        let input = String(repeating: "a", count: 2000) // ~409 tokens
+        XCTAssertEqual(budget.fit(instructions: "", input: input), .fits)
+        let longPrompt = String(repeating: "b", count: 2000) // another ~409 tokens
+        guard case .exceeds = budget.fit(instructions: longPrompt, input: input) else {
+            return XCTFail("the same input must be refused once the prompt is counted")
+        }
+    }
+
+    /// Two prompts of different length must produce different verdicts for the
+    /// same input — i.e. the estimate is mode- and language-specific by
+    /// construction, not by a constant.
+    func testLongerInstructionsShrinkTheAcceptedInputLength() {
+        let budget = PolishContextBudget.appleFoundationModels
+        let shortPrompt = String(repeating: "instruction line. ", count: 100)
+        let longPrompt = String(repeating: "instruction line. ", count: 400)
+        XCTAssertGreaterThan(largestAcceptedLength(budget: budget, instructions: shortPrompt),
+                             largestAcceptedLength(budget: budget, instructions: longPrompt))
+    }
+
+    // MARK: - Latency
+
+    /// The guard runs on every dictation, so it has to be free. Measured over a
+    /// realistic pair: a full-size system prompt and a two-minute dictation.
+    func testEstimatorCostIsNegligibleOnANormalDictation() {
+        let instructions = String(repeating: "an instruction line of the system prompt. ", count: 150)
+        let input = String(repeating: "une phrase de dictée tout à fait ordinaire. ", count: 40)
+        let budget = PolishContextBudget.appleFoundationModels
+        let iterations = 1000
+        let start = Date()
+        for _ in 0..<iterations {
+            _ = budget.fit(instructions: instructions, input: input)
+        }
+        let perCallMs = Date().timeIntervalSince(start) * 1000 / Double(iterations)
+        XCTAssertLessThan(perCallMs, 1.0,
+                          "estimator cost \(perCallMs) ms/call — it must not be visible in the latency breakdown")
+    }
+
+    // MARK: - Pipeline behaviour
+
+    func testTransformRefusesOversizedInputWithoutCallingTheEngine() async {
+        let engine = CeilingStubEngine(window: 200)
+        let result = await PolishPipeline.transform(
+            preprocessed: String(repeating: "a", count: 20_000),
+            engine: engine,
+            target: .french,
+            mode: .natural
+        )
+        XCTAssertEqual(result.outcome, .exceededContextBudget)
+        XCTAssertEqual(engine.polishCallCount, 0, "the engine must never be called on an overflow")
+        XCTAssertNil(result.engineOutput)
+        XCTAssertEqual(result.engineMs, 0)
+    }
+
+    func testTransformStillCallsTheEngineWhenTheInputFits() async {
+        let engine = CeilingStubEngine(window: 4096)
+        let input = "une dictée de longueur parfaitement ordinaire"
+        let result = await PolishPipeline.transform(
+            preprocessed: input, engine: engine, target: .french, mode: .natural
+        )
+        XCTAssertEqual(result.outcome, .success)
+        XCTAssertEqual(engine.polishCallCount, 1)
+        XCTAssertEqual(result.engineOutput, input)
+    }
+
+    /// An overflow must be tellable apart from a backend failure by a caller
+    /// inspecting the result — that distinction is the point of the case.
+    func testOverflowIsDistinguishableFromAnEngineFailure() async {
+        let oversized = String(repeating: "a", count: 20_000)
+        let refused = await PolishPipeline.transform(
+            preprocessed: oversized, engine: CeilingStubEngine(window: 200),
+            target: .french, mode: .natural
+        )
+        // Same oversized input through an engine with no ceiling that throws:
+        // the pipeline records the generic failure it always did.
+        let failed = await PolishPipeline.transform(
+            preprocessed: oversized, engine: ThrowingStubEngine(),
+            target: .french, mode: .natural
+        )
+        XCTAssertEqual(refused.outcome, .exceededContextBudget)
+        XCTAssertEqual(failed.outcome, .engineFailed)
+        XCTAssertNotEqual(refused.outcome, failed.outcome)
+    }
+
+    /// An overflow returns the deterministic floor, exactly as an engine
+    /// failure does — the user's text is never at risk, only the polish is.
+    func testResolvedOutputFallsBackToTheFloorOnOverflow() {
+        let preprocessed = "Ok, petit test ?"
+        let result = PolishPipeline.Result(
+            engineOutput: nil, outcome: .exceededContextBudget, engineMs: 0, postprocessMs: 0
+        )
+        let out = PolishPipeline.resolvedOutput(
+            result, preprocessed: preprocessed, target: .french, mode: .natural
+        )
+        XCTAssertEqual(out, "Ok, petit test\u{00A0}?", "the floor still applies French typography")
+    }
+
+    // MARK: - Engines without a ceiling
+
+    /// The default protocol implementation: an engine that declares no ceiling
+    /// is never refused, however long the input.
+    func testPassthroughEngineDeclaresNoCeiling() {
+        let engine = PassthroughPolishEngine()
+        let fit = engine.contextFit(input: String(repeating: "a", count: 500_000),
+                                    targetLanguage: .french,
+                                    mode: .natural)
+        XCTAssertEqual(fit, .fits)
+    }
+
+    func testTransformRunsAnUnboundedEngineOnAnEnormousInput() async {
+        // 40 000 characters — well past the Apple FM ceiling, irrelevant here.
+        let input = String(repeating: "une phrase de dictée ordinaire. ", count: 1250)
+        let result = await PolishPipeline.transform(
+            preprocessed: input, engine: PassthroughPolishEngine(), target: .french, mode: .natural
+        )
+        XCTAssertEqual(result.outcome, .success)
+        XCTAssertEqual(result.engineOutput, input)
+    }
+
+    // MARK: - The real shipping prompts
+
+    #if canImport(FoundationModels)
+    /// The prompts differ enough in length to matter: the language-agnostic
+    /// Auto prompt is the longest and the English Repair prompt the shortest,
+    /// so the same dictation can fit under one and overflow the other.
+    func testRealPromptsPriceDifferentlyPerModeAndLanguage() throws {
+        guard #available(iOS 26.0, macOS 26.0, *) else {
+            throw XCTSkip("Apple Foundation Models prompts require the iOS/macOS 26 SDK")
+        }
+        let budget = PolishContextBudget.appleFoundationModels
+        let auto = AppleFoundationModelsPolishEngine.instructions(for: .auto, language: .english)
+        let repairEN = AppleFoundationModelsPolishEngine.instructions(for: .repair, language: .english)
+        let autoLimit = largestAcceptedLength(budget: budget, instructions: auto)
+        let repairLimit = largestAcceptedLength(budget: budget, instructions: repairEN)
+        XCTAssertLessThan(autoLimit, repairLimit,
+                          "the longest prompt must leave the least room for input")
+    }
+
+    /// A regression guard on the constants, deliberately loose. The measured
+    /// ceiling for the French Natural prompt sits around 7 000 characters of
+    /// input; the estimate is meant to refuse somewhat earlier than that, not
+    /// at half of it and not past it.
+    func testFrenchNaturalPromptAcceptsARealisticDictationLength() throws {
+        guard #available(iOS 26.0, macOS 26.0, *) else {
+            throw XCTSkip("Apple Foundation Models prompts require the iOS/macOS 26 SDK")
+        }
+        let instructions = AppleFoundationModelsPolishEngine.instructions(
+            for: .natural, language: .french
+        )
+        let limit = largestAcceptedLength(budget: .appleFoundationModels,
+                                          instructions: instructions)
+        XCTAssertGreaterThan(limit, 4000,
+                             "refusing under ~4 000 characters would take polish away from dictations that work today")
+        XCTAssertLessThan(limit, 7000,
+                          "accepting past ~7 000 characters would let the engine throw, which is what this guards against")
+    }
+
+    /// A one-line dictation must be nowhere near any ceiling, on every prompt.
+    func testShortDictationFitsUnderEveryRealPrompt() throws {
+        guard #available(iOS 26.0, macOS 26.0, *) else {
+            throw XCTSkip("Apple Foundation Models prompts require the iOS/macOS 26 SDK")
+        }
+        let engine = AppleFoundationModelsPolishEngine()
+        let input = "bonjour, on se voit demain matin pour parler du projet"
+        for mode in [PolishMode.natural, .repair, .auto] {
+            for language in SupportedLanguage.allCases {
+                XCTAssertEqual(engine.contextFit(input: input, targetLanguage: language, mode: mode),
+                               .fits,
+                               "\(mode)/\(language) refused a one-line dictation")
+            }
+        }
+    }
+    #endif
+}
+
+// MARK: - Stub engines
+
+/// An engine that declares a ceiling and records whether it was called. The
+/// instruction text is empty so a test can reason about the input alone; the
+/// window is the knob.
+private final class CeilingStubEngine: PolishEngineProtocol, @unchecked Sendable {
+
+    let identifier = "ceiling-stub"
+    private let budget: PolishContextBudget
+    private let lock = NSLock()
+    private var calls = 0
+
+    var polishCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return calls
+    }
+
+    init(window: Int) {
+        self.budget = PolishContextBudget(contextWindowTokens: window,
+                                          scaffoldingTokens: 0,
+                                          outputReserveRatio: 1.1,
+                                          safetyMargin: 1.2)
+    }
+
+    func polish(raw: String, targetLanguage: SupportedLanguage, mode: PolishMode) async throws -> String {
+        lock.lock()
+        calls += 1
+        lock.unlock()
+        return raw
+    }
+
+    func contextFit(input: String,
+                    targetLanguage: SupportedLanguage,
+                    mode: PolishMode) -> PolishContextFit {
+        budget.fit(instructions: "", input: input)
+    }
+}
+
+/// An engine with no ceiling that always throws — the generic backend failure
+/// an overflow must remain distinguishable from.
+private struct ThrowingStubEngine: PolishEngineProtocol {
+    let identifier = "throwing-stub"
+
+    struct Failure: Error {}
+
+    func polish(raw: String, targetLanguage: SupportedLanguage, mode: PolishMode) async throws -> String {
+        throw Failure()
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/Polish/PolishContextBudgetTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/Polish/PolishContextBudgetTests.swift
@@ -264,10 +264,11 @@ final class PolishContextBudgetTests: XCTestCase {
                           "the longest prompt must leave the least room for input")
     }
 
-    /// A regression guard on the constants, deliberately loose. The measured
-    /// ceiling for the French Natural prompt sits around 7 000 characters of
-    /// input; the estimate is meant to refuse somewhat earlier than that, not
-    /// at half of it and not past it.
+    /// A regression guard on the constants, deliberately loose. The sweep
+    /// recorded in `PolishContextBudget.appleFoundationModels` puts the useful
+    /// range for the French Natural prompt at roughly 4 000–4 500 characters of
+    /// input: below it the engine reliably succeeds with a usable output, above
+    /// it it truncates and increasingly often throws.
     func testFrenchNaturalPromptAcceptsARealisticDictationLength() throws {
         guard #available(iOS 26.0, macOS 26.0, *) else {
             throw XCTSkip("Apple Foundation Models prompts require the iOS/macOS 26 SDK")
@@ -277,10 +278,10 @@ final class PolishContextBudgetTests: XCTestCase {
         )
         let limit = largestAcceptedLength(budget: .appleFoundationModels,
                                           instructions: instructions)
-        XCTAssertGreaterThan(limit, 4000,
-                             "refusing under ~4 000 characters would take polish away from dictations that work today")
-        XCTAssertLessThan(limit, 7000,
-                          "accepting past ~7 000 characters would let the engine throw, which is what this guards against")
+        XCTAssertGreaterThan(limit, 3500,
+                             "refusing under ~3 500 characters would take polish away from dictations that measurably work today")
+        XCTAssertLessThan(limit, 4800,
+                          "accepting past ~4 800 characters buys output the guardrail rejects, when the engine does not throw first")
     }
 
     /// A one-line dictation must be nowhere near any ceiling, on every prompt.


### PR DESCRIPTION
Implements the **estimation half** of #270. The in-recording warning cue is deliberately not touched — it needs a device-measured threshold and a signal crossing into the keyboard extension, and stays with the maintainer.

## What changed

`PolishPipeline.transform` now asks the engine whether the input fits before calling it. Previously an oversized dictation reached Apple FM, threw `exceededContextWindowSize` mid-call, and was caught by the generic `catch` as `.engineFailed` — indistinguishable from a crash, a timeout or a broken backend.

- **`PolishContextBudget`** (new) — the window, the reserves, and a cheap one-pass token estimator that prices ideographic scripts separately from Latin ones (auto mode accepts the whole long tail, where a Latin-tuned ratio would be badly wrong).
- **`PolishEngineProtocol.contextFit(input:targetLanguage:mode:)`** — the engine answers, because the ceiling is a property of the backend: its window, its resolved system prompt for `(mode, language)`, its prompt scaffolding. A protocol-extension default returns `.fits`, so `PassthroughPolishEngine` and any future ceiling-less engine are untouched.
- **`PolishMetrics.Outcome.exceededContextBudget`** — a refusal is not a failure. Shown in orange on the debug screen, seeded in the JSON export, logged with the token arithmetic behind it.

The user-visible result is unchanged: `resolvedOutput` already returns the deterministic floor on every non-success outcome, so the text still arrives with verbal punctuation applied. What changes is that the system knows *why* — the prerequisite for a Smart Mode (#79) failing closed with an accurate message.

## The numbers are measured, not assumed

Three probes against the real model on macOS 26.5.1 with Apple Intelligence:

1. **Window and tokenizer ratios.** Binary-searched the largest input that does not throw, with `maximumResponseTokens: 1` so only prefill counts. Window: 4096 tokens. Characters per token: French 4.94, English 5.12, German 5.42, Chinese 1.80.
2. **Instructions and input share one pool.** Swapping a one-word instruction for a 5000-character one (~977 tokens) cost 4800 characters of French input (~972 tokens) — one token for one token. This is why the estimate prices the *resolved* prompt rather than a fixed allowance.
3. **Where it actually breaks.** The real French Natural prompt, varied French dictation text, repeated per length:

   | input | result |
   |---|---|
   | 3 000 | ok / ok / ok |
   | 3 600 | threw / ok / ok |
   | 4 150 | ok / ok / ok / threw |
   | 4 400 | ok / threw |
   | 5 000 | threw / ok |
   | 5 200 | threw / threw |

That third probe reshaped the design. The overflow does **not** happen on prefill — it happens fifteen to twenty seconds into generation, and it is probabilistic. A successful call emits ~0.5 tokens per input token; a failing one runs away past 2.3×. **No static estimate can eliminate the throw**, so this guard does not pretend to: `.engineFailed` remains the backstop for the runaway.

What the sweep did establish is where the call stops being worth making. Every successful run returned ~2 300 characters regardless of input length — past ~4 500 characters in, the model truncates rather than polishes, and `PolishGuardrail`'s 0.5 length-ratio floor rejects the result on arrival. The constants put the refusal at ~4 160 characters for that prompt (~690 words, ~4½ minutes of speech), where the two curves meet.

Per-prompt accepted input length: Natural fr 4160 / en 4341 / es 4390 / de 4385, Repair 5213–5350, Auto 4194.

## Verification

- `swift test` — 540 tests, 0 failures (19 new).
- `swiftlint lint --strict` — 0 violations.
- DictusApp, DictusKeyboard, DictusCore all build for the simulator.
- End-to-end through `polish-harness` against the **real** engine: 180 chars → engine called, 4 100 → engine called (4 052 ms), 4 300 → refused at 0 ms, 12 000 → refused at 0 ms.

## Not verified here

Nothing about this change is device-specific — it runs app-side on text — but it has not been exercised on hardware. Steps are in the recap.

refs #270 (`Closes` does not auto-close on a merge into `develop`; close by hand)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context-budget checks before polish requests are processed.
  * Requests that exceed the available context are safely skipped and retain deterministic fallback text.
  * Added support for estimating token usage across multiple writing systems.

* **Bug Fixes**
  * Prevented oversized requests from triggering failed engine calls.
  * Added clear “too long” reporting in debug polish outcomes.

* **Tests**
  * Added comprehensive coverage for token estimation, budget limits, overflow handling, fallback output, and successful processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->