### PR TITLE
fix(scripts): patch the FluidAudio checkout of the build being run (refs #285)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Voir PRD.md pour les specs complètes et DEVELOPMENT.md pour le guide de dévelo
 ## Build, test, lint
 
 - Trois targets à construire : `DictusApp`, `DictusKeyboard`, `DictusCore`.
-- Un worktree neuf — comme tout "Reset Package Caches" — résout les packages de zéro et exige `./scripts/patch-fluidaudio-swift5.sh` avant le premier build, sinon il échoue.
+- Un worktree neuf — comme tout "Reset Package Caches" — résout les packages de zéro et exige `./scripts/patch-fluidaudio-swift5.sh` avant le premier build, sinon il échoue. Le script prend le chemin de derived data du build à venir : `./scripts/patch-fluidaudio-swift5.sh build/DerivedData` pour un build en ligne de commande avec `-derivedDataPath`, sans argument pour un build Xcode. Sans argument il ne patche que la derived data partagée d'Xcode, ce qui ne dit rien du checkout d'un worktree (#285). Il sort en erreur quand il ne trouve aucun checkout sous le chemin demandé.
 - Lint : `swiftlint lint --strict`. Pas de baseline ni de fichier d'exemptions (la baseline a été supprimée en #146), donc toute violation introduite se corrige ou porte un `swiftlint:disable` avec sa raison écrite.
 - Xcode régénère `Localizable.xcstrings` au build (état d'extraction `stale`, newline finale perdue). C'est du bruit de build : le jeter, jamais le committer.
 

--- a/scripts/patch-fluidaudio-swift5.sh
+++ b/scripts/patch-fluidaudio-swift5.sh
@@ -49,9 +49,26 @@ if [ "$#" -gt 1 ]; then
   exit 2
 fi
 
+# An empty path is not a request for the default: it is `$SOME_VAR` expanding to
+# nothing in the caller's command line. Falling back to Xcode's shared location
+# there would sweep stale checkouts and exit 0 for a build that asked about its
+# own — exactly the silent success this script exists to prevent (issue #285).
+# Hence ${DERIVED_DATA_PATH+set}, which tells "unset" from "set to nothing".
+if [ "$#" -eq 1 ] && [ -z "$1" ]; then
+  echo "error: derived data path is empty (an unset variable in the caller?)." >&2
+  usage >&2
+  exit 2
+fi
+if [ "$#" -eq 0 ] && [ -n "${DERIVED_DATA_PATH+set}" ] && [ -z "$DERIVED_DATA_PATH" ]; then
+  echo "error: DERIVED_DATA_PATH is set but empty." >&2
+  usage >&2
+  exit 2
+fi
+
 # Explicit mode = the caller named the derived data path of the build it is
 # about to run, so the script reports on THAT checkout and nothing else.
-# Default mode = Xcode's shared location, the pre-#285 behaviour.
+# Default mode = no argument and no DERIVED_DATA_PATH, i.e. Xcode's shared
+# location, the pre-#285 behaviour.
 REQUESTED="${1:-${DERIVED_DATA_PATH:-}}"
 if [ -n "$REQUESTED" ]; then
   EXPLICIT=1

--- a/scripts/patch-fluidaudio-swift5.sh
+++ b/scripts/patch-fluidaudio-swift5.sh
@@ -12,7 +12,82 @@
 # This edits the SPM CHECKOUT, which is wiped whenever Xcode re-resolves packages
 # ("Reset Package Caches", DerivedData deletion — and sometimes Archive). Re-run
 # this script after any such reset, then rebuild.
+#
+# Each build has its own checkout: a build passing `-derivedDataPath` (git
+# worktree, CI-style command line) resolves packages under that path, not under
+# Xcode's shared location. Patching one says nothing about the other, so the
+# path is an argument and a missing checkout is a hard failure (issue #285).
 set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: patch-fluidaudio-swift5.sh [DERIVED_DATA_PATH]
+
+  DERIVED_DATA_PATH  Derived data directory of the build you are about to run —
+                     the same value passed to `xcodebuild -derivedDataPath`.
+                     May also be given as the DERIVED_DATA_PATH env variable.
+                     Defaults to Xcode's shared location
+                     (~/Library/Developer/Xcode/DerivedData), which is what an
+                     Xcode GUI build uses.
+
+Examples:
+  ./scripts/patch-fluidaudio-swift5.sh                    # Xcode GUI build
+  ./scripts/patch-fluidaudio-swift5.sh build/DerivedData  # CI-style build
+USAGE
+}
+
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+esac
+
+if [ "$#" -gt 1 ]; then
+  echo "error: expected at most one derived data path, got $#." >&2
+  usage >&2
+  exit 2
+fi
+
+# Explicit mode = the caller named the derived data path of the build it is
+# about to run, so the script reports on THAT checkout and nothing else.
+# Default mode = Xcode's shared location, the pre-#285 behaviour.
+REQUESTED="${1:-${DERIVED_DATA_PATH:-}}"
+if [ -n "$REQUESTED" ]; then
+  EXPLICIT=1
+  ROOT="$REQUESTED"
+else
+  EXPLICIT=0
+  ROOT="$HOME/Library/Developer/Xcode/DerivedData"
+fi
+
+# `find -path "*/SourcePackages/..."` needs a leading path component, and a
+# relative root (build/DerivedData) has none — make the root absolute. The
+# directory may not exist yet, and that is a failure we want to name precisely,
+# so resolve it textually rather than with a tool that requires existence.
+case "$ROOT" in
+  /*) ;;
+  *) ROOT="$PWD/${ROOT#./}" ;;
+esac
+ROOT="${ROOT%/}"
+
+# Both failure paths below say the same thing: nothing was patched for the build
+# you asked about, here is how to get a checkout there.
+fail_no_checkout() {
+  if [ "$EXPLICIT" -eq 1 ]; then
+    echo "Resolve the packages for this build first:" >&2
+    echo "  xcodebuild -resolvePackageDependencies -project Dictus.xcodeproj \\" >&2
+    echo "    -scheme DictusApp -derivedDataPath $ROOT" >&2
+  else
+    echo "Open the project in Xcode (resolve packages) first." >&2
+  fi
+  exit 1
+}
+
+if [ ! -d "$ROOT" ]; then
+  echo "error: derived data directory does not exist: $ROOT" >&2
+  fail_no_checkout
+fi
 
 FOUND=0
 while IFS= read -r PKG; do
@@ -34,10 +109,20 @@ assert old in t, "anchor not found - FluidAudio Package.swift changed shape; pat
 open(p, "w").write(t.replace(old, new))
 print("Patched:", p)
 PY
-done < <(find "$HOME/Library/Developer/Xcode/DerivedData" \
+done < <(find "$ROOT" \
   -path "*/SourcePackages/checkouts/FluidAudio/Package.swift" 2>/dev/null)
 
+# The search is confined to $ROOT, so a stale checkout elsewhere on the machine
+# can no longer stand in for the one this build compiles.
 if [ "$FOUND" -eq 0 ]; then
-  echo "FluidAudio checkout not found. Open the project in Xcode (resolve packages) first."
-  exit 1
+  echo "error: no FluidAudio checkout found under: $ROOT" >&2
+  fail_no_checkout
+fi
+
+if [ "$EXPLICIT" -eq 1 ]; then
+  echo "FluidAudio checkout patched for the build using: $ROOT"
+else
+  echo "FluidAudio checkout patched under Xcode's shared derived data: $ROOT"
+  echo "note: a build passing -derivedDataPath (worktree, CI-style command line)" \
+       "uses its own checkout — re-run with that path to patch it."
 fi


### PR DESCRIPTION
Makes `scripts/patch-fluidaudio-swift5.sh` report on the checkout the build
actually compiles, instead of on whatever it finds under `$HOME`.

refs #285

## What changed

- The derived data path is now an argument (or the `DERIVED_DATA_PATH`
  environment variable): `./scripts/patch-fluidaudio-swift5.sh build/DerivedData`.
- In that explicit mode the search is confined to the given path, so the stale
  `Dictus-*` checkouts on a developer machine (18 of them on mine) can no longer
  satisfy the "found something" guard.
- Not finding a checkout under the requested path — or the path not existing —
  now exits non-zero, names the path searched, and prints the
  `-resolvePackageDependencies` command that creates the checkout there.
- With no argument the previous sweep of Xcode's shared derived data is
  unchanged, plus a closing note that a `-derivedDataPath` build has its own
  checkout.
- `-h/--help`, a usage error on more than one argument, and a usage error when a
  path is present but empty — an argument expanded from an unset variable, or
  `DERIVED_DATA_PATH=""`, is a question about a specific build, not a request
  for the default sweep. `${DERIVED_DATA_PATH+set}` tells "unset" from "set to
  nothing"; a genuine no-argument run is unchanged.
- `CLAUDE.md` ("Build, test, lint") now names the argument to pass in a worktree.

Nothing about the patch itself changed: same anchor, same
`swiftLanguageModes: [.v5]` insertion, same `chmod u+w`, same idempotence.

## Verification

The bug reproduced in this fresh worktree first. After
`xcodebuild -resolvePackageDependencies -derivedDataPath build/DerivedData`, the
worktree checkout was unpatched, and the **old** script (run from the worktree)
printed 18 "Already patched" lines for stale directories and exited 0 while
`build/DerivedData/SourcePackages/checkouts/FluidAudio/Package.swift` still had
no `swiftLanguageModes`.

| Check | Result |
| --- | --- |
| Crafted root with an unpatched, read-only `Package.swift` | `Patched: …` then `Already patched: …` on re-run, exit 0 |
| Existing root with no FluidAudio checkout | `error: no FluidAudio checkout found under: …`, exit 1 |
| Non-existent root | `error: derived data directory does not exist: …`, exit 1 |
| Relative path (`./fake`) | resolved to absolute, patched, exit 0 |
| `DERIVED_DATA_PATH` env var on an empty root, 18 stale checkouts present | exit 1 |
| No argument, `DERIVED_DATA_PATH` unset | 18 checkouts under Xcode's shared location reported, exit 0 |
| Two arguments | usage error, exit 2 |
| Empty argument (`""`, or `"$UNSET_VAR"`) | `error: derived data path is empty …`, exit 2 |
| `DERIVED_DATA_PATH=` (set, empty) | `error: DERIVED_DATA_PATH is set but empty.`, exit 2 |
| `./scripts/patch-fluidaudio-swift5.sh build/DerivedData` then the CI build command | `Patched:` then `** BUILD SUCCEEDED **`, no manual editing |
| `swiftlint lint --strict` | 0 violations in 158 files (re-run after the empty-path fix) |
| `swift test` in `DictusCore/` | 586 tests, 1 skipped, 0 failures |

CI is untouched: its build runs on Xcode 26.3, where the FluidAudio Swift 6
errors do not fire, and it never called this script. Its resolve step also has
no `-derivedDataPath`, so calling the script before the build step would fail by
design — see the PR discussion.

The issue's "open question for the maintainer" (scheme pre-action vs. forking
FluidAudio) is deliberately not actioned here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AL9tgVzFmZ1nY6S5Ko3bN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a derived-data path when running the Swift compatibility patch script.
  * Added automatic use of the configured environment path or Xcode’s shared location when no path is provided.

* **Bug Fixes**
  * Improved validation and error messages for invalid paths, missing directories, and unavailable checkouts.
  * Clarified behavior for command-line and Xcode builds.

* **Documentation**
  * Expanded setup instructions with script usage examples and build-specific guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->