### PR TITLE
probe(keyboard): observe the #260 claim predicate and the #281 teardown ordering (refs #260, refs #281)

### DIFF
--- a/DictusApp/DictusApp.swift
+++ b/DictusApp/DictusApp.swift
@@ -123,6 +123,13 @@ struct DictusApp: App {
                     handleIncomingURL(url)
                 }
                 .onChange(of: scenePhase) { phase in
+                    // #281 probe: publish the phase before anything else in this
+                    // closure, so the keyboard extension reads a value that is at
+                    // worst microseconds behind the transition it describes. It is
+                    // written from the same callback that logs the lifecycle line
+                    // below, which is what lets the two be compared at all.
+                    AppScenePhaseProbe.record(phase.sceneMarker)
+
                     switch phase {
                     case .active:
                         PersistentLog.log(.appDidBecomeActive)
@@ -254,6 +261,24 @@ struct DictusApp: App {
             coordinator.stopDictation()
         default:
             break
+        }
+    }
+}
+
+extension ScenePhase {
+    /// This phase as the App Group marker the keyboard extension reads (#281).
+    ///
+    /// `ScenePhase` is a SwiftUI type and the keyboard has no business linking SwiftUI
+    /// for a log field, so the crossing happens here, on the app side, and only the
+    /// `String` raw value travels between the processes.
+    var sceneMarker: AppScenePhaseMarker {
+        switch self {
+        case .active: return .active
+        case .inactive: return .inactive
+        case .background: return .background
+        // A phase SwiftUI adds after this was written is reported honestly rather
+        // than guessed at: the probe's value comes from being trustworthy.
+        @unknown default: return .unknown
         }
     }
 }

--- a/DictusCore/Sources/DictusCore/AppScenePhaseProbe.swift
+++ b/DictusCore/Sources/DictusCore/AppScenePhaseProbe.swift
@@ -45,6 +45,11 @@ public enum AppScenePhaseProbe {
     ///
     /// `synchronize()` because the reader is another process that may look microseconds
     /// later — the same reason the cold-start flag is synchronized on this path.
+    ///
+    /// `.unknown` is written like any other marker rather than clearing the keys. The
+    /// app only produces it from `@unknown default`, and "the app transitioned to a
+    /// phase this build cannot name, just now" is a stronger statement than the silence
+    /// that clearing would leave — which would also discard the last phase we did know.
     public static func record(
         _ marker: AppScenePhaseMarker,
         at date: Date = Date(),
@@ -58,9 +63,12 @@ public enum AppScenePhaseProbe {
     /// The app's phase, its age in milliseconds, and the cold-start flag, in the
     /// shared key=value format. Called from the keyboard only.
     ///
-    /// `appPhaseAgeMs=-1` means no phase has ever been published, in which case
-    /// `appPhase` reads `unknown`; the two always agree, so a negative age is never
-    /// ambiguous with a real measurement.
+    /// `appPhaseAgeMs=-1` means nothing readable is stored, and `appPhase` then reads
+    /// `unknown`. The converse does not hold: `unknown` with a real age is the app
+    /// having reported a phase this build has no name for, which is a live signal and
+    /// deliberately not collapsed into the -1 case. Read the age to tell them apart —
+    /// "the app never published" and "the app moved somewhere unnamed 30 ms ago" are
+    /// very different facts about an ordering question.
     ///
     /// `coldStart` rides along because the #281 window only ever opens during a
     /// cold-start handoff, and reading it here costs one more lookup on `defaults`

--- a/DictusCore/Sources/DictusCore/AppScenePhaseProbe.swift
+++ b/DictusCore/Sources/DictusCore/AppScenePhaseProbe.swift
@@ -1,0 +1,82 @@
+// DictusCore/Sources/DictusCore/AppScenePhaseProbe.swift
+import Foundation
+
+/// Which of its lifecycle states DictusApp last reported.
+///
+/// Mirrors SwiftUI's `ScenePhase` without depending on SwiftUI, so the keyboard
+/// extension can read the value without linking a UI framework it has no use for.
+/// `unknown` is what the keyboard sees when the app has never published a phase in
+/// this install — not a state the app ever writes.
+public enum AppScenePhaseMarker: String {
+    case active
+    case inactive
+    case background
+    case unknown
+}
+
+/// Publishes DictusApp's scene phase to the App Group, and renders it for the
+/// keyboard extension's log lines.
+///
+/// WHY this exists (#281). After a cold-start dictation the extension can lose every
+/// live `KeyboardViewController` and get none back for 10 s or more. The surviving
+/// hypothesis is that the teardown happens when the swipe-back lands *before* iOS has
+/// rotated in a successor controller — that is, that the app handing the foreground
+/// back and the controllers being destroyed are ordered, not merely adjacent.
+///
+/// The debug log cannot settle that today. It has one-second resolution and interleaves
+/// two processes whose writes lag relative to each other, so `<APP> appDidEnterBackground`
+/// and `<KBD> viewDidDisappear` landing in the same second says nothing about which
+/// happened first (see PR #282 §1). Reading the phase from the App Group at the moment
+/// of teardown puts the answer on the keyboard's own line, in the keyboard's own clock,
+/// where no cross-process comparison is needed.
+///
+/// No new IPC path: this is the App Group's shared `UserDefaults`, the same channel
+/// every other cross-process value in this app travels on.
+///
+/// Observation only. Nothing reads these keys to make a decision.
+public enum AppScenePhaseProbe {
+
+    /// Publishes `marker` as DictusApp's current phase. Called from the app only.
+    ///
+    /// The timestamp is stored alongside so the keyboard can report how old the value
+    /// is. Age is what makes the reading trustworthy: the keys survive the app being
+    /// killed, so a phase with no timestamp near it is a leftover from an earlier run
+    /// rather than a statement about now.
+    ///
+    /// `synchronize()` because the reader is another process that may look microseconds
+    /// later — the same reason the cold-start flag is synchronized on this path.
+    public static func record(
+        _ marker: AppScenePhaseMarker,
+        at date: Date = Date(),
+        into defaults: UserDefaults = AppGroup.defaults
+    ) {
+        defaults.set(marker.rawValue, forKey: SharedKeys.appScenePhase)
+        defaults.set(date.timeIntervalSince1970, forKey: SharedKeys.appScenePhaseTimestamp)
+        defaults.synchronize()
+    }
+
+    /// The app's phase, its age in milliseconds, and the cold-start flag, in the
+    /// shared key=value format. Called from the keyboard only.
+    ///
+    /// `appPhaseAgeMs=-1` means no phase has ever been published, in which case
+    /// `appPhase` reads `unknown`; the two always agree, so a negative age is never
+    /// ambiguous with a real measurement.
+    ///
+    /// `coldStart` rides along because the #281 window only ever opens during a
+    /// cold-start handoff, and reading it here costs one more lookup on `defaults`
+    /// the caller has already paid to open.
+    public static func describe(
+        at date: Date = Date(),
+        from defaults: UserDefaults = AppGroup.defaults
+    ) -> String {
+        let stored = defaults.string(forKey: SharedKeys.appScenePhase)
+        let writtenAt = defaults.object(forKey: SharedKeys.appScenePhaseTimestamp) as? Double
+        guard let stored, let marker = AppScenePhaseMarker(rawValue: stored), let writtenAt else {
+            return "appPhase=\(AppScenePhaseMarker.unknown.rawValue) appPhaseAgeMs=-1"
+                + " coldStart=\(defaults.bool(forKey: SharedKeys.coldStartActive))"
+        }
+        let ageMs = Int((date.timeIntervalSince1970 - writtenAt) * 1000)
+        return "appPhase=\(marker.rawValue) appPhaseAgeMs=\(ageMs)"
+            + " coldStart=\(defaults.bool(forKey: SharedKeys.coldStartActive))"
+    }
+}

--- a/DictusCore/Sources/DictusCore/SharedKeys.swift
+++ b/DictusCore/Sources/DictusCore/SharedKeys.swift
@@ -103,6 +103,16 @@ public enum SharedKeys {
     /// Used by auto-return logic to navigate back to the correct app after dictation.
     public static let sourceAppScheme = "dictus.sourceAppScheme"
 
+    // Keyboard teardown diagnostics (issue #281)
+    /// String: DictusApp's last reported scene phase, one of `AppScenePhaseMarker`.
+    /// Written by the app on every scene phase change, read by the keyboard extension
+    /// when its controllers are torn down. Observation only — nothing branches on it.
+    public static let appScenePhase = "dictus.appScenePhase"
+    /// Double (timeIntervalSince1970): when `appScenePhase` was written. The pair is
+    /// only meaningful together: the keys outlive the app process, so the age is what
+    /// separates "the app is in the background right now" from a stale leftover.
+    public static let appScenePhaseTimestamp = "dictus.appScenePhaseTimestamp"
+
     // MARK: - Sound Feedback
     /// Whether sound feedback is enabled for recording events, default true
     public static let soundFeedbackEnabled = "dictus.soundFeedbackEnabled"

--- a/DictusCore/Tests/DictusCoreTests/AppScenePhaseProbeTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/AppScenePhaseProbeTests.swift
@@ -92,6 +92,22 @@ final class AppScenePhaseProbeTests: XCTestCase {
         )
     }
 
+    /// An `unknown` the app actually reported keeps its age, and must not be collapsed
+    /// into the never-published case: "the app moved to a phase this build cannot name,
+    /// 500 ms ago" and "the app has never published anything" are different answers to
+    /// the ordering question the probe exists to settle.
+    func testReportedUnknownKeepsItsAge() {
+        AppScenePhaseProbe.record(.unknown, at: Date(timeIntervalSince1970: 1_000), into: defaults)
+
+        let description = AppScenePhaseProbe.describe(
+            at: Date(timeIntervalSince1970: 1_000.5),
+            from: defaults
+        )
+
+        XCTAssertTrue(description.contains("appPhase=unknown"), description)
+        XCTAssertTrue(description.contains("appPhaseAgeMs=500"), description)
+    }
+
     /// A phase with no timestamp cannot be aged, so it cannot be trusted, so it is
     /// unknown — and the sentinel age keeps that unambiguous with a real measurement.
     func testPhaseWithoutTimestampReadsUnknown() {

--- a/DictusCore/Tests/DictusCoreTests/AppScenePhaseProbeTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/AppScenePhaseProbeTests.swift
@@ -1,0 +1,126 @@
+// DictusCore/Tests/DictusCoreTests/AppScenePhaseProbeTests.swift
+// Tests for AppScenePhaseProbe — the App Group contract the keyboard extension reads
+// to state, on its own log line, whether DictusApp had already backgrounded when iOS
+// tore its controllers down (issue #281).
+import XCTest
+@testable import DictusCore
+
+final class AppScenePhaseProbeTests: XCTestCase {
+
+    /// A suite of its own: these tests write the same keys the app writes, and the
+    /// shared App Group suite is live state on a developer machine.
+    private let suiteName = "dictus.tests.appScenePhaseProbe"
+    private var defaults = UserDefaults.standard
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    // MARK: - Markers
+
+    func testMarkerRawValuesAreTheStringsTheLogCarries() {
+        XCTAssertEqual(AppScenePhaseMarker.active.rawValue, "active")
+        XCTAssertEqual(AppScenePhaseMarker.inactive.rawValue, "inactive")
+        XCTAssertEqual(AppScenePhaseMarker.background.rawValue, "background")
+        XCTAssertEqual(AppScenePhaseMarker.unknown.rawValue, "unknown")
+    }
+
+    // MARK: - Round trip
+
+    func testRecordedPhaseIsReadBack() {
+        AppScenePhaseProbe.record(.background, at: Date(), into: defaults)
+
+        XCTAssertTrue(
+            AppScenePhaseProbe.describe(from: defaults).contains("appPhase=background"),
+            "The phase the app publishes is the phase the keyboard reports"
+        )
+    }
+
+    func testAgeIsMeasuredFromTheRecordedTimestamp() {
+        let written = Date(timeIntervalSince1970: 1_000)
+        AppScenePhaseProbe.record(.active, at: written, into: defaults)
+
+        let description = AppScenePhaseProbe.describe(
+            at: Date(timeIntervalSince1970: 1_002.5),
+            from: defaults
+        )
+
+        XCTAssertTrue(description.contains("appPhaseAgeMs=2500"), description)
+    }
+
+    func testALaterRecordReplacesTheEarlierOne() {
+        AppScenePhaseProbe.record(.background, at: Date(timeIntervalSince1970: 1_000), into: defaults)
+        AppScenePhaseProbe.record(.active, at: Date(timeIntervalSince1970: 1_001), into: defaults)
+
+        let description = AppScenePhaseProbe.describe(
+            at: Date(timeIntervalSince1970: 1_001),
+            from: defaults
+        )
+
+        XCTAssertTrue(description.contains("appPhase=active"), description)
+        XCTAssertTrue(description.contains("appPhaseAgeMs=0"), description)
+    }
+
+    // MARK: - Nothing published
+
+    /// The keyboard can be torn down in an install where the app has never run since
+    /// the probe shipped. It must say so rather than invent a phase, since the whole
+    /// point of the field is to be trusted about ordering.
+    func testUnwrittenPhaseReadsUnknownWithASentinelAge() {
+        let description = AppScenePhaseProbe.describe(from: defaults)
+
+        XCTAssertTrue(description.contains("appPhase=unknown"), description)
+        XCTAssertTrue(description.contains("appPhaseAgeMs=-1"), description)
+    }
+
+    /// A value written by a build whose marker set differs — or corrupted by hand —
+    /// is reported as unknown rather than echoed into the log.
+    func testUnrecognisedPhaseReadsUnknown() {
+        defaults.set("hibernating", forKey: SharedKeys.appScenePhase)
+        defaults.set(Date().timeIntervalSince1970, forKey: SharedKeys.appScenePhaseTimestamp)
+
+        XCTAssertTrue(
+            AppScenePhaseProbe.describe(from: defaults).contains("appPhase=unknown"),
+            "An unrecognised marker must not reach the log verbatim"
+        )
+    }
+
+    /// A phase with no timestamp cannot be aged, so it cannot be trusted, so it is
+    /// unknown — and the sentinel age keeps that unambiguous with a real measurement.
+    func testPhaseWithoutTimestampReadsUnknown() {
+        defaults.set(AppScenePhaseMarker.background.rawValue, forKey: SharedKeys.appScenePhase)
+
+        let description = AppScenePhaseProbe.describe(from: defaults)
+
+        XCTAssertTrue(description.contains("appPhase=unknown"), description)
+        XCTAssertTrue(description.contains("appPhaseAgeMs=-1"), description)
+    }
+
+    // MARK: - Cold start flag
+
+    func testColdStartFlagIsCarriedOnTheSameLine() {
+        AppScenePhaseProbe.record(.background, into: defaults)
+        defaults.set(true, forKey: SharedKeys.coldStartActive)
+
+        XCTAssertTrue(
+            AppScenePhaseProbe.describe(from: defaults).contains("coldStart=true"),
+            "The #281 window only opens during a cold-start handoff"
+        )
+    }
+
+    func testColdStartFlagIsReportedEvenWithNoPhasePublished() {
+        defaults.set(true, forKey: SharedKeys.coldStartActive)
+
+        XCTAssertTrue(
+            AppScenePhaseProbe.describe(from: defaults).contains("coldStart=true"),
+            "The two halves of the line are independent"
+        )
+    }
+}

--- a/DictusKeyboard/KeyboardLifecycleProbe.swift
+++ b/DictusKeyboard/KeyboardLifecycleProbe.swift
@@ -58,6 +58,34 @@ enum KeyboardLifecycleProbe {
 
 extension UIInputViewController {
 
+    /// Whether this controller's own view is in a window right now.
+    ///
+    /// One half of the #260 claim predicate; see `KeyboardViewController.isOnScreen`,
+    /// which is defined as this OR `isInputViewInWindow` and is the only place that
+    /// composition is written down. Both halves live here so that every probe that
+    /// reports window attachment and the predicate that acts on it read the same
+    /// expression — a probe that could disagree with the code it observes is worth
+    /// less than no probe, and #260's open question is precisely whether this
+    /// predicate is true for the controller iOS is showing.
+    var isViewInWindow: Bool { viewIfLoaded?.window != nil }
+
+    /// Whether the `inputView` this controller assigns itself is in a window right now.
+    ///
+    /// The other half of the #260 claim predicate. It is checked separately because
+    /// a `UIInputViewController` that supplies its own `inputView` may have that view
+    /// parented into the keyboard window while `view` never is, so the two halves can
+    /// genuinely disagree — which is the whole reason `isOnScreen` tests both.
+    var isInputViewInWindow: Bool { inputView?.window != nil }
+
+    /// Both halves of the #260 claim predicate, in the shared key=value format.
+    ///
+    /// The predicate itself is `hasWindow || hasInputWindow`. Read them together:
+    /// `hasWindow=false` alone does **not** mean the controller failed the liveness
+    /// test. The lines that carry the composed answer log it as `onScreen=`.
+    var windowAttachmentProbeDetails: String {
+        "hasWindow=\(isViewInWindow) hasInputWindow=\(isInputViewInWindow)"
+    }
+
     /// The input traits of the text field this controller is editing.
     ///
     /// `kbAppear` is the surviving test of the #281 style-flip marker: both
@@ -105,9 +133,7 @@ extension UIInputViewController {
     ///
     /// No IPC: every read is local UIKit state.
     var dismissalProbeDetails: String {
-        let hasWindow = viewIfLoaded?.window != nil
-        let hasInputWindow = inputView?.window != nil
-        return "beingDismissed=\(isBeingDismissed) movingFromParent=\(isMovingFromParent)"
-            + " hasParent=\(parent != nil) hasWindow=\(hasWindow) hasInputWindow=\(hasInputWindow)"
+        "beingDismissed=\(isBeingDismissed) movingFromParent=\(isMovingFromParent)"
+            + " hasParent=\(parent != nil) \(windowAttachmentProbeDetails)"
     }
 }

--- a/DictusKeyboard/KeyboardViewController.swift
+++ b/DictusKeyboard/KeyboardViewController.swift
@@ -99,8 +99,12 @@ class KeyboardViewController: UIInputViewController {
     /// own `inputView`, and either may be the one iOS parents into the keyboard
     /// window. `viewIfLoaded` rather than `view`: asking for the view would load
     /// it, and a controller whose view was never loaded is not on screen anyway.
+    /// The two halves are named in `KeyboardLifecycleProbe`'s
+    /// `UIInputViewController` extension so the probes that report them cannot
+    /// drift from the predicate that acts on them; this line is the only place
+    /// they are composed.
     private var isOnScreen: Bool {
-        viewIfLoaded?.window != nil || inputView?.window != nil
+        isViewInWindow || isInputViewInWindow
     }
 
     /// Whether this instance was counted into `KeyboardLifecycleProbe`'s live
@@ -597,6 +601,16 @@ class KeyboardViewController: UIInputViewController {
 
     /// Emits the same layout snapshot we log in `viewDidAppear_settled`,
     /// reusable from deferred blocks to compare mid- vs post-animation sizes.
+    ///
+    /// It also carries the #260 claim predicate. That issue turns on one boolean —
+    /// is `isOnScreen` true for the controller iOS is actually showing? — and the
+    /// only path that answers it in code, `claimedOwnerlessArea`, needs the rare
+    /// ownership race to fire before it logs anything. This line does not: it runs
+    /// four times per controller on every recording, so an ordinary dictation
+    /// settles the question with no race to reproduce. `onScreen=` is the predicate
+    /// itself, read through `isOnScreen`; `hasWindow=` / `hasInputWindow=` say which
+    /// of the two attachments iOS kept, which is what a redesign would need if the
+    /// answer turns out to be `false`.
     private func logLayoutSnapshot(action: String) {
         let inputBounds = inputView?.bounds.size ?? .zero
         let keyboardFrame = giellaKeyboard?.frame.size ?? .zero
@@ -606,7 +620,7 @@ class KeyboardViewController: UIInputViewController {
             component: "KeyboardViewController",
             instanceID: controllerID,
             action: action,
-            details: "inputBounds=\(Int(inputBounds.width))x\(Int(inputBounds.height)) viewBounds=\(Int(viewBounds.width))x\(Int(viewBounds.height)) keyboardFrame=\(Int(keyboardFrame.width))x\(Int(keyboardFrame.height)) hostingFrame=\(Int(hostingFrame.width))x\(Int(hostingFrame.height)) hostingConst=\(hostingHeightConstraint?.constant ?? -1) heightConst=\(heightConstraint?.constant ?? -1) status=\(KeyboardState.shared.dictationStatus.rawValue) mode=\(KeyboardState.shared.areaMode.rawValue) memMB=\(MemoryFootprint.residentMB())"
+            details: "inputBounds=\(Int(inputBounds.width))x\(Int(inputBounds.height)) viewBounds=\(Int(viewBounds.width))x\(Int(viewBounds.height)) keyboardFrame=\(Int(keyboardFrame.width))x\(Int(keyboardFrame.height)) hostingFrame=\(Int(hostingFrame.width))x\(Int(hostingFrame.height)) hostingConst=\(hostingHeightConstraint?.constant ?? -1) heightConst=\(heightConstraint?.constant ?? -1) status=\(KeyboardState.shared.dictationStatus.rawValue) mode=\(KeyboardState.shared.areaMode.rawValue) onScreen=\(isOnScreen) \(windowAttachmentProbeDetails) memMB=\(MemoryFootprint.residentMB())"
         ))
     }
 
@@ -697,8 +711,13 @@ class KeyboardViewController: UIInputViewController {
             details: "prevStyle=\(previousTraitCollection?.userInterfaceStyle.rawValue ?? -1) newStyle=\(traitCollection.userInterfaceStyle.rawValue) hadColorChange=\(hadColorChange)"
                 // #281: both occurrences show the style flipping to dark (2) on a
                 // device in light mode, seconds before the teardown, and 15 clean
-                // cold starts show no flip at all. hasWindow says whether the flip
+                // cold starts show no flip at all. onScreen says whether the flip
                 // lands on an attached controller or a detached one.
+                //
+                // Named `onScreen=` since #260 because that is what it has always
+                // been — the composed predicate, not the `view`-only half that
+                // `hasWindow=` denotes on every other line. Captures from builds
+                // before this one spell the same value `hasWindow=` here.
                 //
                 // Deliberately reads no textDocumentProxy property here. This
                 // callback fires before viewWillAppear — see the host-connection
@@ -706,7 +725,7 @@ class KeyboardViewController: UIInputViewController {
                 // is no input session yet, and that is exactly where the
                 // documentIdentifier read crashed the extension on every launch.
                 // Bounded at 2-3 lines per controller.
-                + " hasWindow=\(viewIfLoaded?.window != nil || inputView?.window != nil)"
+                + " onScreen=\(isOnScreen)"
         ))
         // Update keyboard theme when dark/light mode changes while keyboard is visible.
         if hadColorChange {

--- a/DictusKeyboard/KeyboardViewController.swift
+++ b/DictusKeyboard/KeyboardViewController.swift
@@ -641,6 +641,14 @@ class KeyboardViewController: UIInputViewController {
             details: "animated=\(animated) memMB=\(MemoryFootprint.residentMB())"
                 + " live=\(KeyboardLifecycleProbe.liveCount)"
                 + " \(dismissalProbeDetails) \(inputContextProbeDetails)"
+                // #281: whether DictusApp had already backgrounded when iOS tore
+                // this controller down. The log's one-second resolution and its
+                // interleaving of two processes make that ordering unrecoverable by
+                // comparing timestamps, and it is the one thing the surviving
+                // hypothesis — the swipe-back landing before iOS rotates in a
+                // successor — needs to be true. Read from the App Group, so no IPC
+                // round trip to the host app on a teardown path.
+                + " \(AppScenePhaseProbe.describe())"
         ))
         PersistentLog.log(.keyboardDidDisappear)
 


### PR DESCRIPTION
Two observation-only probes, bundled into one PR because they touch the same file and every DictusKeyboard change costs one device smoke test. `refs #260`, `refs #281`.

**No behavioural change.** No control flow, no lifecycle, no ownership, no layout, and nothing near the hosting height constraint. Every edit is a log string, plus two App Group keys nothing branches on.

## Probe 1 — is the #260 claim predicate true for the controller iOS is showing? (`refs #260`)

#260 has one open question. PR #280 gates the claim on `KeyboardViewController.isOnScreen`:

```swift
viewIfLoaded?.window != nil || inputView?.window != nil
```

If that is `true` for the controller iOS actually presents during a recording, the fix works whenever it is reached and the issue closes. If it is `false`, the fix is inert and the ownership design needs reworking. Today the only line that reports it, `claimedOwnerlessArea`, needs the ownership race to fire first — observed once, ever, and 17 deliberate cold starts produced nothing.

`logLayoutSnapshot` needs no race. It already runs at `viewDidAppear_settled` and at 500/1000/2000 ms, on every controller of every recording. It now carries:

```
… status=recording mode=recording onScreen=true hasWindow=true hasInputWindow=false memMB=22
```

`onScreen=` is read through `isOnScreen` itself. `hasWindow=` / `hasInputWindow=` are the two halves it composes, and they are there because a redesign would need to know *which* attachment iOS kept, not just that the predicate failed.

### One structural change, deliberate

The predicate existed in **three** copies before this PR: `isOnScreen`, `dismissalProbeDetails`, and an inline copy in `traitCollectionDidChange`. The brief for this issue is explicit that a probe which can disagree with the code it observes is worthless here, since disagreement is the failure mode under investigation. So the two halves are now named once, in `KeyboardLifecycleProbe`'s `UIInputViewController` extension, and every site reads them. `isOnScreen` keeps its documentation and its exact value; only its right-hand side changed, to `isViewInWindow || isInputViewInWindow`.

**One log field is renamed as a consequence.** `hasWindow=` on `traitCollectionDidChange` was the *composed* predicate, while the same name on `viewDidDisappear` was the `view`-only half. That collision would have misled the reading of exactly the boolean this PR exists to measure. The trait line now says `onScreen=`, same value. Captures from earlier builds spell it `hasWindow=` there; the code comment records that.

## Probe 2 — did the app background before or after the teardown? (`refs #281`)

The surviving hypothesis after four captures is that the teardown happens when the swipe-back lands before iOS has rotated in a successor controller. That is an ordering claim, and the log cannot settle it: one-second resolution, two processes whose writes lag relative to each other, so `<APP> appDidEnterBackground` and `<KBD> viewDidDisappear` in the same second cannot be sequenced (PR #282 §1).

DictusApp now publishes its `scenePhase` to the App Group — first thing in the same callback that already logs the lifecycle line — and the keyboard reads it at `viewDidDisappear`:

```
… hasParent=false hasWindow=false hasInputWindow=false fullAccess=true kbAppear=0 \
  appPhase=background appPhaseAgeMs=412 coldStart=true
```

The answer is now on the keyboard's own line, measured on the keyboard's own clock. `appPhaseAgeMs` is what makes it trustworthy: the keys outlive the app process, so a phase with no fresh timestamp behind it is a leftover from an earlier run and reads `appPhase=unknown appPhaseAgeMs=-1`.

No new IPC path — App Group shared defaults, the channel every other cross-process value already travels on. The contract lives in `DictusCore/AppScenePhaseProbe.swift` so both processes share one definition, and so it is unit-testable.

## Log budget (#255)

Both probes extend lines that already exist and already carry per-instance ids, so #255's duplicate collapsing is unaffected and no new line multiplies by controller count.

- snapshot line: +~45 chars, 4 lines per controller per recording
- `viewDidDisappear`: +~50 chars, 1 line per controller
- `traitCollectionDidChange`: net zero (a rename)

## The `documentIdentifier` class of crash does not apply

PR #282 §0: a probe that passed build, CI, 516 tests and SwiftLint still trapped on every extension launch, because `UIInputViewController.documentIdentifier` imports as a non-optional `UUID` and ObjC returns nil. Nothing here goes near it.

Every read added on the keyboard side is either already performed at that same call site today (`viewIfLoaded`, `inputView`, `window`) or is a plain `UserDefaults` lookup. No ObjC-imported property is newly read. **That is an argument, not a substitute for the smoke test below.**

## Verification

- `DictusApp`, `DictusKeyboard`, `DictusCore` — all three schemes **BUILD SUCCEEDED** (iOS Simulator).
- `swift test` in DictusCore: **585 tests, 0 failures**, 1 skipped. 9 of them new, covering the round trip, the age arithmetic, the stale/unwritten/unrecognised cases and the cold-start field.
- `swiftlint lint --strict`: **0 violations in 158 files**. No baseline, no exemption.
- **App-side write path exercised for real**, headless simulator, install + `simctl launch`, App Group plist read back:
  - `dictus.appScenePhase = "active"` at `1785704437.639` — same second as the `appDidBecomeActive` log line;
  - `dictus.appScenePhase = "background"` at `1785704455.769` — same second as `appDidEnterBackground`.
  - The sub-second timestamps are the resolution the log itself lacks, which is the point of the probe.
- No simulator GUI was launched.

### What this verification cannot catch

The extension was never executed. Nothing in this pipeline runs it. See the device list in the recap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced app lifecycle tracking across active, inactive, and background states.
  - Added timestamps and cold-start information to lifecycle diagnostics.
  - Improved keyboard diagnostics with clearer screen visibility, window attachment, teardown, and layout details.
- **Bug Fixes**
  - Standardized visibility reporting to accurately reflect whether the keyboard is on screen.
  - Added safe fallback reporting for unknown or incomplete lifecycle data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->