### PR TITLE
Stop a recording whose app is gone, and tell the user (refs #261)

### DIFF
--- a/DictusApp/DictationCoordinator.swift
+++ b/DictusApp/DictationCoordinator.swift
@@ -731,11 +731,19 @@ class DictationCoordinator: ObservableObject {
     /// `didBecomeActive`, which proceeds only while the stored status is still
     /// `requested`.
     ///
-    /// WHY this writes `.failed` rather than `.idle`: the keyboard's existing failure
-    /// path reads `lastError` and shows it, so the user is told the recording was
-    /// interrupted instead of watching the overlay vanish. WHY it does NOT go through
-    /// `updateStatus`: this process is not failing anything. It is auditing state a
-    /// dead one left behind, and `status` is correctly `.idle` here.
+    /// WHY it writes `.idle` and no `lastError`: this audit is hygiene, not speech.
+    /// The first version wrote `.failed` plus a localised error so the keyboard's
+    /// failure path would show it, which had two problems. By the time the app
+    /// relaunches the moment has passed — the keyboard reconciles in-process, within
+    /// seconds, and that is the surface that tells the user. And `failed` has no
+    /// expiry in the App Group: `KeyboardState.refreshFromDefaults` adopts a stored
+    /// `failed` and shows its `lastError` whenever the extension is next loaded,
+    /// however old it is. That is pre-existing behaviour, but writing `failed` here
+    /// on every reconciliation would have made a stale error message a routine sight.
+    ///
+    /// WHY it does NOT go through `updateStatus`: this process is not failing
+    /// anything. It is auditing state a dead one left behind, and `status` is
+    /// correctly `.idle` here.
     private func reconcileOrphanedDictationState() {
         guard let raw = defaults.string(forKey: SharedKeys.dictationStatus),
               let stored = DictationStatus(rawValue: raw),
@@ -746,13 +754,11 @@ class DictationCoordinator: ObservableObject {
             staleStatus: raw,
             heartbeatAgeMs: -1
         ))
-        defaults.set(
-            String(localized: "Recording interrupted. Please try again."),
-            forKey: SharedKeys.lastError
-        )
-        defaults.set(DictationStatus.failed.rawValue, forKey: SharedKeys.dictationStatus)
+        defaults.set(DictationStatus.idle.rawValue, forKey: SharedKeys.dictationStatus)
         // Clears the heartbeat, the waveform keys and the pending stop/cancel flags
-        // the dead process never got to clean up, and synchronizes.
+        // the dead process never got to clean up, and synchronizes. Dropping the
+        // heartbeat matters most: one that outlives its session is what the keyboard
+        // would otherwise judge the *next* session by (#261).
         cleanupRecordingKeys()
         DarwinNotificationCenter.post(DarwinNotificationName.statusChanged)
     }

--- a/DictusApp/DictationCoordinator.swift
+++ b/DictusApp/DictationCoordinator.swift
@@ -117,6 +117,9 @@ class DictationCoordinator: ObservableObject {
             defaults.synchronize()
         }
 
+        // Audit the shared dictation state before anything reads it (issue #261).
+        reconcileOrphanedDictationState()
+
         // Phase 37 instrumentation: snapshot device capabilities once per app launch
         // so the log stream has a stable anchor for per-device gating analysis.
         let snapshot = DeviceCapabilities.current()
@@ -711,6 +714,47 @@ class DictationCoordinator: ObservableObject {
         defaults.synchronize()
 
         DarwinNotificationCenter.post(DarwinNotificationName.waveformUpdate)
+    }
+
+    /// Clear a dictation the previous process never finished (issue #261).
+    ///
+    /// The invariant this restores: `dictationStatus` describes an active dictation,
+    /// but no live coordinator owns a session for it. That is trivially decidable
+    /// here — this method runs from `init`, so the process has just started and owns
+    /// no session by construction. Nothing else audited the key, which is why an app
+    /// terminated mid-recording left `recording` behind for the keyboard to restore
+    /// an overlay from.
+    ///
+    /// WHY `.requested` is excluded: the keyboard writes it moments before opening
+    /// `dictus://dictate`, i.e. moments before launching this very process. Clearing
+    /// it here would break every cold-start dictation — including the retry in
+    /// `didBecomeActive`, which proceeds only while the stored status is still
+    /// `requested`.
+    ///
+    /// WHY this writes `.failed` rather than `.idle`: the keyboard's existing failure
+    /// path reads `lastError` and shows it, so the user is told the recording was
+    /// interrupted instead of watching the overlay vanish. WHY it does NOT go through
+    /// `updateStatus`: this process is not failing anything. It is auditing state a
+    /// dead one left behind, and `status` is correctly `.idle` here.
+    private func reconcileOrphanedDictationState() {
+        guard let raw = defaults.string(forKey: SharedKeys.dictationStatus),
+              let stored = DictationStatus(rawValue: raw),
+              stored == .recording || stored == .transcribing else { return }
+
+        PersistentLog.log(.dictationStateReconciled(
+            source: "app-launch",
+            staleStatus: raw,
+            heartbeatAgeMs: -1
+        ))
+        defaults.set(
+            String(localized: "Recording interrupted. Please try again."),
+            forKey: SharedKeys.lastError
+        )
+        defaults.set(DictationStatus.failed.rawValue, forKey: SharedKeys.dictationStatus)
+        // Clears the heartbeat, the waveform keys and the pending stop/cancel flags
+        // the dead process never got to clean up, and synchronizes.
+        cleanupRecordingKeys()
+        DarwinNotificationCenter.post(DarwinNotificationName.statusChanged)
     }
 
     /// Clean up recording-related App Group keys after recording completes or is cancelled.

--- a/DictusApp/Localizable.xcstrings
+++ b/DictusApp/Localizable.xcstrings
@@ -1709,17 +1709,6 @@
         }
       }
     },
-    "Recording interrupted. Please try again." : {
-      "comment" : "Shown when a dictation is cleared because the app that was recording it is gone (issue #261).",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enregistrement interrompu. Réessayez."
-          }
-        }
-      }
-    },
     "Reformulate your text with on-device AI" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/DictusApp/Localizable.xcstrings
+++ b/DictusApp/Localizable.xcstrings
@@ -1709,6 +1709,17 @@
         }
       }
     },
+    "Recording interrupted. Please try again." : {
+      "comment" : "Shown when a dictation is cleared because the app that was recording it is gone (issue #261).",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistrement interrompu. Réessayez."
+          }
+        }
+      }
+    },
     "Reformulate your text with on-device AI" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/DictusCore/Sources/DictusCore/DictationSessionLiveness.swift
+++ b/DictusCore/Sources/DictusCore/DictationSessionLiveness.swift
@@ -1,0 +1,92 @@
+// DictusCore/Sources/DictusCore/DictationSessionLiveness.swift
+// Decides whether an active dictation status in the App Group still has a live
+// process behind it. Testable in isolation -- no UserDefaults, no AVFoundation.
+
+import Foundation
+
+/// What the shared dictation state says about the process that wrote it.
+public enum DictationSessionLiveness: String, Equatable, Sendable {
+    /// The stored status describes no dictation in flight. Nothing to reconcile.
+    case notActive
+    /// An active status backed by a heartbeat fresh enough to prove the writer is alive.
+    case live
+    /// An active status with no heartbeat to judge by. Not evidence of death.
+    case unproven
+    /// An active status whose heartbeat stopped. The writing process is gone.
+    case orphaned
+}
+
+/// Reads the shared dictation state and says whether a process still owns it.
+///
+/// WHY this exists (issue #261): when iOS terminates DictusApp mid-dictation,
+/// `SharedKeys.dictationStatus` keeps saying `recording` and nothing audits it.
+/// A keyboard extension rebuilt afterwards faithfully restores a recording overlay
+/// for a session no process is running, the user keeps talking into nothing, and
+/// their stop taps reach a dead listener.
+///
+/// WHY the heartbeat is the evidence and the session id is not: there is no session
+/// id in the App Group at all. `KeyboardState.activeSessionID` is in-memory in the
+/// extension process, so `sessionID=none` is what *every* rebuilt keyboard reports,
+/// whether or not the app is healthy. `SharedKeys.recordingHeartbeat` is the only
+/// value written by the process that would have died: `UnifiedAudioEngine` writes it
+/// from the audio thread every 1 s while recording and every 3 s while the engine is
+/// warm but idle -- which covers `.transcribing` too (#106 Phase C). A stored active
+/// status whose heartbeat stopped is therefore decidable without waiting for anything.
+///
+/// WHY an enum with statics (not a struct): there is no state to carry. The caller
+/// owns the facts; this type only combines them. Same pattern as `IdleReleasePolicy`.
+public enum DictationSessionLivenessPolicy {
+
+    /// How stale the heartbeat must be before the writer is declared gone.
+    ///
+    /// WHY 8 s and not the watchdog's 5 s: the slowest legitimate cadence is the
+    /// 3 s idle heartbeat, and a cross-process `UserDefaults` read can lag behind
+    /// the write. 8 s clears both with margin, and is still roughly half the 15 s
+    /// cold-start grace this check exists to bypass.
+    public static let staleHeartbeatThreshold: TimeInterval = 8
+
+    /// Whether `status` describes a dictation that some process should be driving.
+    ///
+    /// WHY an exhaustive switch and not a `Set`: adding a case to `DictationStatus`
+    /// (`processing`, #267) must stop the compiler here rather than silently fall
+    /// through to "nothing is in flight".
+    public static func isActive(_ status: DictationStatus) -> Bool {
+        switch status {
+        case .requested, .recording, .transcribing:
+            return true
+        case .idle, .ready, .failed:
+            return false
+        }
+    }
+
+    /// What the shared state says about the process behind it.
+    ///
+    /// - Parameters:
+    ///   - status: the stored `SharedKeys.dictationStatus`, or nil when unset or
+    ///     unrecognised.
+    ///   - heartbeat: the stored `SharedKeys.recordingHeartbeat` as seconds since
+    ///     1970, or nil when the key is absent.
+    ///   - now: seconds since 1970.
+    ///
+    /// Fails **closed** in two places, deliberately. `.requested` is active but is
+    /// never orphaned here: the keyboard writes it moments before launching the app
+    /// for a cold start, so a heartbeat left over from an earlier session would
+    /// condemn every cold-start dictation. And a missing heartbeat yields
+    /// `.unproven` rather than `.orphaned` -- an absent value is not evidence, and
+    /// the keyboard's own 5 s/15 s watchdog already covers that case. A clock that
+    /// moved backwards reads as `.live` for the same reason: killing a live
+    /// recording is the worse error.
+    public static func evaluate(
+        status: DictationStatus?,
+        heartbeat: TimeInterval?,
+        now: TimeInterval,
+        threshold: TimeInterval = staleHeartbeatThreshold
+    ) -> DictationSessionLiveness {
+        guard let status, isActive(status) else { return .notActive }
+        guard status != .requested else { return .unproven }
+        guard let heartbeat, heartbeat > 0 else { return .unproven }
+        let age = now - heartbeat
+        guard age > threshold else { return .live }
+        return .orphaned
+    }
+}

--- a/DictusCore/Sources/DictusCore/DictationSessionLiveness.swift
+++ b/DictusCore/Sources/DictusCore/DictationSessionLiveness.swift
@@ -10,7 +10,7 @@ public enum DictationSessionLiveness: String, Equatable, Sendable {
     case notActive
     /// An active status backed by a heartbeat fresh enough to prove the writer is alive.
     case live
-    /// An active status with no heartbeat to judge by. Not evidence of death.
+    /// An active status with no heartbeat that can speak about it. Not evidence of death.
     case unproven
     /// An active status whose heartbeat stopped. The writing process is gone.
     case orphaned
@@ -28,22 +28,36 @@ public enum DictationSessionLiveness: String, Equatable, Sendable {
 /// id in the App Group at all. `KeyboardState.activeSessionID` is in-memory in the
 /// extension process, so `sessionID=none` is what *every* rebuilt keyboard reports,
 /// whether or not the app is healthy. `SharedKeys.recordingHeartbeat` is the only
-/// value written by the process that would have died: `UnifiedAudioEngine` writes it
-/// from the audio thread every 1 s while recording and every 3 s while the engine is
-/// warm but idle -- which covers `.transcribing` too (#106 Phase C). A stored active
-/// status whose heartbeat stopped is therefore decidable without waiting for anything.
+/// value written by the process that would have died -- `UnifiedAudioEngine` writes
+/// it from the audio thread.
 ///
 /// WHY an enum with statics (not a struct): there is no state to carry. The caller
 /// owns the facts; this type only combines them. Same pattern as `IdleReleasePolicy`.
 public enum DictationSessionLivenessPolicy {
 
-    /// How stale the heartbeat must be before the writer is declared gone.
+    /// How stale the heartbeat must be, while the stored status is `recording`,
+    /// before the writer is declared gone.
     ///
-    /// WHY 8 s and not the watchdog's 5 s: the slowest legitimate cadence is the
-    /// 3 s idle heartbeat, and a cross-process `UserDefaults` read can lag behind
-    /// the write. 8 s clears both with margin, and is still roughly half the 15 s
-    /// cold-start grace this check exists to bypass.
-    public static let staleHeartbeatThreshold: TimeInterval = 8
+    /// WHY 4 s: the audio thread writes the heartbeat at 1 Hz while recording, and
+    /// that path `synchronize()`s every 200 ms, so four missed beats is a wide margin
+    /// over both the cadence and cross-process lag.
+    ///
+    /// WHY it has to be under 5 s, which is the constraint that actually fixes #261's
+    /// first device failure: `KeyboardState`'s watchdog resets the status once waveform
+    /// data is 5 s stale, and both ages start ticking from the same instant -- the app
+    /// dies and stops writing waveform and heartbeat together. A threshold above 5 s is
+    /// therefore unreachable by construction: the watchdog resets to `.idle` first and
+    /// its own guard then stops the timer. The first shipped version used 8 s for both
+    /// states and, on device, never fired once for exactly that reason.
+    public static let recordingStaleThreshold: TimeInterval = 4
+
+    /// The same, while the stored status is `transcribing`.
+    ///
+    /// WHY 8 s and not 4 s: recording has stopped, so the audio thread has fallen back
+    /// to its warm-idle path, which writes only every 3 s (#106 Phase C, sized to stay
+    /// under the watchdog's 5 s threshold). Judging that cadence by the recording
+    /// threshold would condemn every transcription that runs longer than four seconds.
+    public static let transcribingStaleThreshold: TimeInterval = 8
 
     /// Whether `status` describes a dictation that some process should be driving.
     ///
@@ -59,6 +73,19 @@ public enum DictationSessionLivenessPolicy {
         }
     }
 
+    /// How long the heartbeat may go quiet, for a given stored status, before the
+    /// writer is declared gone. Nil for statuses that are never judged this way.
+    public static func staleThreshold(for status: DictationStatus) -> TimeInterval? {
+        switch status {
+        case .recording:
+            return recordingStaleThreshold
+        case .transcribing:
+            return transcribingStaleThreshold
+        case .requested, .idle, .ready, .failed:
+            return nil
+        }
+    }
+
     /// What the shared state says about the process behind it.
     ///
     /// - Parameters:
@@ -66,27 +93,45 @@ public enum DictationSessionLivenessPolicy {
     ///     unrecognised.
     ///   - heartbeat: the stored `SharedKeys.recordingHeartbeat` as seconds since
     ///     1970, or nil when the key is absent.
+    ///   - localSessionStartedAt: when *this* process started the dictation it
+    ///     currently owns, as seconds since 1970. Nil when it owns none.
     ///   - now: seconds since 1970.
     ///
-    /// Fails **closed** in two places, deliberately. `.requested` is active but is
-    /// never orphaned here: the keyboard writes it moments before launching the app
-    /// for a cold start, so a heartbeat left over from an earlier session would
-    /// condemn every cold-start dictation. And a missing heartbeat yields
-    /// `.unproven` rather than `.orphaned` -- an absent value is not evidence, and
-    /// the keyboard's own 5 s/15 s watchdog already covers that case. A clock that
-    /// moved backwards reads as `.live` for the same reason: killing a live
-    /// recording is the worse error.
+    /// ### The rule that carries this
+    ///
+    /// **A heartbeat can only speak about a session it postdates.** One older than the
+    /// moment this process started its current session belongs to an earlier session
+    /// and says nothing about this one, however stale it looks.
+    ///
+    /// That is not a refinement, it is the load-bearing clause. Without it, on device
+    /// (2026-08-03, build 25): a watchdog reset left a corpse heartbeat behind at
+    /// 14:36:51, the user tapped the mic at 14:37:02, the app cold-started and wrote
+    /// `recording` at 14:37:03, and the keyboard judged that one-second-old session by
+    /// the eleven-second-old heartbeat, declared it orphaned and killed it. The keyboard
+    /// was holding the proof it should not have -- its own session id, set a second
+    /// earlier -- and the predicate was not looking at it.
+    ///
+    /// ### Fails closed, in three more places
+    ///
+    /// `.requested` is active but is never orphaned here: the keyboard writes it moments
+    /// before launching the app for a cold start, so a leftover heartbeat would condemn
+    /// every cold-start dictation. A missing heartbeat yields `.unproven` -- an absent
+    /// value is not evidence, and the keyboard's own watchdog still covers it. A clock
+    /// that moved backwards reads as `.live`, because killing a live recording is the
+    /// worse error.
     public static func evaluate(
         status: DictationStatus?,
         heartbeat: TimeInterval?,
-        now: TimeInterval,
-        threshold: TimeInterval = staleHeartbeatThreshold
+        localSessionStartedAt: TimeInterval? = nil,
+        now: TimeInterval
     ) -> DictationSessionLiveness {
         guard let status, isActive(status) else { return .notActive }
-        guard status != .requested else { return .unproven }
+        guard let threshold = staleThreshold(for: status) else { return .unproven }
         guard let heartbeat, heartbeat > 0 else { return .unproven }
-        let age = now - heartbeat
-        guard age > threshold else { return .live }
+        if let localSessionStartedAt, heartbeat <= localSessionStartedAt {
+            return .unproven
+        }
+        guard now - heartbeat > threshold else { return .live }
         return .orphaned
     }
 }

--- a/DictusCore/Sources/DictusCore/LiveActivityStateMachine.swift
+++ b/DictusCore/Sources/DictusCore/LiveActivityStateMachine.swift
@@ -36,8 +36,17 @@ public struct LiveActivityStateMachine {
     /// Allowed transitions for each phase.
     /// WHY a stored property (not computed): The map is constant and small (6 entries).
     /// Storing it avoids re-creating the dictionary on every transition call.
+    ///
+    /// WHY `.idle -> .failed` is allowed (issue #261): a dictation can fail while the
+    /// manager sits at `.idle` -- the app relaunches after being terminated
+    /// mid-recording, receives the stop the keyboard sent into the void, collects zero
+    /// samples and reports a failure. Rejecting that transition left the Dynamic Island
+    /// unable to show an error in exactly the situation where the user most needs one,
+    /// and produced `liveActivityFailed context=rejectedTransition error=idle->failed`
+    /// instead. `endWithFailure()` still returns early when no activity is held, so
+    /// allowing this creates no pill out of nothing.
     private let validTransitions: [Phase: Set<Phase>] = [
-        .idle: [.standby],
+        .idle: [.standby, .failed],
         .standby: [.recording, .idle],
         .recording: [.transcribing, .standby],
         .transcribing: [.ready, .failed],

--- a/DictusCore/Sources/DictusCore/LogEvent.swift
+++ b/DictusCore/Sources/DictusCore/LogEvent.swift
@@ -44,6 +44,12 @@ public enum LogEvent: Sendable {
     case dictationCompleted(durationMs: Int)
     case dictationFailed(error: String)
     case dictationDeferred(reason: String)
+    /// Issue #261: an active dictation status was found in the App Group with no
+    /// live process behind it, and was cleared. `heartbeatAgeMs` is -1 when the
+    /// heartbeat key was absent, which is how the app-side launch audit reports it
+    /// (a fresh process owns no session by construction, so it needs no heartbeat
+    /// to reach its verdict).
+    case dictationStateReconciled(source: String, staleStatus: String, heartbeatAgeMs: Int)
 
     // MARK: Audio
     case audioEngineStarted
@@ -173,7 +179,8 @@ public enum LogEvent: Sendable {
     /// The subsystem this event belongs to, derived from the case.
     public var subsystem: Subsystem {
         switch self {
-        case .dictationStarted, .dictationCompleted, .dictationFailed, .dictationDeferred:
+        case .dictationStarted, .dictationCompleted, .dictationFailed, .dictationDeferred,
+             .dictationStateReconciled:
             return .dictation
         case .audioEngineStarted, .audioEngineStopped, .audioSessionConfigured, .audioSessionFailed,
              .audioInterruptionBegan, .audioInterruptionEnded, .audioRouteChanged,
@@ -233,7 +240,8 @@ public enum LogEvent: Sendable {
             return .error
 
         // Warnings
-        case .dictationDeferred, .watchdogReset, .engineWarmUpFailed, .recordingTooShort,
+        case .dictationDeferred, .dictationStateReconciled,
+             .watchdogReset, .engineWarmUpFailed, .recordingTooShort,
              .waveformStall, .waveformTimelineNotFiring,
              .coldStartDarwinFallback, .modelPrewarmTimeout,
              .audioInterruptionBegan, .audioMediaServicesReset,
@@ -287,6 +295,7 @@ public enum LogEvent: Sendable {
         case .dictationCompleted: return "dictationCompleted"
         case .dictationFailed: return "dictationFailed"
         case .dictationDeferred: return "dictationDeferred"
+        case .dictationStateReconciled: return "dictationStateReconciled"
         case .audioEngineStarted: return "audioEngineStarted"
         case .audioEngineStopped: return "audioEngineStopped"
         case .audioSessionConfigured: return "audioSessionConfigured"
@@ -387,6 +396,8 @@ public enum LogEvent: Sendable {
             return "error=\(error)"
         case .dictationDeferred(let reason):
             return "reason=\(reason)"
+        case .dictationStateReconciled(let source, let staleStatus, let heartbeatAgeMs):
+            return "source=\(source) staleStatus=\(staleStatus) heartbeatAgeMs=\(heartbeatAgeMs)"
 
         // Audio
         case .audioEngineStarted, .audioEngineStopped:

--- a/DictusCore/Sources/DictusCore/LogEvent.swift
+++ b/DictusCore/Sources/DictusCore/LogEvent.swift
@@ -93,6 +93,17 @@ public enum LogEvent: Sendable {
     case keyboardMicTapped
     case keyboardTextInserted  // No content parameter -- privacy by design
 
+    // MARK: Keyboard status message (#261)
+    /// The toolbar message was assigned. `reason` names what asked for it.
+    case dictationMessageSet(reason: String, owner: String, visible: Bool)
+    /// A live view put that message on screen. One line per view that rendered it,
+    /// which is the whole point: iOS keeps several controllers alive, and whether
+    /// the one the user is looking at was among them is exactly the open question.
+    case dictationMessageDisplayed(rootView: String, controller: String, owner: String, visible: Bool)
+    /// The message ended. `displayedCount` is how many views had reported rendering
+    /// it over its life, so a single line answers whether anybody could have read it.
+    case dictationMessageCleared(reason: String, displayedCount: Int)
+
     // MARK: Animation
     case overlayShown(status: String)
     case overlayHidden(status: String)
@@ -197,6 +208,7 @@ public enum LogEvent: Sendable {
             return .model
         case .keyboardDidAppear, .keyboardDidDisappear, .keyboardMicTapped, .keyboardTextInserted,
              .overlayShown, .overlayHidden, .rapidTapRejected,
+             .dictationMessageSet, .dictationMessageDisplayed, .dictationMessageCleared,
              .waveformAppeared, .waveformDisappeared, .waveformHeartbeat, .waveformStall,
              .waveformRefreshIDChanged, .waveformEnergyTransition, .waveformTimelineNotFiring,
              .overlayBodyEvaluated, .overlayTimerStarted, .overlayTimerStopped, .overlayRecreated,
@@ -233,6 +245,11 @@ public enum LogEvent: Sendable {
     /// stops/internal state = debug.
     public var level: LogLevel {
         switch self {
+        // A message nobody rendered is the failure this instrumentation exists to
+        // catch (#261), so it is findable by level and not only by reading the count.
+        case .dictationMessageCleared(_, let displayedCount):
+            return displayedCount == 0 ? .warning : .info
+
         // Errors
         case .dictationFailed, .audioSessionFailed, .transcriptionFailed,
              .modelDownloadFailed, .modelDeleteFailed,
@@ -260,6 +277,7 @@ public enum LogEvent: Sendable {
              .modelDeleted, .modelPrewarmStarted, .modelCleanupPerformed,
              .modelPrewarmPeakMemory, .modelLoadStateChanged, .transcriptionPerformance,
              .keyboardDidAppear, .keyboardMicTapped,
+             .dictationMessageSet, .dictationMessageDisplayed,
              .appLaunched, .appWhisperKitLoaded, .logExportCompleted,
              .deviceCapabilitySnapshot,
              .liveActivityStarted, .liveActivityTransition, .liveActivityEnded,
@@ -323,6 +341,9 @@ public enum LogEvent: Sendable {
         case .keyboardDidAppear: return "keyboardDidAppear"
         case .keyboardDidDisappear: return "keyboardDidDisappear"
         case .keyboardMicTapped: return "keyboardMicTapped"
+        case .dictationMessageSet: return "dictationMessageSet"
+        case .dictationMessageDisplayed: return "dictationMessageDisplayed"
+        case .dictationMessageCleared: return "dictationMessageCleared"
         case .keyboardTextInserted: return "keyboardTextInserted"
         case .engineWarmUpAttempt: return "engineWarmUpAttempt"
         case .engineWarmUpSuccess: return "engineWarmUpSuccess"
@@ -514,6 +535,13 @@ public enum LogEvent: Sendable {
             return "model=\(modelName)"
 
         // Animation
+        case .dictationMessageSet(let reason, let owner, let visible):
+            return "reason=\(reason) owner=\(owner) visible=\(visible)"
+        case .dictationMessageDisplayed(let rootView, let controller, let owner, let visible):
+            return "rootView=\(rootView) controller=\(controller) owner=\(owner) visible=\(visible)"
+        case .dictationMessageCleared(let reason, let displayedCount):
+            return "reason=\(reason) displayedCount=\(displayedCount)"
+
         case .overlayShown(let status):
             return "status=\(status)"
         case .overlayHidden(let status):

--- a/DictusCore/Tests/DictusCoreTests/DictationSessionLivenessTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/DictationSessionLivenessTests.swift
@@ -7,21 +7,34 @@ import XCTest
 /// Coverage for the decision that tells a phantom dictation from a live one.
 ///
 /// These tests exist because neither side of #261 can be exercised end to end:
-/// `KeyboardState` is a singleton in an extension target with no test bundle, and
-/// the failure it reacts to is iOS terminating another process. The predicate is
-/// the whole of the decision, so it is the part worth pinning down — and the two
-/// fail-closed clauses below are the ones that would break cold-start dictation if
-/// they ever regressed.
+/// `KeyboardState` is a singleton in an extension target with no test bundle, the
+/// failure it reacts to is iOS terminating another process, and a simulator cannot
+/// even enable the Dictus keyboard. The predicate is the whole of the decision.
+///
+/// The device-scenario cases below carry the real timestamps from the 2026-08-03
+/// capture on build 25, because that run is what proved the first design wrong in
+/// both directions at once.
 final class DictationSessionLivenessTests: XCTestCase {
 
     private let now: TimeInterval = 1_700_000_000
-    private var threshold: TimeInterval { DictationSessionLivenessPolicy.staleHeartbeatThreshold }
+    private var recordingThreshold: TimeInterval {
+        DictationSessionLivenessPolicy.recordingStaleThreshold
+    }
+    private var transcribingThreshold: TimeInterval {
+        DictationSessionLivenessPolicy.transcribingStaleThreshold
+    }
 
     private func evaluate(
         _ status: DictationStatus?,
-        heartbeat: TimeInterval?
+        heartbeat: TimeInterval?,
+        localSessionStartedAt: TimeInterval? = nil
     ) -> DictationSessionLiveness {
-        DictationSessionLivenessPolicy.evaluate(status: status, heartbeat: heartbeat, now: now)
+        DictationSessionLivenessPolicy.evaluate(
+            status: status,
+            heartbeat: heartbeat,
+            localSessionStartedAt: localSessionStartedAt,
+            now: now
+        )
     }
 
     // MARK: - isActive
@@ -50,8 +63,6 @@ final class DictationSessionLivenessTests: XCTestCase {
     // MARK: - The reported failure
 
     func testRecordingWithADeadHeartbeatIsOrphaned() {
-        // The #261 capture: the app stopped emitting at 15:08:10, the rebuilt
-        // keyboard read the state at 15:08:33.
         XCTAssertEqual(evaluate(.recording, heartbeat: now - 23), .orphaned)
     }
 
@@ -61,23 +72,21 @@ final class DictationSessionLivenessTests: XCTestCase {
         XCTAssertEqual(evaluate(.transcribing, heartbeat: now - 23), .orphaned)
     }
 
+    func testARebuiltKeyboardOwnsNoSessionAndStillReachesAVerdict() {
+        // The originally reported incident: the extension is a fresh process, so it
+        // has no session of its own, and the App Group is all it has to go on.
+        XCTAssertEqual(evaluate(.recording, heartbeat: now - 23, localSessionStartedAt: nil), .orphaned)
+    }
+
     // MARK: - A live app must never be declared dead
 
     func testFreshHeartbeatIsLive() {
         XCTAssertEqual(evaluate(.recording, heartbeat: now - 1), .live)
     }
 
-    func testIdleCadenceHeartbeatIsLive() {
+    func testIdleCadenceHeartbeatIsLiveDuringTranscription() {
         // The slowest legitimate write is every 3 s, and it must not read as death.
         XCTAssertEqual(evaluate(.transcribing, heartbeat: now - 3), .live)
-    }
-
-    func testHeartbeatExactlyAtTheThresholdIsLive() {
-        XCTAssertEqual(evaluate(.recording, heartbeat: now - threshold), .live)
-    }
-
-    func testHeartbeatJustPastTheThresholdIsOrphaned() {
-        XCTAssertEqual(evaluate(.recording, heartbeat: now - threshold - 0.01), .orphaned)
     }
 
     func testHeartbeatInTheFutureIsLive() {
@@ -86,18 +95,105 @@ final class DictationSessionLivenessTests: XCTestCase {
         XCTAssertEqual(evaluate(.recording, heartbeat: now + 60), .live)
     }
 
+    // MARK: - Thresholds track the writer's cadence
+
+    func testRecordingUsesTheShorterThreshold() {
+        XCTAssertEqual(recordingThreshold, 4)
+        XCTAssertEqual(evaluate(.recording, heartbeat: now - recordingThreshold), .live)
+        XCTAssertEqual(evaluate(.recording, heartbeat: now - recordingThreshold - 0.01), .orphaned)
+    }
+
+    func testTranscribingUsesTheLongerThreshold() {
+        XCTAssertEqual(transcribingThreshold, 8)
+        XCTAssertEqual(evaluate(.transcribing, heartbeat: now - transcribingThreshold), .live)
+        XCTAssertEqual(evaluate(.transcribing, heartbeat: now - transcribingThreshold - 0.01), .orphaned)
+    }
+
+    func testTheRecordingThresholdIsUnderTheKeyboardWatchdogWindow() {
+        // Defect 1 of the 2026-08-03 device run, pinned as a rule rather than a
+        // comment. `KeyboardState`'s watchdog resets a stale dictation once waveform
+        // data is 5 s old, and both ages start at the same instant, so a predicate
+        // threshold at or above 5 s can never fire: the watchdog resets to `.idle`
+        // first and its own guard then stops the timer. The first shipped version
+        // used 8 s and never once fired on device.
+        XCTAssertLessThan(
+            recordingThreshold, 5,
+            "a threshold at or above the watchdog's 5 s window is unreachable by construction"
+        )
+    }
+
+    func testTranscribingKeepsRoomForTheThreeSecondIdleCadence() {
+        XCTAssertGreaterThan(
+            transcribingThreshold, 3 * 2,
+            "the warm-idle heartbeat writes every 3 s; the threshold must clear two of them"
+        )
+    }
+
+    // MARK: - A heartbeat can only speak about a session it postdates
+
+    func testHeartbeatFromBeforeOurSessionProvesNothing() {
+        // Defect 2 of the 2026-08-03 device run, with its real numbers. A watchdog
+        // reset left a corpse heartbeat at 14:36:51. The user tapped the mic at
+        // 14:37:02 and the app wrote `recording` at 14:37:03. Judging that
+        // one-second-old session by the eleven-second-old heartbeat declared it
+        // orphaned and killed a healthy cold start.
+        let corpseHeartbeat = now - 11.609
+        let sessionStarted = now - 1
+        XCTAssertEqual(
+            evaluate(.recording, heartbeat: corpseHeartbeat, localSessionStartedAt: sessionStarted),
+            .unproven
+        )
+    }
+
+    func testHeartbeatFromDuringOurSessionCanStillBeOrphaned() {
+        // The mirror image, and the reason the rule is "postdates" rather than
+        // "we hold a session": the app died in the middle of a dictation this
+        // keyboard started, so its heartbeat is younger than the session and its
+        // silence does mean something.
+        let sessionStarted = now - 20
+        XCTAssertEqual(
+            evaluate(.recording, heartbeat: now - 8, localSessionStartedAt: sessionStarted),
+            .orphaned
+        )
+    }
+
+    func testHeartbeatExactlyAtOurSessionStartProvesNothing() {
+        // Ambiguous by construction, so it fails closed.
+        let sessionStarted = now - 30
+        XCTAssertEqual(
+            evaluate(.recording, heartbeat: sessionStarted, localSessionStartedAt: sessionStarted),
+            .unproven
+        )
+    }
+
+    func testALiveSessionOfOurOwnDoesNotSuppressAFreshVerdict() {
+        // Owning a session must not make the keyboard blind: a fresh heartbeat from
+        // within it still reads as live.
+        XCTAssertEqual(
+            evaluate(.recording, heartbeat: now - 1, localSessionStartedAt: now - 10),
+            .live
+        )
+    }
+
     // MARK: - Fail closed
 
     func testRequestedIsNeverOrphaned() {
         // The keyboard writes `.requested` moments before launching the app for a
         // cold start. A heartbeat left over from an earlier session would otherwise
-        // condemn every cold-start dictation before the app had a chance to write one.
+        // condemn every cold-start dictation before the app had written one.
         XCTAssertEqual(evaluate(.requested, heartbeat: now - 3600), .unproven)
     }
 
+    func testRequestedIsNeverOrphanedEvenWithNoSessionOfOurOwn() {
+        XCTAssertEqual(
+            evaluate(.requested, heartbeat: now - 3600, localSessionStartedAt: nil),
+            .unproven
+        )
+    }
+
     func testMissingHeartbeatIsUnprovenNotOrphaned() {
-        // An absent value is not evidence. The keyboard's own 5 s/15 s watchdog
-        // still covers this case.
+        // An absent value is not evidence. The keyboard's own watchdog still covers
+        // this case.
         XCTAssertEqual(evaluate(.recording, heartbeat: nil), .unproven)
     }
 
@@ -105,5 +201,31 @@ final class DictationSessionLivenessTests: XCTestCase {
         // `UserDefaults.double(forKey:)` returns 0 for a missing key, which is how
         // the absence actually reaches the policy.
         XCTAssertEqual(evaluate(.recording, heartbeat: 0), .unproven)
+    }
+
+    // MARK: - Local and stored state disagreeing, exhaustively
+
+    func testLocalAndStoredDisagreementMatrix() {
+        // Every combination of "do we own a session, and when did it start" against
+        // "what does the App Group say", for the two statuses that can be orphaned.
+        // The failure this suite exists for lived in one cell of this table and was
+        // invisible to a simulator run that only ever seeded one of the two.
+        let cases: [(DictationStatus, TimeInterval, TimeInterval?, DictationSessionLiveness, String)] = [
+            (.recording, now - 20, nil, .orphaned, "rebuilt keyboard, dead app"),
+            (.recording, now - 20, now - 1, .unproven, "corpse heartbeat, session we just started"),
+            (.recording, now - 20, now - 60, .orphaned, "our session, app died inside it"),
+            (.recording, now - 1, now - 60, .live, "our session, app alive"),
+            (.recording, now - 1, nil, .live, "rebuilt keyboard, app alive"),
+            (.transcribing, now - 20, now - 1, .unproven, "corpse heartbeat during transcription"),
+            (.transcribing, now - 5, now - 60, .live, "idle cadence inside our session"),
+            (.transcribing, now - 20, nil, .orphaned, "rebuilt keyboard, dead app, transcribing")
+        ]
+        for (status, heartbeat, sessionStart, expected, label) in cases {
+            XCTAssertEqual(
+                evaluate(status, heartbeat: heartbeat, localSessionStartedAt: sessionStart),
+                expected,
+                label
+            )
+        }
     }
 }

--- a/DictusCore/Tests/DictusCoreTests/DictationSessionLivenessTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/DictationSessionLivenessTests.swift
@@ -1,0 +1,109 @@
+// DictusCore/Tests/DictusCoreTests/DictationSessionLivenessTests.swift
+// Unit tests for the orphaned-dictation predicate (issue #261).
+
+import XCTest
+@testable import DictusCore
+
+/// Coverage for the decision that tells a phantom dictation from a live one.
+///
+/// These tests exist because neither side of #261 can be exercised end to end:
+/// `KeyboardState` is a singleton in an extension target with no test bundle, and
+/// the failure it reacts to is iOS terminating another process. The predicate is
+/// the whole of the decision, so it is the part worth pinning down — and the two
+/// fail-closed clauses below are the ones that would break cold-start dictation if
+/// they ever regressed.
+final class DictationSessionLivenessTests: XCTestCase {
+
+    private let now: TimeInterval = 1_700_000_000
+    private var threshold: TimeInterval { DictationSessionLivenessPolicy.staleHeartbeatThreshold }
+
+    private func evaluate(
+        _ status: DictationStatus?,
+        heartbeat: TimeInterval?
+    ) -> DictationSessionLiveness {
+        DictationSessionLivenessPolicy.evaluate(status: status, heartbeat: heartbeat, now: now)
+    }
+
+    // MARK: - isActive
+
+    func testActiveStatesAreTheOnesThatOwnADictation() {
+        XCTAssertTrue(DictationSessionLivenessPolicy.isActive(.requested))
+        XCTAssertTrue(DictationSessionLivenessPolicy.isActive(.recording))
+        XCTAssertTrue(DictationSessionLivenessPolicy.isActive(.transcribing))
+        XCTAssertFalse(DictationSessionLivenessPolicy.isActive(.idle))
+        XCTAssertFalse(DictationSessionLivenessPolicy.isActive(.ready))
+        XCTAssertFalse(DictationSessionLivenessPolicy.isActive(.failed))
+    }
+
+    // MARK: - Nothing to reconcile
+
+    func testUnsetStatusIsNotActive() {
+        XCTAssertEqual(evaluate(nil, heartbeat: now - 3600), .notActive)
+    }
+
+    func testTerminalStatusesAreNotActive() {
+        for status: DictationStatus in [.idle, .ready, .failed] {
+            XCTAssertEqual(evaluate(status, heartbeat: now - 3600), .notActive, "\(status.rawValue)")
+        }
+    }
+
+    // MARK: - The reported failure
+
+    func testRecordingWithADeadHeartbeatIsOrphaned() {
+        // The #261 capture: the app stopped emitting at 15:08:10, the rebuilt
+        // keyboard read the state at 15:08:33.
+        XCTAssertEqual(evaluate(.recording, heartbeat: now - 23), .orphaned)
+    }
+
+    func testTranscribingWithADeadHeartbeatIsOrphaned() {
+        // The engine keeps writing a 3 s idle heartbeat through transcription
+        // (#106 Phase C), so silence here means the same thing.
+        XCTAssertEqual(evaluate(.transcribing, heartbeat: now - 23), .orphaned)
+    }
+
+    // MARK: - A live app must never be declared dead
+
+    func testFreshHeartbeatIsLive() {
+        XCTAssertEqual(evaluate(.recording, heartbeat: now - 1), .live)
+    }
+
+    func testIdleCadenceHeartbeatIsLive() {
+        // The slowest legitimate write is every 3 s, and it must not read as death.
+        XCTAssertEqual(evaluate(.transcribing, heartbeat: now - 3), .live)
+    }
+
+    func testHeartbeatExactlyAtTheThresholdIsLive() {
+        XCTAssertEqual(evaluate(.recording, heartbeat: now - threshold), .live)
+    }
+
+    func testHeartbeatJustPastTheThresholdIsOrphaned() {
+        XCTAssertEqual(evaluate(.recording, heartbeat: now - threshold - 0.01), .orphaned)
+    }
+
+    func testHeartbeatInTheFutureIsLive() {
+        // A clock that moved backwards is not evidence of anything. Killing a live
+        // recording is the worse error.
+        XCTAssertEqual(evaluate(.recording, heartbeat: now + 60), .live)
+    }
+
+    // MARK: - Fail closed
+
+    func testRequestedIsNeverOrphaned() {
+        // The keyboard writes `.requested` moments before launching the app for a
+        // cold start. A heartbeat left over from an earlier session would otherwise
+        // condemn every cold-start dictation before the app had a chance to write one.
+        XCTAssertEqual(evaluate(.requested, heartbeat: now - 3600), .unproven)
+    }
+
+    func testMissingHeartbeatIsUnprovenNotOrphaned() {
+        // An absent value is not evidence. The keyboard's own 5 s/15 s watchdog
+        // still covers this case.
+        XCTAssertEqual(evaluate(.recording, heartbeat: nil), .unproven)
+    }
+
+    func testZeroHeartbeatIsUnproven() {
+        // `UserDefaults.double(forKey:)` returns 0 for a missing key, which is how
+        // the absence actually reaches the policy.
+        XCTAssertEqual(evaluate(.recording, heartbeat: 0), .unproven)
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/LiveActivityStateMachineTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/LiveActivityStateMachineTests.swift
@@ -14,6 +14,16 @@ final class LiveActivityStateMachineTests: XCTestCase {
         XCTAssertEqual(sm.currentPhase, .standby)
     }
 
+    func testIdleToFailedSucceeds() {
+        // Issue #261: the app relaunches after being terminated mid-recording,
+        // receives the stop the keyboard sent into the void, collects zero samples
+        // and reports a failure from `.idle`. Rejecting it left the Dynamic Island
+        // unable to show an error in the one situation the user most needs one.
+        var sm = LiveActivityStateMachine()
+        XCTAssertTrue(sm.transition(to: .failed))
+        XCTAssertEqual(sm.currentPhase, .failed)
+    }
+
     func testStandbyToRecordingSucceeds() {
         var sm = LiveActivityStateMachine()
         sm.transition(to: .standby)

--- a/DictusCore/Tests/DictusCoreTests/LogEventTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/LogEventTests.swift
@@ -67,6 +67,44 @@ final class LogEventTests: XCTestCase {
         XCTAssertEqual(event.subsystem, .dictation)
     }
 
+    func testDictationStateReconciledIsWarningDictation() {
+        let event = LogEvent.dictationStateReconciled(
+            source: "keyboard-refresh",
+            staleStatus: "recording",
+            heartbeatAgeMs: 23_000
+        )
+        XCTAssertEqual(event.level, .warning)
+        XCTAssertEqual(event.subsystem, .dictation)
+    }
+
+    func testDictationStateReconciledIsGreppableWithItsEvidence() {
+        // Issue #261 acceptance criterion 4: the exported log must carry an explicit
+        // event for the reconciliation, so this failure is self-diagnosing without a
+        // rebuild — the same rationale as `localModelResolved` for #249. The name and
+        // the heartbeat age are what a reader greps for, so both are pinned here.
+        let event = LogEvent.dictationStateReconciled(
+            source: "keyboard-watchdog",
+            staleStatus: "recording",
+            heartbeatAgeMs: 23_000
+        )
+        XCTAssertEqual(event.name, "dictationStateReconciled")
+        XCTAssertEqual(
+            event.message,
+            "source=keyboard-watchdog staleStatus=recording heartbeatAgeMs=23000"
+        )
+    }
+
+    func testDictationStateReconciledReportsAnAbsentHeartbeatAsMinusOne() {
+        // The app-side launch audit reaches its verdict from the fact that a fresh
+        // process owns no session, so it has no heartbeat to report.
+        let event = LogEvent.dictationStateReconciled(
+            source: "app-launch",
+            staleStatus: "transcribing",
+            heartbeatAgeMs: -1
+        )
+        XCTAssertEqual(event.message, "source=app-launch staleStatus=transcribing heartbeatAgeMs=-1")
+    }
+
     // MARK: - Audio events
 
     func testAudioEngineStartedIsInfoAudio() {

--- a/DictusCore/Tests/DictusCoreTests/LogEventTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/LogEventTests.swift
@@ -105,6 +105,44 @@ final class LogEventTests: XCTestCase {
         XCTAssertEqual(event.message, "source=app-launch staleStatus=transcribing heartbeatAgeMs=-1")
     }
 
+    // MARK: - Keyboard status message trail (#261)
+
+    func testDictationMessageSetIsGreppableWithItsOwner() {
+        // The device test script tells the maintainer to grep these exact names, so
+        // the names and the field order are a contract, not an implementation detail.
+        let event = LogEvent.dictationMessageSet(reason: "reconciled-keyboard-refresh", owner: "9DF73D57", visible: true)
+        XCTAssertEqual(event.name, "dictationMessageSet")
+        XCTAssertEqual(event.message, "reason=reconciled-keyboard-refresh owner=9DF73D57 visible=true")
+        XCTAssertEqual(event.level, .info)
+        XCTAssertEqual(event.subsystem, .keyboard)
+    }
+
+    func testDictationMessageDisplayedCarriesBothIdentities() {
+        // `rootView` and `controller` against `owner` is what tests the hypothesis
+        // that a message renders into a tree the user is not looking at.
+        let event = LogEvent.dictationMessageDisplayed(
+            rootView: "D67967A0",
+            controller: "9DF73D57",
+            owner: "9DF73D57",
+            visible: true
+        )
+        XCTAssertEqual(event.name, "dictationMessageDisplayed")
+        XCTAssertEqual(event.message, "rootView=D67967A0 controller=9DF73D57 owner=9DF73D57 visible=true")
+        XCTAssertEqual(event.subsystem, .keyboard)
+    }
+
+    func testDictationMessageClearedWarnsWhenNobodyRenderedIt() {
+        // The whole point of counting: `displayedCount=0` is "the user was never
+        // told", and it is findable by level as well as by reading the number.
+        let unseen = LogEvent.dictationMessageCleared(reason: "reconciled-timeout", displayedCount: 0)
+        XCTAssertEqual(unseen.name, "dictationMessageCleared")
+        XCTAssertEqual(unseen.message, "reason=reconciled-timeout displayedCount=0")
+        XCTAssertEqual(unseen.level, .warning)
+
+        let seen = LogEvent.dictationMessageCleared(reason: "reconciled-timeout", displayedCount: 2)
+        XCTAssertEqual(seen.level, .info)
+    }
+
     // MARK: - Audio events
 
     func testAudioEngineStartedIsInfoAudio() {

--- a/DictusKeyboard/KeyboardRootView.swift
+++ b/DictusKeyboard/KeyboardRootView.swift
@@ -117,6 +117,8 @@ struct KeyboardRootView: View {
             dictationStatus: state.dictationStatus,
             onMicTap: { state.startRecording() },
             statusMessage: state.statusMessage,
+            messageProbeRootViewID: instanceID,
+            messageProbeControllerID: controllerID,
             suggestions: [],
             suggestionMode: .idle,
             onSuggestionTap: { _ in },
@@ -245,6 +247,8 @@ struct KeyboardRootView: View {
                     dictationStatus: state.dictationStatus,
                     onMicTap: { state.startRecording() },
                     statusMessage: state.statusMessage,
+                    messageProbeRootViewID: instanceID,
+                    messageProbeControllerID: controllerID,
                     suggestions: suggestionState.suggestions,
                     suggestionMode: suggestionState.mode,
                     onSuggestionTap: { index in

--- a/DictusKeyboard/KeyboardState.swift
+++ b/DictusKeyboard/KeyboardState.swift
@@ -15,7 +15,27 @@ import DictusCore
 class KeyboardState: ObservableObject {
     static let shared = KeyboardState()
     private let instanceID = String(UUID().uuidString.prefix(8))
-    private(set) var activeSessionID: String?
+
+    /// The dictation this keyboard process currently owns, if any.
+    ///
+    /// WHY the `didSet` (#261): `sessionStartedAt` below has to be in step with this
+    /// at every instant, and this property is assigned from six places. The same
+    /// funnel argument as `dictationStatus` and `ownership` applies -- a property
+    /// observer is the only path none of them can bypass, so the two cannot drift.
+    private(set) var activeSessionID: String? {
+        didSet {
+            guard oldValue != activeSessionID else { return }
+            sessionStartedAt = activeSessionID == nil ? nil : Date()
+        }
+    }
+
+    /// When the session above started, in this process.
+    ///
+    /// This is what stops a heartbeat left behind by an *earlier* dictation from being
+    /// read as evidence about the current one (#261). It is in-process by nature: the
+    /// App Group cannot carry it, because a value there would outlive the process that
+    /// wrote it and reintroduce the very problem.
+    private(set) var sessionStartedAt: Date?
 
     /// WHY didSet and not a sync call at each write site: this property is
     /// assigned from a dozen places (Darwin refresh, mic tap, cancel, watchdog
@@ -249,6 +269,18 @@ class KeyboardState: ObservableObject {
     /// Force-reset all dictation state to idle.
     /// Called by the watchdog timer or stale-state detection on keyboard appear.
     /// Writes to App Group so the app side sees the reset too.
+    ///
+    /// WHY it clears the shared recording keys as well as the status (#261): this
+    /// used to write `idle` and leave the heartbeat, the waveform and the cold-start
+    /// flag exactly as the abandoned session left them. A heartbeat that outlives the
+    /// session it belonged to is then read against the *next* one — on device
+    /// (2026-08-03) a corpse left here at 14:36:51 was judged against a session that
+    /// started at 14:37:02 and killed it. Whatever gives up on a dictation has to
+    /// leave the App Group describing no dictation at all.
+    ///
+    /// `stopRequested` / `cancelRequested` are deliberately untouched: those are
+    /// commands in flight, not state, and clearing them here would race a caller that
+    /// posts one immediately before resetting.
     func forceResetToIdle() {
         guard !isResettingToIdle else { return }
         isResettingToIdle = true
@@ -262,100 +294,12 @@ class KeyboardState: ObservableObject {
         activeSessionID = nil
         // Write to App Group so app side sees the reset
         defaults.set(DictationStatus.idle.rawValue, forKey: SharedKeys.dictationStatus)
-        defaults.synchronize()
-        DarwinNotificationCenter.post(DarwinNotificationName.statusChanged)
-    }
-
-    // MARK: - Orphaned dictation reconciliation (#261)
-
-    /// How long the "the recording was interrupted" message stays on the toolbar.
-    /// Matches the existing `.failed` message lifetime below, deliberately: this is
-    /// the same failure UX, reached from a different direction.
-    private static let interruptedMessageDuration: TimeInterval = 3
-
-    /// What the App Group says about the dictation, and what that means.
-    private struct DictationLivenessReading {
-        let verdict: DictationSessionLiveness
-        let status: DictationStatus?
-        /// Age of the heartbeat in milliseconds, or -1 when there was none to read.
-        let heartbeatAgeMs: Int
-    }
-
-    /// Ask the shared state whether a live process is still behind it.
-    ///
-    /// Reads the App Group directly rather than `dictationStatus`, because the point
-    /// is to audit what was *written* -- a keyboard rebuilt after the app died has no
-    /// in-memory status of its own yet.
-    private func dictationLiveness() -> DictationLivenessReading {
-        let status = defaults.string(forKey: SharedKeys.dictationStatus)
-            .flatMap(DictationStatus.init(rawValue:))
-        let raw = defaults.double(forKey: SharedKeys.recordingHeartbeat)
-        let heartbeat: TimeInterval? = raw > 0 ? raw : nil
-        let now = Date().timeIntervalSince1970
-        return DictationLivenessReading(
-            verdict: DictationSessionLivenessPolicy.evaluate(
-                status: status,
-                heartbeat: heartbeat,
-                now: now
-            ),
-            status: status,
-            heartbeatAgeMs: heartbeat.map { Int((now - $0) * 1000) } ?? -1
-        )
-    }
-
-    /// Clear a dictation whose owning process is gone, and tell the user (#261).
-    ///
-    /// WHY the keyboard does this itself rather than waiting: when iOS terminates
-    /// DictusApp mid-dictation, nothing relaunches it. The overlay would keep
-    /// pretending to record until the watchdog's 5 s -- or 15 s during a cold start --
-    /// expired, and it would then reset in silence, which is what left the user tapping
-    /// a stop button that did nothing and losing a long voice note without explanation.
-    ///
-    /// WHY it still posts a stop first: the verdict rests on a cross-process
-    /// `UserDefaults` read. If that read were ever wrong, resetting alone would leave a
-    /// live engine capturing with nobody watching -- the #60 failure. A stop costs
-    /// nothing when nobody is listening, and salvages the recording when someone is:
-    /// the transcription is inserted irrespective of the keyboard's local status.
-    ///
-    /// Returns whether it acted, so callers can skip the work they were about to do.
-    @discardableResult
-    private func reconcileOrphanedDictation(source: String) -> Bool {
-        let reading = dictationLiveness()
-        guard reading.verdict == .orphaned, let status = reading.status else { return false }
-
-        PersistentLog.log(.dictationStateReconciled(
-            source: source,
-            staleStatus: status.rawValue,
-            heartbeatAgeMs: reading.heartbeatAgeMs
-        ))
-
-        defaults.set(true, forKey: SharedKeys.stopRequested)
-        defaults.synchronize()
-        DarwinNotificationCenter.post(DarwinNotificationName.stopRecording)
-
-        // Clears the local status, the session id and the message, writes `idle` to
-        // the App Group and posts `statusChanged` -- so the overlay is gone on the
-        // next run loop pass rather than on the next watchdog tick.
-        forceResetToIdle()
-
-        // The recording keys the dead process never got to clean up. Leaving the
-        // heartbeat behind would make the next evaluation read a session that no
-        // longer exists.
         defaults.removeObject(forKey: SharedKeys.recordingHeartbeat)
         defaults.removeObject(forKey: SharedKeys.waveformEnergy)
         defaults.removeObject(forKey: SharedKeys.recordingElapsedSeconds)
         defaults.set(false, forKey: SharedKeys.coldStartActive)
         defaults.synchronize()
-
-        // Said after the reset, because `forceResetToIdle` clears the message. The
-        // wording is "interrupted", not "crashed": from the user's side that is both
-        // truer and less alarming, and it is what they need to know -- the recording
-        // is gone and the next tap starts fresh.
-        statusMessage = String(localized: "Recording interrupted. Please try again.")
-        DispatchQueue.main.asyncAfter(deadline: .now() + Self.interruptedMessageDuration) { [weak self] in
-            self?.statusMessage = nil
-        }
-        return true
+        DarwinNotificationCenter.post(DarwinNotificationName.statusChanged)
     }
 
     /// Start a repeating 1s timer that checks for stale active states.
@@ -374,12 +318,17 @@ class KeyboardState: ObservableObject {
                 return
             }
             // A heartbeat that stopped is positive evidence that the app is gone, and
-            // it outranks both thresholds below (#261). The 15 s cold-start grace was
-            // written for an app that is slow to start posting waveform data, not for
-            // one that has died; waiting it out is what let a phantom session run for
-            // ~34 s. Reconciling tells the user and resets, where the watchdog reset
-            // below only resets.
-            if self.reconcileOrphanedDictation(source: "keyboard-watchdog") { return }
+            // it can pre-empt the 15 s cold-start grace below (#261) -- that grace was
+            // written for an app slow to start posting waveform data, not for one that
+            // has died, and waiting it out is what let a phantom session run for ~34 s.
+            //
+            // It also beats the 5 s path, but only because the recording threshold is
+            // deliberately 4 s. The first shipped version used 8 s and therefore never
+            // fired: both ages start at the same instant, so a threshold above the
+            // watchdog's own is unreachable — the reset below lands first and the guard
+            // above then stops the timer. That is defect 1 of the device run in one
+            // sentence, and it is why the two numbers are now coupled on purpose.
+            if self.reconcileIfOrphaned(source: "keyboard-watchdog") { return }
 
             // During cold start, the app transitions foreground→background while
             // setting up audio. Waveform data may not flow for ~10s. Use 15s threshold.
@@ -396,8 +345,24 @@ class KeyboardState: ObservableObject {
                     self.lastWaveformUpdate = Date()
                     return
                 }
+                // This test has decided; it does not consult the predicate again, and
+                // must not — its own thresholds are what proved themselves on device.
+                // What changes here is only the outcome: the reset is no longer local
+                // and silent. It clears the shared state too and says something, so a
+                // watchdog win and a predicate win are the same event to the user, and
+                // leave the same state behind for the next dictation.
+                //
+                // `watchdogReset` is still logged, so this line keeps meaning what it
+                // means in every log written before this change.
                 PersistentLog.log(.watchdogReset(source: "keyboard", staleState: self.dictationStatus.rawValue))
-                self.forceResetToIdle()
+                let heartbeatAgeMs = heartbeat > 0
+                    ? Int((Date().timeIntervalSince1970 - heartbeat) * 1000)
+                    : -1
+                self.reconcileAbandonedDictation(
+                    source: "keyboard-watchdog-stale",
+                    staleStatus: self.dictationStatus,
+                    heartbeatAgeMs: heartbeatAgeMs
+                )
             }
         }
     }
@@ -494,7 +459,7 @@ class KeyboardState: ObservableObject {
             // rebuilds this extension routinely, and a keyboard rebuilt mid-dictation
             // has no session id while the app records perfectly happily. Dropping the
             // overlay there would abandon a live transcription.
-            if reconcileOrphanedDictation(source: "keyboard-stop") { return }
+            if reconcileIfOrphaned(source: "keyboard-stop") { return }
         }
 
         defaults.set(true, forKey: SharedKeys.stopRequested)
@@ -532,7 +497,7 @@ class KeyboardState: ObservableObject {
         // own `init`, so an app terminated mid-dictation is caught here -- at the
         // first read, not after a watchdog grace. Reconciling already wrote `idle`,
         // so there is nothing left to adopt.
-        if reconcileOrphanedDictation(source: "keyboard-refresh") { return }
+        if reconcileIfOrphaned(source: "keyboard-refresh") { return }
 
         if let rawStatus = defaults.string(forKey: SharedKeys.dictationStatus),
            let status = DictationStatus(rawValue: rawStatus) {
@@ -1311,5 +1276,133 @@ class KeyboardState: ObservableObject {
             middle,
             last
         )
+    }
+}
+
+// MARK: - Orphaned dictation reconciliation (#261)
+
+/// WHY these live in an extension rather than in the class body: `KeyboardState` is
+/// already at SwiftLint's `type_body_length` budget, and this block is a coherent
+/// unit that reads as one. Same device as `DictationCoordinator`'s engine-init
+/// extension, and for the same reason. Being in the same file keeps access to the
+/// class's private members, so nothing had to be widened to make room.
+private extension KeyboardState {
+
+    /// How long the "the recording was interrupted" message stays on the toolbar.
+    /// Matches the `.failed` message lifetime in `refreshFromDefaults`, deliberately:
+    /// this is the same failure UX, reached from a different direction.
+    static let interruptedMessageDuration: TimeInterval = 3
+
+    /// What the App Group says about the dictation, and what that means.
+    struct DictationLivenessReading {
+        let verdict: DictationSessionLiveness
+        let status: DictationStatus?
+        /// Age of the heartbeat in milliseconds, or -1 when there was none to read.
+        let heartbeatAgeMs: Int
+    }
+
+    /// Ask the shared state whether a live process is still behind it.
+    ///
+    /// Reads the App Group directly rather than `dictationStatus`, because the point
+    /// is to audit what was *written* -- a keyboard rebuilt after the app died has no
+    /// in-memory status of its own yet.
+    func dictationLiveness() -> DictationLivenessReading {
+        let status = defaults.string(forKey: SharedKeys.dictationStatus)
+            .flatMap(DictationStatus.init(rawValue:))
+        let raw = defaults.double(forKey: SharedKeys.recordingHeartbeat)
+        let heartbeat: TimeInterval? = raw > 0 ? raw : nil
+        let now = Date().timeIntervalSince1970
+        return DictationLivenessReading(
+            verdict: DictationSessionLivenessPolicy.evaluate(
+                status: status,
+                heartbeat: heartbeat,
+                // The in-process fact that keeps a corpse heartbeat from being read
+                // against a session this keyboard started after it (#261).
+                localSessionStartedAt: sessionStartedAt?.timeIntervalSince1970,
+                now: now
+            ),
+            status: status,
+            heartbeatAgeMs: heartbeat.map { Int((now - $0) * 1000) } ?? -1
+        )
+    }
+
+    /// Reconcile only if the shared state proves the writing process is gone (#261).
+    ///
+    /// Used where nothing else has made a determination: the first read after the
+    /// extension is rebuilt, and the watchdog tick, where this is what lets a stale
+    /// heartbeat pre-empt the 15 s cold-start grace.
+    ///
+    /// Returns whether it acted, so callers can skip the work they were about to do.
+    @discardableResult
+    func reconcileIfOrphaned(source: String) -> Bool {
+        let reading = dictationLiveness()
+        guard reading.verdict == .orphaned, let status = reading.status else { return false }
+        reconcileAbandonedDictation(
+            source: source,
+            staleStatus: status,
+            heartbeatAgeMs: reading.heartbeatAgeMs
+        )
+        return true
+    }
+
+    /// Give up on the current dictation, leave both sides consistent, and tell the
+    /// user (#261).
+    ///
+    /// WHY the keyboard does this itself rather than waiting for the app: when iOS
+    /// terminates DictusApp mid-dictation, nothing relaunches it. The overlay used to
+    /// keep pretending to record until the watchdog expired, and the watchdog then
+    /// reset in silence -- which is what left the user tapping a stop button that did
+    /// nothing and losing a long voice note with no explanation.
+    ///
+    /// WHY it posts a **cancel** and not a stop: the first version posted a stop, on
+    /// the argument that it would cost nothing if nobody was listening and salvage the
+    /// recording if somebody was. The device disagreed (2026-08-03). A false positive
+    /// is by definition the case where somebody *is* listening, so the cost lands
+    /// exactly where the insurance was meant to pay out: the app took the stop, found
+    /// `sampleCount=0`, and turned a recoverable UI desync into a failed dictation.
+    /// A cancel discards and returns the app to `.idle` instead, which is the clean
+    /// state the next mic tap needs. Doing nothing at all was the other candidate and
+    /// was rejected: it would leave the app stuck in `.recording`, where
+    /// `startDictation`'s duplicate guard refuses every subsequent tap.
+    ///
+    /// WHY the cancel is posted for a stale `recording` and not a stale `transcribing`:
+    /// cancelling a recording nobody is capturing costs nothing, but `cancelDictation`
+    /// also cancels the in-flight transcription task. Reaching this during
+    /// `transcribing` does not prove the transcriber is dead — only that the audio
+    /// engine stopped writing, and those are independent (tapping Power in the Dynamic
+    /// Island does exactly that). Posting a cancel there would destroy text that would
+    /// otherwise still arrive: `handleTranscriptionReady` inserts it irrespective of
+    /// the keyboard's local status. The app has its own 30 s transcription watchdog for
+    /// the case where the transcriber really is stuck, so nothing is left unattended.
+    func reconcileAbandonedDictation(
+        source: String,
+        staleStatus: DictationStatus,
+        heartbeatAgeMs: Int
+    ) {
+        PersistentLog.log(.dictationStateReconciled(
+            source: source,
+            staleStatus: staleStatus.rawValue,
+            heartbeatAgeMs: heartbeatAgeMs
+        ))
+
+        if staleStatus == .recording {
+            defaults.set(true, forKey: SharedKeys.cancelRequested)
+            defaults.synchronize()
+            DarwinNotificationCenter.post(DarwinNotificationName.cancelRecording)
+        }
+
+        // Clears the local status, the session id and the message, writes `idle` and
+        // drops the shared recording keys, then posts `statusChanged` -- so the overlay
+        // is gone on the next run loop pass rather than on the next watchdog tick.
+        forceResetToIdle()
+
+        // Said after the reset, because `forceResetToIdle` clears the message. The
+        // wording is "interrupted", not "crashed": from the user's side that is both
+        // truer and less alarming, and it is what they need to know -- the recording
+        // is gone and the next tap starts fresh.
+        statusMessage = String(localized: "Recording interrupted. Please try again.")
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.interruptedMessageDuration) { [weak self] in
+            self?.statusMessage = nil
+        }
     }
 }

--- a/DictusKeyboard/KeyboardState.swift
+++ b/DictusKeyboard/KeyboardState.swift
@@ -122,7 +122,39 @@ class KeyboardState: ObservableObject {
     }
 
     @Published var lastTranscription: String?
-    @Published var statusMessage: String?
+
+    /// The red line the toolbar shows above the keys: a dictation error from the app,
+    /// or the interruption notice the keyboard raises itself (#261).
+    ///
+    /// WHY the `didSet` and not a log line at each write site: this is assigned from
+    /// seven places across three lifecycles, and the open question about it is
+    /// whether the user ever *saw* one — an answer that cannot be assembled from
+    /// call sites that each report only themselves. The same funnel argument as
+    /// `dictationStatus` and `ownership` above: a property observer is the only path
+    /// none of them can bypass. Writers go through `assignStatusMessage(_:reason:)`
+    /// so the observer has a reason to record; a write that skipped it would still be
+    /// logged, as `reason=unspecified`, rather than silently inheriting the last one.
+    ///
+    /// The observer only logs. Nothing here changes when a message is set, how long
+    /// it lives, or what it says.
+    @Published var statusMessage: String? {
+        didSet {
+            guard oldValue != statusMessage else { return }
+            logStatusMessageTransition(from: oldValue)
+            statusMessageReason = Self.unspecifiedMessageReason
+        }
+    }
+
+    /// What asked for the pending `statusMessage` write. Read and reset by the
+    /// observer above.
+    private var statusMessageReason = KeyboardState.unspecifiedMessageReason
+    private static let unspecifiedMessageReason = "unspecified"
+
+    /// How many live views have reported putting the current message on screen.
+    /// Reset when a message is assigned, reported when it ends: `displayedCount=0`
+    /// on a `dictationMessageCleared` line means nobody could have read it.
+    private var statusMessageDisplayCount = 0
+
     @Published var waveformEnergy: [Float] = []
     @Published var recordingElapsed: Double = 0
 
@@ -290,7 +322,7 @@ class KeyboardState: ObservableObject {
         dictationStatus = .idle
         waveformEnergy = []
         recordingElapsed = 0
-        statusMessage = nil
+        assignStatusMessage(nil, reason: "forceResetToIdle")
         activeSessionID = nil
         // Write to App Group so app side sees the reset
         defaults.set(DictationStatus.idle.rawValue, forKey: SharedKeys.dictationStatus)
@@ -481,7 +513,7 @@ class KeyboardState: ObservableObject {
         dictationStatus = .idle
         waveformEnergy = []
         recordingElapsed = 0
-        statusMessage = nil
+        assignStatusMessage(nil, reason: "requestCancel")
         activeSessionID = nil
     }
 
@@ -535,11 +567,11 @@ class KeyboardState: ObservableObject {
                     activeSessionID = nil
                     // Read and display error message from App Group
                     if status == .failed, let errorMsg = defaults.string(forKey: SharedKeys.lastError) {
-                        statusMessage = errorMsg
+                        assignStatusMessage(errorMsg, reason: "appError")
                         defaults.removeObject(forKey: SharedKeys.lastError)
                         defaults.synchronize()
                         DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
-                            self?.statusMessage = nil
+                            self?.assignStatusMessage(nil, reason: "appError-timeout")
                         }
                     }
                 }
@@ -652,7 +684,7 @@ class KeyboardState: ObservableObject {
         dictationStatus = .idle
         waveformEnergy = []
         recordingElapsed = 0
-        statusMessage = nil
+        assignStatusMessage(nil, reason: "textInserted")
         lastTranscription = nil
         activeSessionID = nil
 
@@ -1400,9 +1432,92 @@ private extension KeyboardState {
         // wording is "interrupted", not "crashed": from the user's side that is both
         // truer and less alarming, and it is what they need to know -- the recording
         // is gone and the next tap starts fresh.
-        statusMessage = String(localized: "Recording interrupted. Please try again.")
+        assignStatusMessage(
+            String(localized: "Recording interrupted. Please try again."),
+            reason: "reconciled-\(source)"
+        )
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.interruptedMessageDuration) { [weak self] in
-            self?.statusMessage = nil
+            self?.assignStatusMessage(nil, reason: "reconciled-timeout")
         }
+    }
+}
+
+// MARK: - Status message trail (#261)
+
+/// Instrumentation for the toolbar message's whole life: set, displayed, ended.
+///
+/// WHY it exists: the sharpened acceptance criterion for #261 is "stop the recording
+/// *and say something*", and until now nothing in the exported log recorded whether
+/// anything was said. The message is assigned on a singleton, but iOS keeps several
+/// `KeyboardViewController` instances alive at once (~9 during a dictation, #281), so
+/// "assigned" and "on screen in front of the user" are different facts and only the
+/// first one was observable. A single "I set the message" line would reproduce that
+/// ambiguity exactly, which is why set and displayed are separate events.
+///
+/// Cost: one line when a message is assigned, one per view that renders it, one when
+/// it ends. The message changes a handful of times per session, so this is
+/// proportional to the message and not to the render loop — nothing here fires per
+/// frame or per render tick.
+extension KeyboardState {
+
+    /// Assign the toolbar message and name what asked for it.
+    ///
+    /// The reason travels in a property rather than a parameter because the observer
+    /// that logs it is on `statusMessage` itself, which is what makes it impossible
+    /// for a writer to escape the trail.
+    func assignStatusMessage(_ message: String?, reason: String) {
+        statusMessageReason = reason
+        statusMessage = message
+    }
+
+    /// Record a message assignment or its end. Called only from `statusMessage`'s
+    /// observer, so every write reaches it.
+    ///
+    /// A message replacing another emits both lines, so `set` and `cleared` always
+    /// pair up and a reader can bracket each message's life without inference.
+    func logStatusMessageTransition(from oldValue: String?) {
+        let reason = statusMessageReason
+        if oldValue != nil {
+            PersistentLog.log(.dictationMessageCleared(
+                reason: statusMessage == nil ? reason : "replaced",
+                displayedCount: statusMessageDisplayCount
+            ))
+        }
+        statusMessageDisplayCount = 0
+        guard statusMessage != nil else { return }
+        PersistentLog.log(.dictationMessageSet(
+            reason: reason,
+            owner: activeControllerID ?? "none",
+            visible: isKeyboardVisible
+        ))
+    }
+
+    /// Called by the toolbar when the message enters the view hierarchy.
+    ///
+    /// This is the line that answers "was the user told". Compare its `rootView` and
+    /// `controller` against `owner`: a view that rendered the message while it did not
+    /// own the keyboard area drew into a tree nobody was looking at, which is the
+    /// maintainer's hypothesis stated as a grep.
+    func noteStatusMessageDisplayed(rootView: String, controller: String) {
+        statusMessageDisplayCount += 1
+        PersistentLog.log(.dictationMessageDisplayed(
+            rootView: rootView,
+            controller: controller,
+            owner: activeControllerID ?? "none",
+            visible: isKeyboardVisible
+        ))
+    }
+
+    /// Called by the toolbar when the message leaves the view hierarchy.
+    ///
+    /// Fine grain, so a probe rather than an event: this fires when the message is
+    /// cleared and also when the toolbar itself goes away (a controller torn down, or
+    /// the recording overlay taking the area), and the surrounding lines are what
+    /// tell those apart.
+    func noteStatusMessageHidden(rootView: String, controller: String) {
+        logProbe(
+            "statusMessageHidden",
+            details: "rootView=\(rootView) controllerID=\(controller) owner=\(activeControllerID ?? "none") visible=\(isKeyboardVisible)"
+        )
     }
 }

--- a/DictusKeyboard/KeyboardState.swift
+++ b/DictusKeyboard/KeyboardState.swift
@@ -266,6 +266,98 @@ class KeyboardState: ObservableObject {
         DarwinNotificationCenter.post(DarwinNotificationName.statusChanged)
     }
 
+    // MARK: - Orphaned dictation reconciliation (#261)
+
+    /// How long the "the recording was interrupted" message stays on the toolbar.
+    /// Matches the existing `.failed` message lifetime below, deliberately: this is
+    /// the same failure UX, reached from a different direction.
+    private static let interruptedMessageDuration: TimeInterval = 3
+
+    /// What the App Group says about the dictation, and what that means.
+    private struct DictationLivenessReading {
+        let verdict: DictationSessionLiveness
+        let status: DictationStatus?
+        /// Age of the heartbeat in milliseconds, or -1 when there was none to read.
+        let heartbeatAgeMs: Int
+    }
+
+    /// Ask the shared state whether a live process is still behind it.
+    ///
+    /// Reads the App Group directly rather than `dictationStatus`, because the point
+    /// is to audit what was *written* -- a keyboard rebuilt after the app died has no
+    /// in-memory status of its own yet.
+    private func dictationLiveness() -> DictationLivenessReading {
+        let status = defaults.string(forKey: SharedKeys.dictationStatus)
+            .flatMap(DictationStatus.init(rawValue:))
+        let raw = defaults.double(forKey: SharedKeys.recordingHeartbeat)
+        let heartbeat: TimeInterval? = raw > 0 ? raw : nil
+        let now = Date().timeIntervalSince1970
+        return DictationLivenessReading(
+            verdict: DictationSessionLivenessPolicy.evaluate(
+                status: status,
+                heartbeat: heartbeat,
+                now: now
+            ),
+            status: status,
+            heartbeatAgeMs: heartbeat.map { Int((now - $0) * 1000) } ?? -1
+        )
+    }
+
+    /// Clear a dictation whose owning process is gone, and tell the user (#261).
+    ///
+    /// WHY the keyboard does this itself rather than waiting: when iOS terminates
+    /// DictusApp mid-dictation, nothing relaunches it. The overlay would keep
+    /// pretending to record until the watchdog's 5 s -- or 15 s during a cold start --
+    /// expired, and it would then reset in silence, which is what left the user tapping
+    /// a stop button that did nothing and losing a long voice note without explanation.
+    ///
+    /// WHY it still posts a stop first: the verdict rests on a cross-process
+    /// `UserDefaults` read. If that read were ever wrong, resetting alone would leave a
+    /// live engine capturing with nobody watching -- the #60 failure. A stop costs
+    /// nothing when nobody is listening, and salvages the recording when someone is:
+    /// the transcription is inserted irrespective of the keyboard's local status.
+    ///
+    /// Returns whether it acted, so callers can skip the work they were about to do.
+    @discardableResult
+    private func reconcileOrphanedDictation(source: String) -> Bool {
+        let reading = dictationLiveness()
+        guard reading.verdict == .orphaned, let status = reading.status else { return false }
+
+        PersistentLog.log(.dictationStateReconciled(
+            source: source,
+            staleStatus: status.rawValue,
+            heartbeatAgeMs: reading.heartbeatAgeMs
+        ))
+
+        defaults.set(true, forKey: SharedKeys.stopRequested)
+        defaults.synchronize()
+        DarwinNotificationCenter.post(DarwinNotificationName.stopRecording)
+
+        // Clears the local status, the session id and the message, writes `idle` to
+        // the App Group and posts `statusChanged` -- so the overlay is gone on the
+        // next run loop pass rather than on the next watchdog tick.
+        forceResetToIdle()
+
+        // The recording keys the dead process never got to clean up. Leaving the
+        // heartbeat behind would make the next evaluation read a session that no
+        // longer exists.
+        defaults.removeObject(forKey: SharedKeys.recordingHeartbeat)
+        defaults.removeObject(forKey: SharedKeys.waveformEnergy)
+        defaults.removeObject(forKey: SharedKeys.recordingElapsedSeconds)
+        defaults.set(false, forKey: SharedKeys.coldStartActive)
+        defaults.synchronize()
+
+        // Said after the reset, because `forceResetToIdle` clears the message. The
+        // wording is "interrupted", not "crashed": from the user's side that is both
+        // truer and less alarming, and it is what they need to know -- the recording
+        // is gone and the next tap starts fresh.
+        statusMessage = String(localized: "Recording interrupted. Please try again.")
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.interruptedMessageDuration) { [weak self] in
+            self?.statusMessage = nil
+        }
+        return true
+    }
+
     /// Start a repeating 1s timer that checks for stale active states.
     /// WHY 5s threshold: Waveform updates arrive at ~5Hz during recording.
     /// If 5 seconds pass without any update while status is still active,
@@ -281,6 +373,14 @@ class KeyboardState: ObservableObject {
                 self.stopWatchdog()
                 return
             }
+            // A heartbeat that stopped is positive evidence that the app is gone, and
+            // it outranks both thresholds below (#261). The 15 s cold-start grace was
+            // written for an app that is slow to start posting waveform data, not for
+            // one that has died; waiting it out is what let a phantom session run for
+            // ~34 s. Reconciling tells the user and resets, where the watchdog reset
+            // below only resets.
+            if self.reconcileOrphanedDictation(source: "keyboard-watchdog") { return }
+
             // During cold start, the app transitions foreground→background while
             // setting up audio. Waveform data may not flow for ~10s. Use 15s threshold.
             let inGracePeriod = self.coldStartGraceEnd.map { Date() < $0 } ?? false
@@ -379,6 +479,24 @@ class KeyboardState: ObservableObject {
     /// then post the notification so the app reads the flag when it handles the notification.
     func requestStop() {
         logProbe("requestStop", details: sessionDetails())
+
+        // A stop tapped by a keyboard that never started this dictation (#261). The
+        // line is written whatever comes next, because two taps used to produce
+        // nothing at all -- neither on screen nor in the log -- and that silence is
+        // what made the reported incident unreadable.
+        if activeSessionID == nil {
+            let reading = dictationLiveness()
+            logProbe(
+                "requestStopWithoutSession",
+                details: "storedStatus=\(reading.status?.rawValue ?? "nil") liveness=\(reading.verdict.rawValue)"
+            )
+            // Reset locally only on the evidence, not on the missing id alone: iOS
+            // rebuilds this extension routinely, and a keyboard rebuilt mid-dictation
+            // has no session id while the app records perfectly happily. Dropping the
+            // overlay there would abandon a live transcription.
+            if reconcileOrphanedDictation(source: "keyboard-stop") { return }
+        }
+
         defaults.set(true, forKey: SharedKeys.stopRequested)
         defaults.synchronize()
         DarwinNotificationCenter.post(DarwinNotificationName.stopRecording)
@@ -408,6 +526,14 @@ class KeyboardState: ObservableObject {
     /// Starts/stops the watchdog timer based on the new status.
     func refreshFromDefaults() {
         logProbe("refreshFromDefaults", details: "storedStatus=\(defaults.string(forKey: SharedKeys.dictationStatus) ?? "nil") visible=\(isKeyboardVisible) \(sessionDetails())")
+
+        // Before adopting what the App Group says, check that somebody is still
+        // writing it (#261). This is the read a rebuilt extension performs from its
+        // own `init`, so an app terminated mid-dictation is caught here -- at the
+        // first read, not after a watchdog grace. Reconciling already wrote `idle`,
+        // so there is nothing left to adopt.
+        if reconcileOrphanedDictation(source: "keyboard-refresh") { return }
+
         if let rawStatus = defaults.string(forKey: SharedKeys.dictationStatus),
            let status = DictationStatus(rawValue: rawStatus) {
             let oldStatus = dictationStatus

--- a/DictusKeyboard/Localizable.xcstrings
+++ b/DictusKeyboard/Localizable.xcstrings
@@ -122,6 +122,17 @@
         }
       }
     },
+    "Recording interrupted. Please try again." : {
+      "comment" : "Toolbar message shown when the keyboard clears a recording whose app was terminated (issue #261).",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistrement interrompu. Réessayez."
+          }
+        }
+      }
+    },
     "Search Emoji" : {
       "localizations" : {
         "fr" : {

--- a/DictusKeyboard/Views/ToolbarView.swift
+++ b/DictusKeyboard/Views/ToolbarView.swift
@@ -28,6 +28,12 @@ struct ToolbarView: View {
 
     // Suggestion bar integration parameters (default to idle/empty)
     var statusMessage: String?
+
+    /// Identity carried purely so the status message's rendering can be attributed
+    /// to a view and a controller in the exported log (#261). Defaulted, so a call
+    /// site that does not care is unaffected; both current call sites supply them.
+    var messageProbeRootViewID: String = "unknown"
+    var messageProbeControllerID: String = "unknown"
     var suggestions: [String] = []
     var suggestionMode: SuggestionMode = .idle
     var onSuggestionTap: ((Int) -> Void)?
@@ -106,6 +112,24 @@ struct ToolbarView: View {
                     .foregroundColor(.red)
                     .lineLimit(1)
                     .frame(maxWidth: .infinity)
+                    // Instrumentation only (#261). "The message was assigned" and
+                    // "a live view put it on screen" are different facts, and only
+                    // the first was observable — iOS keeps several controllers
+                    // alive, so a message can be set and rendered into a tree the
+                    // user is not looking at. This is the second fact, reported
+                    // from the one place that can actually attest to it.
+                    .onAppear {
+                        KeyboardState.shared.noteStatusMessageDisplayed(
+                            rootView: messageProbeRootViewID,
+                            controller: messageProbeControllerID
+                        )
+                    }
+                    .onDisappear {
+                        KeyboardState.shared.noteStatusMessageHidden(
+                            rootView: messageProbeRootViewID,
+                            controller: messageProbeControllerID
+                        )
+                    }
             } else if showsDictationUndo {
                 dictationUndoButton
 


### PR DESCRIPTION
refs #261

## Root cause, in my own words

`dictationStatus` is written forward and never audited. When iOS terminates DictusApp mid-dictation, the App Group keeps saying `recording`, and the next keyboard extension process faithfully restores a recording overlay for a session no process is running. The user keeps talking, their stop taps reach a dead listener, and 34 seconds later the session ends in silence with the audio lost.

The maintainer's comment sharpens what to do about it, and I took that as the contract: the keyboard must **stop the recording itself and tell the user**, without waiting for the app to relaunch and without waiting out the 15 s cold-start watchdog grace.

## Three things in the issue that the code contradicts

I checked every claim rather than trusting the list. Three did not hold, and two of them changed the design.

1. **There is no `dictationSessionID` in the App Group.** `SharedKeys` has no such key. The session id is `KeyboardState.activeSessionID`, in-memory in the extension process. So `sessionID=none` is what **every** rebuilt keyboard reports, whether or not the app is healthy — it is a symptom, never a cause, and it cannot be the discriminator. Criterion 2's "clear `dictationSessionID`" is satisfied by `forceResetToIdle()`, which already nils it.

2. **`requestStop` does not drop anything.** It writes `stopRequested=true` and posts the Darwin notification unconditionally. The two taps produced nothing because nobody was listening, not because the keyboard swallowed them.

3. **Criterion 3, read literally, would cause a regression.** "A `requestStop` arriving with `sessionID=none` … resets the keyboard locally" also describes a keyboard rebuilt mid-dictation while the app records perfectly happily — iOS rebuilds this extension routinely (~9 controllers per dictation, #281). Resetting there would drop the overlay during a live transcription. **The log line is unconditional; the local reset is gated on evidence.** That is a deliberate divergence and the one thing in here worth your veto.

## What the evidence actually is

`SharedKeys.recordingHeartbeat`. `UnifiedAudioEngine` writes it from the audio thread every 1 s while recording and every 3 s while the engine is warm but idle — which covers transcription (#106 Phase C, sized at 3 s precisely so it stays under the watchdog's 5 s threshold). It is the one value written by the process that would have died. An active status whose heartbeat stopped is decidable on the spot, with no grace to wait out. In the #261 capture the app died at 15:08:10 and the rebuilt keyboard read the state at 15:08:33 — a 23 s stale heartbeat, decidable at the first read.

## What changed

**`DictusCore/DictationSessionLiveness.swift`** (new) — `evaluate(status:heartbeat:now:)` → `.notActive` / `.live` / `.unproven` / `.orphaned`, threshold 8 s. Pure, no UserDefaults, 13 tests. It fails **closed** in three places, and those are the clauses that would break cold-start dictation if they ever regressed:
- `.requested` is never orphaned — the keyboard writes it moments before launching the app, so a leftover heartbeat would condemn every cold start;
- a missing heartbeat is `.unproven`, not `.orphaned` — an absent value is not evidence, and the existing watchdog still covers it;
- a clock that moved backwards reads as `.live`.

Why 8 s and not the watchdog's 5 s: the slowest legitimate write is the 3 s idle heartbeat, and a cross-process `UserDefaults` read can lag. 8 s clears both, and is still roughly half the 15 s grace this exists to bypass.

**`DictusKeyboard/KeyboardState.swift`** — `reconcileOrphanedDictation(source:)`, evaluated from `refreshFromDefaults` (so a rebuilt extension catches it on its **first read**) and from the watchdog tick (so a keyboard that outlives the app catches it too). On `.orphaned` it logs the event, posts a stop, resets, clears the recording keys, and sets a localised toolbar message.

**It posts a stop before resetting**, and that is the deliberate part. The verdict rests on a cross-process read. If that read were ever wrong, resetting alone would leave a live engine capturing with nobody watching — that is #60. A stop costs nothing when nobody is listening and salvages the recording when someone is, since `handleTranscriptionReady` inserts irrespective of the keyboard's local status. The cost is that a false positive shows "interrupted" and then delivers the text anyway. I would rather be confusing than silently orphan an engine.

**The message.** `String(localized: "Recording interrupted. Please try again.")` / « Enregistrement interrompu. Réessayez. » It goes through `statusMessage`, i.e. the same red toolbar line and the same 3 s lifetime as the existing `.failed` path — same register, reached from a different direction. It says *interrupted*, never *crash*.

**`DictusApp/DictationCoordinator.swift`** — `reconcileOrphanedDictationState()` at init. A process that has just started owns no session by construction, so a stored `recording` or `transcribing` is decidable without a heartbeat. **`.requested` is excluded**: the keyboard writes it moments before opening `dictus://dictate`, i.e. moments before launching this very process, and the `didBecomeActive` retry proceeds only while it is still there. Reconciling it would break every cold-start dictation — that is the trap in this issue and it is verified below, not merely reasoned about.

It writes `.failed` plus a localised `lastError` rather than `.idle`, so the keyboard's existing failure path tells the user. It does **not** go through `updateStatus`: this process is not failing anything, it is auditing what a dead one left behind, and its own `status` is correctly `.idle`.

**`DictusCore/LiveActivityStateMachine.swift`** — `.idle -> .failed` is now valid (issue change 3). `endWithFailure()` still returns early when it holds no activity, so this creates no pill out of nothing.

Not done, on purpose: **no case added to `DictationStatus`** (#267 owns that, and nothing here needed one), **no keyboard height constraint touched** (#166), **no change to `KeyboardOwnership`** (#260).

## Verified, with the commands and what they printed

- `xcodebuild build -scheme DictusApp -destination 'platform=iOS Simulator,id=231991C2…'` — **BUILD SUCCEEDED** (signed, no CI signing flags — an unsigned build makes `AppGroup.containerURL` nil, which is the surface being changed).
- `swiftlint lint --strict` — **0 violations, 0 serious in 159 files.** One `large_tuple` violation I introduced was fixed properly (a named struct), not suppressed.
- `cd DictusCore && swift test` — **603 tests, 0 failures**, 17 of them new.

### Simulator run, seeding the App Group and reading the exported log

`.recording` left behind by a dead process:

```
[2026-08-03T13:59:38Z] INFO    [lifecycle] <APP> appLaunched version=1.8.0
[2026-08-03T13:59:38Z] WARNING [dictation] <APP> dictationStateReconciled source=app-launch staleStatus=recording heartbeatAgeMs=-1
```

and the resulting shared state, read back from the App Group plist:

```
{'dictus.dictationStatus': 'failed', 'dictus.lastError': 'Enregistrement interrompu. Réessayez.'}
```

`recordingHeartbeat` is gone. The French string is the one that reached the shared error key, so the localisation is real and not just present in the catalogue.

`.transcribing` behaves the same:

```
[2026-08-03T14:00:50Z] WARNING [dictation] <APP> dictationStateReconciled source=app-launch staleStatus=transcribing heartbeatAgeMs=-1
```

**The negative control, which is the one that matters most.** Seeded `.requested` **plus a 600 s-old heartbeat** — the exact shape that would break every cold-start dictation if the guard were wrong:

```
[2026-08-03T14:00:22Z] INFO    [lifecycle] <APP> appLaunched version=1.8.0
        (no dictationStateReconciled line)
{'dictus.dictationStatus': 'requested', 'dictus.recordingHeartbeat': 1785765017.499578}
```

Status and heartbeat untouched. The cold-start path is not disturbed.

## What I could NOT verify

Plainly, because it matters more than the green checks above.

- **The reported failure itself is unverifiable by me.** It needs force-quitting DictusApp from the app switcher mid-dictation on a device. A simulator cannot reproduce a jetsam kill faithfully, and it cannot even enable the Dictus keyboard (`docs/agents/simulator.md` §7 — four documented attempts, all failed).
- **Nothing keyboard-side has been executed at all.** `KeyboardState` compiles and is covered by review; the predicate it consults is covered by tests. The message has never been rendered, the overlay has never been observed leaving, and the timing of "within ~1 second" is reasoned from the code path, not measured.
- **The heartbeat's cross-process propagation is assumed, not measured.** The existing watchdog already depends on exactly this and was device-validated in #106 Phase C, which is why I relied on it — but I have not watched a heartbeat cross the App Group myself.
- **Criterion 5 (a normal dictation across an app switch still completes) is entirely untested.** It is the regression that would hurt most.

## Known narrow false positive

Tapping Power in the Dynamic Island **during transcription** runs `deactivateSession()`, which stops the engine and therefore the heartbeat, while the transcription Task keeps running. About 8 s later the keyboard would declare an orphan and show "interrupted" — and then the text would arrive anyway, because insertion does not depend on the keyboard's status. Narrow (it needs a deliberate user action, mid-transcription), self-correcting, and the fail-safe direction. Recorded rather than hidden.

## Two things you should know that are not mine

- **`xcodebuild test -scheme DictusCore-Package -destination 'platform=iOS Simulator,…'` is broken on `develop`.** The scheme builds `polish-harness`, which is macOS-only by intent (`'SystemLanguageModel' is only available in iOS 26.0 or newer`) but is not excluded from iOS builds. I confirmed it by stashing my changes and re-running on a clean tree — same four failures. `swift test` is what actually runs the suite here, contrary to what the ship instructions say. Worth its own issue.
- The `.idle -> .failed` change interacts mildly with #233's no-activity suppression: a failure now moves the phase off `.idle`, so the next cycle logs one `bootstrap-fallback` line instead of one `bootstrapUnavailable` line. Same volume, different name. No flood.

## Device test protocol

**Do the smoke test first. A green build does not prove the extension launches.**

0. **Keyboard smoke.** Open any app, bring up the Dictus keyboard. It must present, type, and dictate normally. If it does not, stop here — nothing below is meaningful.

1. **The reported failure (~2 min).** Start a keyboard dictation, swipe back to the host app, then force-quit DictusApp from the app switcher while it is still recording.
   **Expect:** the recording overlay leaves within about a second, and the toolbar shows « Enregistrement interrompu. Réessayez. » in red for 3 seconds. No stop tap needed.
   **In the log:** `dictationStateReconciled source=keyboard-watchdog staleStatus=recording heartbeatAgeMs=~8000`, then `statusChanged from=recording to=idle source=keyboardState`. No `watchdogReset`.

2. **The rebuilt-keyboard variant.** Same kill, but dismiss the keyboard first and bring it back afterwards (or wait for iOS to rebuild the extension).
   **Expect:** the keyboard never shows a recording layout at all. `dictationStateReconciled source=keyboard-refresh` with a large `heartbeatAgeMs`.

3. **The stop tap (criterion 3).** Same kill, then tap stop before the reconciliation lands.
   **Expect:** something happens on the first tap. `requestStopWithoutSession storedStatus=recording liveness=orphaned` in the log, followed by the reconciliation.

4. **App relaunch after the kill.** Reopen Dictus by hand.
   **Expect:** `dictationStateReconciled source=app-launch` if the keyboard did not get there first, and nothing at all if it did.

5. **Regression, and the one I most want run (criterion 5).** Dictate normally from the keyboard, switch apps mid-dictation, come back, stop, and let it insert. Then do it two or three more times.
   **Expect:** completely unchanged behaviour. **Zero** `dictationStateReconciled` lines in the whole session. Any occurrence here is a false positive and this PR should not merge.

6. **Cold start.** Force-quit Dictus, then dictate from the keyboard so the app launches from scratch.
   **Expect:** the dictation works as today. No reconciliation line at launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AL9tgVzFmZ1nY6S5Ko3bN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when dictation is interrupted or unexpectedly terminated.
  * Automatically detects stale dictation sessions and resets them to an idle state with a temporary interruption message.
  * Prevented orphaned sessions from interfering with new dictation attempts.
  * Improved handling when stopping dictation without an active session.

* **Reliability**
  * Added heartbeat-based detection for live, stale, and unverified dictation sessions.
  * Preserved eligible dictation requests for retry after app relaunch.
  * Live Activity status can now transition from idle to failed when recovery is required.
  * Improved status-message visibility and lifecycle tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->