### PR TITLE
fix(app): decide cold start before the first frame (refs #264)

### DIFF
--- a/Dictus.xcodeproj/project.pbxproj
+++ b/Dictus.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		AA000003 /* KeyboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100003 /* KeyboardViewController.swift */; };
 		AA000004 /* KeyboardRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100004 /* KeyboardRootView.swift */; };
 		AA000005 /* DictationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100009 /* DictationCoordinator.swift */; };
+		AA000264 /* ColdStartLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100264 /* ColdStartLaunch.swift */; };
 		AA000006 /* DictationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10000A /* DictationView.swift */; };
 		AA000007 /* KeyboardState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10000B /* KeyboardState.swift */; };
 		AA0000F7 /* KeyboardLifecycleProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1000F6 /* KeyboardLifecycleProbe.swift */; };
@@ -180,6 +181,7 @@
 		AA100007 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AA100008 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AA100009 /* DictationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationCoordinator.swift; sourceTree = "<group>"; };
+		AA100264 /* ColdStartLaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColdStartLaunch.swift; sourceTree = "<group>"; };
 		AA10000A /* DictationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationView.swift; sourceTree = "<group>"; };
 		AA10000B /* KeyboardState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardState.swift; sourceTree = "<group>"; };
 		AA1000F6 /* KeyboardLifecycleProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardLifecycleProbe.swift; sourceTree = "<group>"; };
@@ -355,6 +357,7 @@
 				AA100001 /* DictusApp.swift */,
 				AA100002 /* ContentView.swift */,
 				AA100009 /* DictationCoordinator.swift */,
+				AA100264 /* ColdStartLaunch.swift */,
 				AA10000A /* DictationView.swift */,
 				AA1000F5 /* LiveActivityManager.swift */,
 				SS400001 /* Subscription */,
@@ -927,6 +930,7 @@
 				AA000001 /* DictusApp.swift in Sources */,
 				AA000002 /* ContentView.swift in Sources */,
 				AA000005 /* DictationCoordinator.swift in Sources */,
+				AA000264 /* ColdStartLaunch.swift in Sources */,
 				AA000006 /* DictationView.swift in Sources */,
 				AA0000F5 /* LiveActivityManager.swift in Sources */,
 				AA00P201 /* PolishAvailability.swift in Sources */,

--- a/DictusApp/ColdStartLaunch.swift
+++ b/DictusApp/ColdStartLaunch.swift
@@ -1,0 +1,76 @@
+// DictusApp/ColdStartLaunch.swift
+// Captures the dictation URL that launched the process, before SwiftUI draws anything.
+import UIKit
+import DictusCore
+
+/// The keyboard dictation intent this process was *launched with*, if any.
+///
+/// WHY this exists (issue #264):
+/// `MainTabView` decided cold start inside `.onOpenURL`, and SwiftUI evaluates `body` at
+/// least once before any URL handler runs. On a keyboard-launched cold start the home
+/// screen was therefore always drawn for a frame before the swipe-back overlay replaced
+/// it. Reading `SharedKeys.coldStartActive` does not help: that flag is written by
+/// DictusApp's own `.onOpenURL`, which fires even later, so at first render it still holds
+/// the previous session's value.
+///
+/// The launch URL is the only source of truth that exists early enough. iOS hands it to
+/// the scene in `scene(_:willConnectTo:options:)`, before SwiftUI builds any view, so
+/// `MainTabView` can seed its state from it in `init`.
+///
+/// WHY this does NOT consume the URL:
+/// `.onOpenURL` still fires for the same launch URL and remains the only place that starts
+/// the dictation, writes the App Group flag and flips the "has handled a URL in this
+/// process" flags. Marking the URL handled here would flip those flags early and make a
+/// later engine-dead restart look like a warm start.
+enum ColdStartLaunch {
+    /// The intent carried by the launch URL. `nil` for every other launch path
+    /// (Home screen, notification, widget), which is what keeps the normal launch
+    /// rendering its tab navigation immediately.
+    private(set) static var intent: KeyboardDictationIntent?
+
+    /// Records the launch URL handed to the scene at connection time.
+    ///
+    /// WHY only the first match: a scene connects with a set of URL contexts, and the
+    /// dictation URL is the only one we care about. Anything else leaves `intent` nil.
+    static func capture(_ urlContexts: Set<UIOpenURLContext>) {
+        guard let launchIntent = urlContexts.lazy
+            .compactMap({ KeyboardDictationURL.intent(from: $0.url) })
+            .first
+        else {
+            return
+        }
+
+        intent = launchIntent
+        PersistentLog.log(.diagnosticProbe(
+            component: "coldStart", instanceID: "0",
+            action: "launchURLCaptured",
+            details: "intent=\(launchIntent.rawValue)"
+        ))
+    }
+
+    /// Forgets the launch URL.
+    ///
+    /// WHY: the intent describes the frame this process launched into, not a lasting mode.
+    /// It is cleared with the rest of the cold-start state when the scene goes to the
+    /// background, so a view rebuilt later in the same process never replays a cold start.
+    static func clear() {
+        intent = nil
+    }
+}
+
+/// Scene delegate installed for the sole purpose of seeing the launch URL.
+///
+/// WHY a scene delegate in a SwiftUI-lifecycle app:
+/// `UIScene.ConnectionOptions` is the only place the launch URL is exposed, and it is
+/// only passed to `scene(_:willConnectTo:options:)`. SwiftUI keeps owning the window and
+/// the view hierarchy — this delegate creates nothing and, by not implementing
+/// `scene(_:openURLContexts:)`, leaves URL delivery to SwiftUI's `.onOpenURL` untouched.
+final class DictusSceneDelegate: NSObject, UIWindowSceneDelegate {
+    func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
+        ColdStartLaunch.capture(connectionOptions.urlContexts)
+    }
+}

--- a/DictusApp/ColdStartLaunch.swift
+++ b/DictusApp/ColdStartLaunch.swift
@@ -22,6 +22,14 @@ import DictusCore
 /// the dictation, writes the App Group flag and flips the "has handled a URL in this
 /// process" flags. Marking the URL handled here would flip those flags early and make a
 /// later engine-dead restart look like a warm start.
+///
+/// THREADING: main thread only, by construction. The three call sites are
+/// `scene(_:willConnectTo:options:)`, `MainTabView.init` and the view's
+/// `scenePhase` handler, all of which UIKit and SwiftUI run on the main thread.
+/// The target builds in Swift 5 language mode, so the invariant is documented
+/// rather than annotated: marking the enum `@MainActor` would make it
+/// unreachable from `MainTabView.init`, which is nonisolated. Enforcing it
+/// belongs to a Swift 6 migration, not here.
 enum ColdStartLaunch {
     /// The intent carried by the launch URL. `nil` for every other launch path
     /// (Home screen, notification, widget), which is what keeps the normal launch

--- a/DictusApp/DictusApp.swift
+++ b/DictusApp/DictusApp.swift
@@ -20,6 +20,25 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         // Return false so SwiftUI onOpenURL still handles the URL
         return false
     }
+
+    /// Installs `DictusSceneDelegate` so the launch URL can be read at scene connection.
+    ///
+    /// WHY here rather than in Info.plist: the app has no `UISceneConfigurations` entry,
+    /// and UIKit asks the app delegate first. Returning a configuration with our delegate
+    /// class is the least invasive way to get `UIScene.ConnectionOptions` — the only API
+    /// that exposes the launch URL before SwiftUI evaluates its first body (issue #264).
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        let configuration = UISceneConfiguration(
+            name: nil,
+            sessionRole: connectingSceneSession.role
+        )
+        configuration.delegateClass = DictusSceneDelegate.self
+        return configuration
+    }
 }
 
 @main
@@ -184,15 +203,11 @@ struct DictusApp: App {
 
         switch url.host {
         case "dictate":
-            let isFromKeyboard = URLComponents(url: url, resolvingAgainstBaseURL: false)?
-                .queryItems?
-                .first(where: { $0.name == "source" })?
-                .value == "keyboard"
-            let isPrepareOnly = URLComponents(url: url, resolvingAgainstBaseURL: false)?
-                .queryItems?
-                .contains(where: { $0.name == "intent" && $0.value == "prepare" }) ?? false
+            // Single source of truth for what the keyboard is asking (issue #264).
+            let keyboardIntent = KeyboardDictationURL.intent(from: url)
+            let isFromKeyboard = keyboardIntent != nil
 
-            if isFromKeyboard && isPrepareOnly {
+            if keyboardIntent == .prepare {
                 DictusLogger.app.info("Keyboard requested model preparation without recording")
                 PersistentLog.log(.dictationDeferred(reason: "keyboard prepare-only URL"))
                 NotificationCenter.default.post(

--- a/DictusApp/Views/MainTabView.swift
+++ b/DictusApp/Views/MainTabView.swift
@@ -28,7 +28,7 @@ struct MainTabView: View {
     private static var hasHandledURL = false
 
     /// Tracks whether the app was opened from the keyboard for cold start dictation.
-    @State private var isColdStartMode = false
+    @State private var isColdStartMode: Bool
 
     /// Active model preparation requested by the keyboard without starting a
     /// recording. The overlay dismisses itself after its contextual ready state.
@@ -36,10 +36,31 @@ struct MainTabView: View {
 
     @Environment(\.scenePhase) private var scenePhase
 
+    /// Seeds the presentation state from the URL this process was launched with (issue #264).
+    ///
+    /// WHY in init rather than in `.onOpenURL`:
+    /// SwiftUI evaluates `body` before any URL handler runs, so a cold start decided in
+    /// `.onOpenURL` always rendered one frame of the home screen first. `ColdStartLaunch`
+    /// reads the launch URL at scene connection, which happens before this view is built,
+    /// so the very first frame is already the right one. Every other launch leaves the
+    /// intent nil and lands on the tab navigation with nothing added to the path.
+    init() {
+        let launchIntent = ColdStartLaunch.intent
+        _isColdStartMode = State(initialValue: launchIntent == .record)
+        _preparingModelID = State(
+            initialValue: launchIntent == .prepare ? Self.persistedActiveModelIdentifier : nil
+        )
+    }
+
+    /// The active model as persisted in the App Group, with the shipped default.
+    /// Static so `init` can read it before `modelManager` exists — `ModelManager.init`
+    /// loads `activeModel` from the same key, so both paths agree.
+    private static var persistedActiveModelIdentifier: String {
+        AppGroup.defaults.string(forKey: SharedKeys.activeModel) ?? "openai_whisper-small"
+    }
+
     private var activeModelIdentifier: String {
-        modelManager.activeModel
-            ?? AppGroup.defaults.string(forKey: SharedKeys.activeModel)
-            ?? "openai_whisper-small"
+        modelManager.activeModel ?? Self.persistedActiveModelIdentifier
     }
 
     var body: some View {
@@ -104,30 +125,29 @@ struct MainTabView: View {
         // Detect cold start directly from URL params. MainTabView's onOpenURL fires
         // BEFORE DictusApp's (SwiftUI propagates inner-to-outer), so we can't rely
         // on DictusApp having set the AppGroup flag yet.
+        //
+        // A URL-launched cold start has already been answered in init, but this handler
+        // still runs for it: it is what marks the URL handled, and re-asserting the same
+        // state is a no-op. It remains the only path for every URL that arrives while the
+        // process is already alive.
         .onOpenURL { url in
-            guard let host = url.host, host == "dictate",
-                  let query = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
-                  query.contains(where: { $0.name == "source" && $0.value == "keyboard" }) else {
-                return
-            }
+            guard let intent = KeyboardDictationURL.intent(from: url) else { return }
 
-            if query.contains(where: { $0.name == "intent" && $0.value == "prepare" }) {
+            if intent == .prepare {
                 preparingModelID = activeModelIdentifier
                 return
             }
 
-            if !query.isEmpty {
-                if !Self.hasHandledURL {
-                    // True cold start: process was just launched by keyboard URL.
-                    isColdStartMode = true
-                } else if !coordinator.isEngineRunning {
-                    // Engine-dead restart: app is in memory but audio engine was stopped
-                    // (e.g., Power button in Dynamic Island). User needs the swipe-back
-                    // overlay to know how to return to their keyboard.
-                    isColdStartMode = true
-                }
-                Self.hasHandledURL = true
+            if !Self.hasHandledURL {
+                // True cold start: process was just launched by keyboard URL.
+                isColdStartMode = true
+            } else if !coordinator.isEngineRunning {
+                // Engine-dead restart: app is in memory but audio engine was stopped
+                // (e.g., Power button in Dynamic Island). User needs the swipe-back
+                // overlay to know how to return to their keyboard.
+                isColdStartMode = true
             }
+            Self.hasHandledURL = true
         }
         .onReceive(NotificationCenter.default.publisher(for: .dictusKeyboardPreparationRequested)) { _ in
             preparingModelID = activeModelIdentifier
@@ -135,6 +155,10 @@ struct MainTabView: View {
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .background {
                 isColdStartMode = false
+                // The launch intent describes the frame this process launched into.
+                // Forgetting it here keeps a view rebuilt later in the same process
+                // from replaying the cold-start overlay (issue #264).
+                ColdStartLaunch.clear()
             }
         }
     }

--- a/DictusCore/Sources/DictusCore/KeyboardDictationURL.swift
+++ b/DictusCore/Sources/DictusCore/KeyboardDictationURL.swift
@@ -1,0 +1,48 @@
+// DictusCore/Sources/DictusCore/KeyboardDictationURL.swift
+// The single rule that recognises the dictation URLs the keyboard sends to the app.
+import Foundation
+
+/// What the keyboard is asking the app to do with a `dictus://dictate` URL.
+public enum KeyboardDictationIntent: String, Sendable, Equatable, CaseIterable {
+    /// Start a dictation now (`dictus://dictate?source=keyboard`).
+    case record
+    /// Only load the active model, without recording (`&intent=prepare`, issue #262).
+    case prepare
+}
+
+/// Recognises the dictation URLs sent by the keyboard extension.
+///
+/// WHY a shared parser instead of inline query lookups:
+/// The same URL is inspected in three places — at scene connection (to decide the very
+/// first frame, issue #264), in `MainTabView.onOpenURL`, and in `DictusApp.handleIncomingURL`.
+/// Three copies of "host is dictate, source is keyboard, intent may be prepare" drift the
+/// moment one of them gains a parameter, and a drifting copy shows the wrong overlay.
+///
+/// WHY in DictusCore:
+/// The rule is pure `Foundation` and testable off-device, and the keyboard side may later
+/// build its URLs from the same vocabulary.
+public enum KeyboardDictationURL {
+    /// The scheme registered by DictusApp in `CFBundleURLTypes`.
+    private static let scheme = "dictus"
+    /// The only host that carries a dictation request.
+    private static let host = "dictate"
+
+    /// Returns the intent carried by `url`, or `nil` when the URL is not a keyboard
+    /// dictation request.
+    ///
+    /// Returning `nil` covers everything the caller must not treat as a keyboard
+    /// dictation: another scheme, `dictus://stop`, and the widget's `dictus://dictate`
+    /// deep link, which has no `source=keyboard` query item.
+    public static func intent(from url: URL) -> KeyboardDictationIntent? {
+        guard url.scheme?.lowercased() == scheme,
+              url.host?.lowercased() == host,
+              let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
+              queryItems.contains(where: { $0.name == "source" && $0.value == "keyboard" })
+        else {
+            return nil
+        }
+
+        let isPrepareOnly = queryItems.contains { $0.name == "intent" && $0.value == "prepare" }
+        return isPrepareOnly ? .prepare : .record
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/KeyboardDictationURLTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/KeyboardDictationURLTests.swift
@@ -1,0 +1,64 @@
+// DictusCore/Tests/DictusCoreTests/KeyboardDictationURLTests.swift
+// Unit tests pinning the single rule that recognises keyboard dictation URLs (issue #264).
+import XCTest
+@testable import DictusCore
+
+final class KeyboardDictationURLTests: XCTestCase {
+
+    /// The URL the keyboard opens on a microphone tap (KeyboardState).
+    func testRecordURLFromKeyboard() {
+        let url = URL(string: "dictus://dictate?source=keyboard")!
+        XCTAssertEqual(KeyboardDictationURL.intent(from: url), .record)
+    }
+
+    /// The prepare-only URL from issue #262 must never be read as a recording request:
+    /// it loads the model and shows the loading overlay, nothing else.
+    func testPrepareURLFromKeyboard() {
+        let url = URL(string: "dictus://dictate?source=keyboard&intent=prepare")!
+        XCTAssertEqual(KeyboardDictationURL.intent(from: url), .prepare)
+    }
+
+    /// Query item order must not matter — the rule is a lookup, not a prefix match.
+    func testPrepareURLWithReversedQueryOrder() {
+        let url = URL(string: "dictus://dictate?intent=prepare&source=keyboard")!
+        XCTAssertEqual(KeyboardDictationURL.intent(from: url), .prepare)
+    }
+
+    /// An unknown intent value is still a recording request: only `prepare` diverts.
+    func testUnknownIntentFallsBackToRecord() {
+        let url = URL(string: "dictus://dictate?source=keyboard&intent=whatever")!
+        XCTAssertEqual(KeyboardDictationURL.intent(from: url), .record)
+    }
+
+    /// The Live Activity deep link opens the same host without a source, and must not
+    /// be mistaken for a keyboard cold start (it would show the swipe-back overlay).
+    func testWidgetDictateURLIsNotAKeyboardRequest() {
+        let url = URL(string: "dictus://dictate")!
+        XCTAssertNil(KeyboardDictationURL.intent(from: url))
+    }
+
+    /// Another source value is not the keyboard.
+    func testOtherSourceIsNotAKeyboardRequest() {
+        let url = URL(string: "dictus://dictate?source=widget")!
+        XCTAssertNil(KeyboardDictationURL.intent(from: url))
+    }
+
+    /// `dictus://stop` and `dictus://open` share the scheme but not the host.
+    func testOtherHostsAreNotKeyboardRequests() {
+        XCTAssertNil(KeyboardDictationURL.intent(from: URL(string: "dictus://stop")!))
+        XCTAssertNil(KeyboardDictationURL.intent(from: URL(string: "dictus://open?source=keyboard")!))
+    }
+
+    /// A foreign scheme never matches, even with an identical host and query.
+    func testForeignSchemeIsNotAKeyboardRequest() {
+        let url = URL(string: "whatsapp://dictate?source=keyboard")!
+        XCTAssertNil(KeyboardDictationURL.intent(from: url))
+    }
+
+    /// iOS normalises schemes and hosts to lower case, but URLs handed to the app can
+    /// carry any casing. Matching must not depend on it.
+    func testSchemeAndHostMatchingIsCaseInsensitive() {
+        let url = URL(string: "DICTUS://Dictate?source=keyboard")!
+        XCTAssertEqual(KeyboardDictationURL.intent(from: url), .record)
+    }
+}


### PR DESCRIPTION
refs #264

## What changed

`MainTabView` decided cold start inside `.onOpenURL`, and SwiftUI evaluates `body` at least once before any URL handler runs. On a keyboard-launched cold start the home screen was therefore **always** drawn for a frame before the swipe-back overlay replaced it. The flash was deterministic, only its visible duration varied.

The launch URL is the only source of truth available early enough: iOS hands it to the scene at connection time, before SwiftUI builds any view.

1. **`DictusCore/KeyboardDictationURL`** — the rule "scheme `dictus`, host `dictate`, `source=keyboard`, `intent=prepare` selects the prepare path" now lives in one place, with unit tests. `MainTabView` and `DictusApp` both call it instead of hand-rolling query lookups.
2. **`DictusApp/ColdStartLaunch.swift`** — a scene delegate, installed from the existing `AppDelegate` via `application(_:configurationForConnecting:options:)`, records the launch intent in `scene(_:willConnectTo:options:)`. It creates no window; SwiftUI keeps owning the view hierarchy.
3. **`MainTabView.init`** seeds `isColdStartMode` / `preparingModelID` from that intent, so the first frame is already correct. The intent is forgotten when the scene goes to the background.

**On double-handling** (the hazard named in the brief): the early path deliberately does **not** consume the URL. `.onOpenURL` still fires for it and remains the only place that starts the dictation, writes the App Group cold-start flag, and flips the "has handled a URL in this process" flags — so an engine-dead restart is still classified as one. Re-asserting the same state from the handler is a no-op. Simulator logs confirm `coldStartURLReceived` / `coldStartFlagSet` / `dictationStarted` fire exactly once per launch.

## Verification

All on the iOS 26.5 simulator (iPhone 17 Pro), headless, using a throwaway opener app so the URL arrives app-to-app exactly as the keyboard sends it. Three targets build, `swiftlint lint --strict` reports 0 violations, `swift test` in DictusCore passes 530 tests (9 new).

| Criterion | Status |
| --- | --- |
| No home frame before the swipe-back overlay | **Needs device.** Verified on the simulator that the overlay is the first Dictus content drawn; the flash itself does not reproduce there (see below) |
| Normal launch shows the tab navigation, no splash or delay | Verified — screenshot shows the tab bar immediately |
| Engine-dead restart still reaches the overlay | Code path unchanged; **needs device** |
| `intent=prepare` shows the model loading overlay, never swipe-back | Verified — prepare cold start renders `ModelLoadingOverlay` |
| Dictation still starts on cold start | Partly — `dictationStarted fromURL=true` logged; no model installed in the sim, so no transcription |
| URL handled exactly once | Verified in the log |
| Background still clears cold-start mode, not the flag while recording | Logic untouched; **needs device** |
| The matching rule exists in one place | Verified — only `KeyboardDictationURL` matches; the keyboard still *builds* its URL strings inline |

**Honest limitation:** the one-frame flash does not reproduce in the simulator. I recorded the cold start at 60 fps with the fix enabled and again with it disabled: both go launch screen → cross-fade → swipe-back overlay, with no home-screen frame in either. So the simulator confirms the flow is correct but cannot demonstrate the flash is gone. That needs a device.

## Device validation

1. Force-quit Dictus. Open a text field in another app, switch to the Dictus keyboard, tap the microphone. Watch the first frame Dictus draws — a slow-motion screen recording makes a sub-second flash reviewable. Expected: swipe-back overlay, no home screen.
2. Same again, then speak and swipe back: the transcription must land in the host app, once.
3. With Dictus already running, kill the audio engine (Power button in the Dynamic Island), then tap the keyboard microphone: the swipe-back overlay must still appear.
4. Launch Dictus normally from the home screen: tab navigation, no splash, no added latency.
5. A prepare-only handoff (`intent=prepare`, #262): model loading overlay, never swipe-back.
6. Background the app mid-recording: the keyboard must keep its watchdog grace period (the App Group flag must not be cleared while recording).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwNiou6WfSt8vJzVUxpzQW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved keyboard dictation launch handling, including launches from a closed app.
  * Added support for preparing dictation before recording begins.
  * Preserved dictation state and overlays when opening or returning to the app.
* **Bug Fixes**
  * Improved recognition of keyboard dictation links regardless of parameter order or letter casing.
  * Prevented unsupported or unrelated links from triggering dictation.
* **Tests**
  * Added coverage for recording, preparation, validation, and fallback behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->