### PR TITLE
Play the key click on touch-down, in step with the haptic (refs #286)

### DIFF
--- a/Dictus.xcodeproj/project.pbxproj
+++ b/Dictus.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		EE0DE001 /* de_spellcheck.dict in Resources */ = {isa = PBXBuildFile; fileRef = EE1DE001 /* de_spellcheck.dict */; };
 		EE0DE002 /* de_ngrams.dict in Resources */ = {isa = PBXBuildFile; fileRef = EE1DE002 /* de_ngrams.dict */; };
 		CC000030 /* KeyboardMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC100030 /* KeyboardMetrics.swift */; };
+		CC000050 /* KeySoundPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC100050 /* KeySoundPolicy.swift */; };
 		CC000010 /* KeyboardLayouts.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC100010 /* KeyboardLayouts.swift */; };
 		CC000001 /* GiellaUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC100001 /* GiellaUtils.swift */; };
 		CC000002 /* KeyDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC100002 /* KeyDefinition.swift */; };
@@ -267,6 +268,7 @@
 		BB100005 /* StopStandbyIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopStandbyIntent.swift; sourceTree = "<group>"; };
 		BB200001 /* DictusWidgets.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = DictusWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC100030 /* KeyboardMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardMetrics.swift; sourceTree = "<group>"; };
+		CC100050 /* KeySoundPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeySoundPolicy.swift; sourceTree = "<group>"; };
 		CC100010 /* KeyboardLayouts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardLayouts.swift; sourceTree = "<group>"; };
 		CC100020 /* DictusKeyboardBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictusKeyboardBridge.swift; sourceTree = "<group>"; };
 		CC100040 /* HostInputTraits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostInputTraits.swift; sourceTree = "<group>"; };
@@ -389,6 +391,7 @@
 				AA1000F6 /* KeyboardLifecycleProbe.swift */,
 				AA100030 /* InputView.swift */,
 				CC100030 /* KeyboardMetrics.swift */,
+				CC100050 /* KeySoundPolicy.swift */,
 				CC100010 /* KeyboardLayouts.swift */,
 				CC100020 /* DictusKeyboardBridge.swift */,
 				CC100040 /* HostInputTraits.swift */,
@@ -1005,6 +1008,7 @@
 				AA0000D4 /* SuggestionBarView.swift in Sources */,
 				AA0000G0 /* KeyTapSignposter.swift in Sources */,
 				CC000030 /* KeyboardMetrics.swift in Sources */,
+				CC000050 /* KeySoundPolicy.swift in Sources */,
 				CC000010 /* KeyboardLayouts.swift in Sources */,
 				CC000020 /* DictusKeyboardBridge.swift in Sources */,
 				CC000040 /* HostInputTraits.swift in Sources */,

--- a/DictusCore/Sources/DictusCore/KeySoundCategory.swift
+++ b/DictusCore/Sources/DictusCore/KeySoundCategory.swift
@@ -1,0 +1,36 @@
+// DictusCore/Sources/DictusCore/KeySoundCategory.swift
+// The three key-click categories the keyboard plays, and the system sound each maps to.
+import Foundation
+
+/// Which of the three iOS keyboard clicks a key produces.
+///
+/// The split into letter / delete / modifier comes from giellakbd-ios and matches what
+/// Apple's own keyboard does: typing sounds different from deleting, which sounds
+/// different from a layer switch.
+///
+/// Lives in DictusCore rather than DictusKeyboard so the identifiers are unit-testable —
+/// the keyboard extension target has no test bundle. Same reasoning as `KeyboardAreaMode`
+/// and `LayoutType`. The keyboard target keeps the other half of the decision: which
+/// category a given key belongs to (`KeySound.category(for:)`).
+public enum KeySoundCategory: String, Equatable, CaseIterable, Sendable {
+    /// Character insertion — letters, digits, punctuation, the adaptive accent key.
+    case letter
+    /// Backspace, including each tick of an accelerated repeat.
+    case delete
+    /// Everything that is not text: shift, the symbol layers, space, return, emoji, globe.
+    case modifier
+
+    /// AudioServices system sound identifier for this category.
+    ///
+    /// `UInt32` rather than `SystemSoundID` so DictusCore stays free of AudioToolbox;
+    /// `SystemSoundID` is a type alias for `UInt32`, so call sites pass this straight to
+    /// `AudioServicesPlaySystemSound`. That API respects the hardware silent switch
+    /// natively, which is why the keyboard uses it rather than an audio player.
+    public var systemSoundID: UInt32 {
+        switch self {
+        case .letter: return 1104
+        case .delete: return 1155
+        case .modifier: return 1156
+        }
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/KeySoundCategoryTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/KeySoundCategoryTests.swift
@@ -1,0 +1,29 @@
+// DictusCore/Tests/DictusCoreTests/KeySoundCategoryTests.swift
+// Contract tests pinning the three key-click identifiers (#286).
+import XCTest
+@testable import DictusCore
+
+final class KeySoundCategoryTests: XCTestCase {
+
+    // MARK: - Cases
+
+    func testEnumHasExactlyThreeCases() {
+        XCTAssertEqual(KeySoundCategory.allCases.count, 3)
+    }
+
+    // MARK: - System sound identifiers
+
+    /// Moving the click to touchDown (#286) must not change WHICH sound plays.
+    /// These are the identifiers the bridge handlers used before the move, and the
+    /// same ones giellakbd-ios and Apple's keyboard use.
+    func testSystemSoundIdentifiersAreUnchanged() {
+        XCTAssertEqual(KeySoundCategory.letter.systemSoundID, 1104)
+        XCTAssertEqual(KeySoundCategory.delete.systemSoundID, 1155)
+        XCTAssertEqual(KeySoundCategory.modifier.systemSoundID, 1156)
+    }
+
+    func testEachCategoryHasItsOwnSound() {
+        let ids = Set(KeySoundCategory.allCases.map(\.systemSoundID))
+        XCTAssertEqual(ids.count, KeySoundCategory.allCases.count)
+    }
+}

--- a/DictusKeyboard/DictusKeyboardBridge.swift
+++ b/DictusKeyboard/DictusKeyboardBridge.swift
@@ -1,10 +1,10 @@
 // DictusKeyboard/DictusKeyboardBridge.swift
 // Delegate bridge from giellakbd-ios GiellaKeyboardView key events to Dictus text actions.
 // Created for Phase 18 Plan 02 -- wires the vendored UICollectionView keyboard
-// to textDocumentProxy operations with haptic feedback and 3-category key sounds.
+// to textDocumentProxy operations. Haptic and key sound both fire on touchDown in
+// GiellaKeyboardView, not here (#286).
 
 import UIKit
-import AudioToolbox
 import DictusCore
 
 /// Adapts GiellaKeyboardView delegate callbacks into Dictus keyboard actions.
@@ -17,10 +17,15 @@ import DictusCore
 ///
 /// The bridge receives key events from the UICollectionView keyboard and:
 /// - Inserts/deletes text via textDocumentProxy
-/// - Plays haptic feedback via DictusCore's HapticFeedback
-/// - Plays 3-category key sounds via AudioServicesPlaySystemSound
 /// - Manages shift/capslock page state on the keyboard view
 /// - Handles auto-full-stop (double-space -> period)
+///
+/// It emits no key click. The click and the key-tap haptic both fire on touchDown in
+/// GiellaKeyboardView, the only layer that knows when a finger lands. The bridge hears
+/// about a key once its action is due, and for every letter that is on touchUp —
+/// sounding the click from here is what made typing feel out of sync with the
+/// haptic (#286). The haptics that remain here are the ones with no touchDown to
+/// attach to: the cursor-movement tick, and the emoji toggle's own feedback.
 final class DictusKeyboardBridge: NSObject,
     GiellaKeyboardViewDelegate,
     GiellaKeyboardViewKeyboardKeyDelegate {
@@ -83,7 +88,7 @@ final class DictusKeyboardBridge: NSObject,
         case .input(let character, let alternate):
             if alternate == "accent" {
                 handleAdaptiveAccentKey()
-            } else if character == "\u{1F600}" {
+            } else if character == KeyboardLayouts.emojiKeyGlyph {
                 // Emoji button: identified by the emoji glyph on the key.
                 // No alternate text so the key shows only the smiley icon.
                 handleEmojiToggle()
@@ -120,13 +125,13 @@ final class DictusKeyboardBridge: NSObject,
 
         case .keyboard:
             // Globe/next keyboard button -- advance to next input method
-            AudioServicesPlaySystemSound(KeySound.modifier)
             controller?.advanceToNextInputMode()
 
         case .keyboardMode, .splitKeyboard, .normalKeyboard,
              .sideKeyboardLeft, .sideKeyboardRight:
-            // iPad keyboard mode keys -- not supported on iPhone, no-op
-            AudioServicesPlaySystemSound(KeySound.modifier)
+            // iPad keyboard mode keys -- not supported on iPhone, no-op.
+            // The click still plays on touchDown, from KeySound.category(for:).
+            break
 
         case .spacer, .caps:
             // Spacer is a layout element, caps is handled by double-tap shift
@@ -147,7 +152,7 @@ final class DictusKeyboardBridge: NSObject,
     private static func editsDocument(_ key: KeyDefinition) -> Bool {
         switch key.type {
         case .input(let character, _):
-            return character != "\u{1F600}"
+            return character != KeyboardLayouts.emojiKeyGlyph
         case .backspace, .spacebar, .returnkey, .comma, .fullStop, .tab:
             return true
         default:
@@ -158,9 +163,8 @@ final class DictusKeyboardBridge: NSObject,
     func didTriggerDoubleTap(forKey key: KeyDefinition) {
         switch key.type {
         case .shift:
-            // Double-tap shift activates caps lock
-            // Haptic already fired in touchesBegan
-            AudioServicesPlaySystemSound(KeySound.modifier)
+            // Double-tap shift activates caps lock.
+            // Haptic and click already fired in touchesBegan.
             keyboardView?.page = .capslock
             lastShiftTapTime = 0 // Reset to prevent triple-tap confusion
             isManualShift = false // Caps lock is its own mode, not "manual shift"
@@ -246,16 +250,15 @@ final class DictusKeyboardBridge: NSObject,
     // MARK: - Key Action Handlers
 
     /// Handle character input (letters, numbers, punctuation).
-    /// Inserts the character, plays letter sound, auto-unshifts after one letter,
-    /// then rechecks autocapitalization (e.g., typing "." may prepare shift for next char).
-    /// NOTE: Haptic fires in GiellaKeyboardView.touchesBegan() for ALL keys on touchDown.
+    /// Inserts the character, auto-unshifts after one letter, then rechecks
+    /// autocapitalization (e.g., typing "." may prepare shift for next char).
+    /// NOTE: Haptic and click fire in GiellaKeyboardView.touchesBegan() for ALL keys
+    /// on touchDown, so neither is emitted here.
     private func handleInputKey(_ character: String) {
         // Clear rejected words when starting a new word
         if suggestionState?.currentWord.isEmpty == true {
             suggestionState?.rejectedWords.removeAll()
         }
-
-        AudioServicesPlaySystemSound(KeySound.letter)
 
         // Insert the character. When on shifted/capslock page, the key definition
         // already contains the uppercase character, so we insert as-is.
@@ -284,8 +287,6 @@ final class DictusKeyboardBridge: NSObject,
     /// Handle backspace/delete key. Always deletes one character.
     /// Autocorrect undo is handled by tapping the suggestion bar, not backspace.
     private func handleBackspace() {
-        AudioServicesPlaySystemSound(KeySound.delete)
-
         controller?.textDocumentProxy.deleteBackward()
         secondToLastInsertedCharacter = nil
         lastInsertedCharacter = nil
@@ -315,7 +316,6 @@ final class DictusKeyboardBridge: NSObject,
     /// The algorithm: trim trailing spaces, find the previous word boundary (last space),
     /// delete everything from cursor back to that boundary.
     private func handleWordDelete() {
-        AudioServicesPlaySystemSound(KeySound.delete)
         suggestionState?.pendingUndo = nil
         guard let proxy = controller?.textDocumentProxy,
               let before = proxy.documentContextBeforeInput, !before.isEmpty else {
@@ -362,7 +362,6 @@ final class DictusKeyboardBridge: NSObject,
     /// behavior -- corrections appear only when the user finishes the word (space/return).
     /// Correcting mid-word would be disorienting as the text changes while typing.
     private func handleSpace() {
-        AudioServicesPlaySystemSound(KeySound.modifier)
         secondToLastInsertedCharacter = lastInsertedCharacter
 
         // Next space after autocorrect = undo window closes
@@ -529,7 +528,6 @@ final class DictusKeyboardBridge: NSObject,
     /// After inserting newline, recheck autocapitalization -- many apps use
     /// .sentences autocap which should capitalize after a newline.
     private func handleReturn() {
-        AudioServicesPlaySystemSound(KeySound.modifier)
         suggestionState?.pendingUndo = nil
         controller?.textDocumentProxy.insertText("\n")
         secondToLastInsertedCharacter = lastInsertedCharacter
@@ -570,8 +568,6 @@ final class DictusKeyboardBridge: NSObject,
     /// previous character with the accented version is how iOS native French keyboards
     /// handle accent insertion as well.
     private func handleAdaptiveAccentKey() {
-        AudioServicesPlaySystemSound(KeySound.letter)
-
         let label = FrenchAdaptiveKey.label(
             afterTyping: lastInsertedCharacter,
             precedingChar: secondToLastInsertedCharacter
@@ -603,7 +599,6 @@ final class DictusKeyboardBridge: NSObject,
 
     /// Handle emoji button tap: triggers the emoji picker toggle.
     private func handleEmojiToggle() {
-        AudioServicesPlaySystemSound(KeySound.modifier)
         HapticFeedback.keyTapped()
         onEmojiToggle?()
     }
@@ -627,8 +622,6 @@ final class DictusKeyboardBridge: NSObject,
     /// but we also detect it here as a fallback because the timing can differ between
     /// the gesture recognizer and our manual tracking. Both paths lead to .capslock.
     private func handleShift() {
-        AudioServicesPlaySystemSound(KeySound.modifier)
-
         guard let kbView = keyboardView else { return }
 
         let now = Date.timeIntervalSinceReferenceDate
@@ -664,8 +657,6 @@ final class DictusKeyboardBridge: NSObject,
     /// Handle 123/ABC layer switch.
     /// Toggles between letter pages (normal/shifted/capslock) and symbols1.
     private func handleSymbolsToggle() {
-        AudioServicesPlaySystemSound(KeySound.modifier)
-
         guard let kbView = keyboardView else { return }
 
         switch kbView.page {
@@ -679,8 +670,6 @@ final class DictusKeyboardBridge: NSObject,
     /// Handle #+=/123 toggle on symbols pages.
     /// Toggles between symbols1 and symbols2.
     private func handleShiftSymbolsToggle() {
-        AudioServicesPlaySystemSound(KeySound.modifier)
-
         guard let kbView = keyboardView else { return }
 
         switch kbView.page {

--- a/DictusKeyboard/KeySoundPolicy.swift
+++ b/DictusKeyboard/KeySoundPolicy.swift
@@ -1,0 +1,46 @@
+// DictusKeyboard/KeySoundPolicy.swift
+// Which click a key produces, decided without performing the key's action.
+
+import DictusCore
+
+extension KeySound {
+    /// The click `key` produces, or nil for keys that stay silent.
+    ///
+    /// WHY this exists (#286): the click used to be emitted from inside the fourteen
+    /// `DictusKeyboardBridge` handlers that `didTriggerKey()` reaches, so it could only
+    /// happen at the moment the key's action ran — touch-up for every letter, while the
+    /// haptic had already fired on touch-down. Splitting "what does this key sound like"
+    /// from "do what this key does" lets the touch layer play the click on finger contact,
+    /// in step with the haptic, for keys that act on release just as much as for keys
+    /// that act on contact.
+    ///
+    /// The table below reproduces exactly what each handler played before the split. It
+    /// is a timing change, not a sound-design change: no key gained, lost or swapped a
+    /// category here.
+    static func category(for key: KeyDefinition) -> KeySoundCategory? {
+        switch key.type {
+        case .input(let character, _):
+            // The emoji toggle is an `.input` key carrying the smiley rather than a type
+            // of its own, and it opens a picker instead of typing — it clicked like a
+            // modifier, not like a letter. `didTriggerKey` tells the two apart the same way.
+            return character == KeyboardLayouts.emojiKeyGlyph ? .modifier : .letter
+
+        case .comma, .fullStop, .tab:
+            // Routed through handleInputKey, so they clicked like the letters they insert.
+            return .letter
+
+        case .backspace:
+            return .delete
+
+        case .shift, .symbols, .shiftSymbols, .spacebar, .returnkey, .keyboard,
+             .keyboardMode, .splitKeyboard, .normalKeyboard,
+             .sideKeyboardLeft, .sideKeyboardRight:
+            return .modifier
+
+        case .spacer, .caps:
+            // Spacer is a layout element and caps is reached through double-tap shift;
+            // neither ever played a sound.
+            return nil
+        }
+    }
+}

--- a/DictusKeyboard/KeyboardLayouts.swift
+++ b/DictusKeyboard/KeyboardLayouts.swift
@@ -15,6 +15,14 @@ import DictusCore
 /// Globe key is provided by iOS below third-party keyboards -- not part of our layout.
 enum KeyboardLayouts {
 
+    /// Glyph carried by the emoji-picker toggle key.
+    ///
+    /// The toggle has no `KeyType` of its own — it is an `.input` key whose character is
+    /// the smiley, and everything downstream tells it apart from a typed character by
+    /// comparing against this glyph. Naming it once keeps those comparisons in step
+    /// (`DictusKeyboardBridge.didTriggerKey`, `editsDocument`, `KeySound.category(for:)`).
+    static let emojiKeyGlyph = "\u{1F600}"
+
     // MARK: - Public API
 
     /// AZERTY layout (default for French).
@@ -211,7 +219,7 @@ enum KeyboardLayouts {
         var row: [KeyDefinition] = needsGlobe ? [globeKey()] : []
         row.append(contentsOf: [
             KeyDefinition(type: .symbols, size: CGSize(width: 1.5, height: 1)),
-            KeyDefinition(type: .input(key: "\u{1F600}", alternate: nil), size: CGSize(width: 1.5, height: 1)),
+            KeyDefinition(type: .input(key: emojiKeyGlyph, alternate: nil), size: CGSize(width: 1.5, height: 1)),
             KeyDefinition(type: .spacebar(name: lang.spaceName), size: CGSize(width: needsGlobe ? 4.0 : 5.0, height: 1)),
             KeyDefinition(type: .returnkey(name: lang.returnName), size: CGSize(width: 2.0, height: 1))
         ])

--- a/DictusKeyboard/KeyboardMetrics.swift
+++ b/DictusKeyboard/KeyboardMetrics.swift
@@ -5,6 +5,7 @@
 import SwiftUI
 import UIKit
 import AudioToolbox
+import DictusCore
 
 // MARK: - Device Class (from old KeyButton.swift)
 
@@ -75,10 +76,12 @@ enum KeyMetrics {
 
 /// 3-category system sounds for key feedback.
 /// These sound IDs are the same as giellakbd-ios Audio class and respect silent switch.
+/// The identifiers themselves live in DictusCore's `KeySoundCategory` so they have one
+/// source of truth and can be unit-tested; these are the shorthand the keyboard uses.
 enum KeySound {
-    static let letter: SystemSoundID = 1104
-    static let delete: SystemSoundID = 1155
-    static let modifier: SystemSoundID = 1156
+    static let letter: SystemSoundID = KeySoundCategory.letter.systemSoundID
+    static let delete: SystemSoundID = KeySoundCategory.delete.systemSoundID
+    static let modifier: SystemSoundID = KeySoundCategory.modifier.systemSoundID
 }
 
 // MARK: - Key Popup (from old KeyButton.swift, used by EmojiPickerView)

--- a/DictusKeyboard/Vendored/Views/KeyboardView.swift
+++ b/DictusKeyboard/Vendored/Views/KeyboardView.swift
@@ -3,6 +3,7 @@
 // Stripped: No external dependencies to remove (no Sentry in this file)
 
 import UIKit
+import AudioToolbox
 import DictusCore
 
 protocol GiellaKeyboardViewDelegate: AnyObject {
@@ -561,6 +562,8 @@ final internal class GiellaKeyboardView: UIView,
         // Fire haptic on touchDown for ALL keys (not just triggersOnTouchDown).
         // The delegate's didTriggerKey() may fire on touchUp for input keys,
         // but the user should FEEL the tap immediately on finger contact.
+        // The matching click is played in handleTouches below, as soon as the touch
+        // resolves to a key — it needs the key to pick a category, the haptic does not (#286).
         hapticFeedback.prepare()
         HapticFeedback.keyTapped()
 
@@ -581,11 +584,25 @@ final internal class GiellaKeyboardView: UIView,
         handleTouches(touches)
     }
 
+    /// Play `key`'s click, if it has one. Silent keys (spacer, caps) play nothing.
+    private func playSound(for key: KeyDefinition) {
+        guard let category = KeySound.category(for: key) else { return }
+        AudioServicesPlaySystemSound(category.systemSoundID)
+    }
+
     private func handleTouches(_ touches: Set<UITouch>) {
         for touch in touches {
             let touchPoint = clampedPoint(touch.location(in: collectionView))
             if let indexPath = collectionView.indexPathForItem(at: touchPoint) {
                 let key = currentPage[indexPath.section][indexPath.row]
+
+                // Click on finger contact, in step with the haptic fired above (#286).
+                // This is the only point where a touch resolves to a key, so it is also
+                // the only place the click is emitted — the bridge handlers no longer
+                // play one, which is what keeps touchDown keys from clicking twice.
+                // Placed before the double-tap branch below: that branch returns early,
+                // and a double-tapped shift must still click exactly once.
+                playSound(for: key)
 
                 if key.type.supportsDoubleTap {
                     let timeInterval = Date.timeIntervalSinceReferenceDate
@@ -801,6 +818,10 @@ final internal class GiellaKeyboardView: UIView,
 
             // Haptic feedback on each deletion
             HapticFeedback.keyTapped()
+            // ...and its click. Each repeat tick used to click from inside the bridge's
+            // delete handlers; emitting it here keeps a held backspace at exactly one
+            // click per deletion now that those handlers are silent (#286).
+            playSound(for: activeKey.key)
 
             increaseKeyRepeatRateIfNeeded()
         }


### PR DESCRIPTION
Fixes the sync gap in #286: the haptic fired on finger contact, the click on release, so typing felt slightly detached.

## What changed

`GiellaKeyboardView.touchesBegan` has fired the haptic on touch-down for every key for a while, and documents why in its own comment. The click never moved with it — it lived inside the thirteen `DictusKeyboardBridge` handlers that `didTriggerKey()` reaches, and for every letter `didTriggerKey()` fires on touch-up. Only shift, the two symbol layers and backspace were in sync, by accident of declaring `triggersOnTouchDown`.

The fix splits *what a key sounds like* from *what a key does*:

- **`DictusCore/Sources/DictusCore/KeySoundCategory.swift`** (new) — the letter/delete/modifier split and its three AudioServices identifiers, in the shared framework so they are unit-testable. `KeySound` in the keyboard now delegates to it, so the identifiers have one source of truth.
- **`DictusKeyboard/KeySoundPolicy.swift`** (new) — `KeySound.category(for:)`, the `KeyType` → category table. Answers the question without performing the key's action. This is the seam the brief asked for.
- **`DictusKeyboard/Vendored/Views/KeyboardView.swift`** — `handleTouches` plays the click at the single point where a touch resolves to a key, placed *before* the double-tap branch (that branch returns early, and a double-tapped shift must still click once). `keyRepeatTimerDidTrigger` plays its own click next to the haptic it already fires.
- **`DictusKeyboard/DictusKeyboardBridge.swift`** — all thirteen click calls removed, `import AudioToolbox` dropped, stale doc comments corrected.
- **`DictusKeyboard/KeyboardLayouts.swift`** — the emoji-toggle glyph gets a name. The classifier has to make the same "is this the emoji key" distinction the bridge makes, and a fourth copy of the raw `\u{1F600}` literal is a drift hazard.

## Why no key can click twice

Every click call is removed from the handler layer and exactly one is added at the touch layer:

| Path | Result |
|---|---|
| touch-down keys (shift, 123, #+=, backspace) | click in `handleTouches`, handler silent |
| touch-up keys (letters, space, return, emoji) | click in `handleTouches`, handler silent |
| shift double tap | `handleTouches` clicks, then returns early into a now-silent `didTriggerDoubleTap` |
| second finger while a key is still active | the commit calls a silent `didTriggerKey`, `handleTouches` clicks for the new key |
| slide from key to key | `touchesMoved` reassigns `activeKey` without calling `handleTouches` — no extra click |
| swipe key / accent-picker selection | release handler silent; the click already played at contact |
| held backspace | handlers silent, repeat timer clicks once per deletion — exactly today's count |

## Category table (unchanged, per key)

letter → `.input` letters, the adaptive accent key, `.comma`, `.fullStop`, `.tab`. delete → `.backspace` and each repeat tick. modifier → `.shift`, `.symbols`, `.shiftSymbols`, `.spacebar`, `.returnkey`, the emoji toggle, `.keyboard`, the iPad mode keys. Silent → `.spacer`, `.caps`.

This is a timing change, not a sound-design change. `AudioServicesPlaySystemSound` is unchanged, so the hardware silent switch is still respected natively.

## Declared behaviour changes

- Dragging off a key before release leaves a click with no inserted character. Settled decision on the issue, and what Apple's keyboard does.
- Long-pressing the spacebar for the cursor trackpad now clicks once at contact. It was silent end to end before, because no key was ever triggered. Same accepted trade-off.
- Selecting an accent from the long-press picker no longer clicks at selection — the click happened at contact. Still one click per press.

## Verification

- Build: `xcodebuild build -scheme DictusApp -destination 'platform=iOS Simulator,id=<iPhone 17>'` → **BUILD SUCCEEDED**
- Tests: `xcodebuild test -scheme DictusCore-Package -destination 'platform=macOS,arch=arm64'` → **TEST SUCCEEDED**, including the 3 new `KeySoundCategoryTests`. The iOS-simulator destination named in the brief fails on `develop` too, before this branch: the `-Package` scheme builds the macOS-only `polish-harness` target for iOS. Pre-existing, unrelated, worth its own issue.
- Lint: `swiftlint lint --strict` → **0 violations in 160 files**
- App installs, launches and stays alive on the simulator; `DictusKeyboard.appex` registers with `pluginkit`.

**Not verified, device only:** timing feel, doubled clicks, the silent switch, haptic strength. A simulator cannot enable the keyboard or inject touches. Manual steps are in the recap.

## Known, left alone on purpose

- The **globe key** has neither click nor haptic today, and still does not. Its touches are swallowed by the invisible overlay `UIButton` that sits above the (non-interactive) collection view, so they never reach `touchesBegan`, and the `.keyboard` branch in `didTriggerKey` is unreachable in practice. Giving it a click would be a sound-design change, which the brief rules out.
- `handleEmojiToggle` fires a second `HapticFeedback.keyTapped()` on top of the one from `touchesBegan` — a pre-existing doubled haptic. "The haptic is unchanged" is an acceptance criterion, so it stays.

refs #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AL9tgVzFmZ1nY6S5Ko3bN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distinct keyboard sounds for letters, deletion, and modifier keys.
  * Key sounds now play consistently for regular input, double-taps, and repeated deletions.
  * Silent keys remain quiet while touch haptics continue providing feedback.
* **Bug Fixes**
  * Prevented duplicate key sounds during keyboard interactions.
  * Improved sound behavior for emoji, punctuation, tab, and control keys.
  * Preserved haptic feedback for cursor movement and emoji-toggle actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->