### PR TITLE
fix(core): evict the user dictionary by recency, so the cap stops deleting personal vocabulary (refs #304)

### DIFF
--- a/DictusCore/Sources/DictusCore/UserDictionary.swift
+++ b/DictusCore/Sources/DictusCore/UserDictionary.swift
@@ -10,6 +10,11 @@ import Foundation
 /// 2. Repetition learning: user types an unknown word multiple times → after
 ///    `repetitionThreshold` occurrences, the word is learned.
 ///
+/// HOW WORDS ARE FORGOTTEN:
+/// The dictionary is capped at `maxLearnedWords`. Past the cap the
+/// least-recently-used entries are dropped — see `shouldEvictFirst()` for why
+/// recency and not usage count.
+///
 /// WHY App Group UserDefaults:
 /// The dictionary must be shared between DictusApp and DictusKeyboard extension.
 /// UserDefaults via App Group is the simplest cross-process storage on iOS.
@@ -26,25 +31,52 @@ public final class UserDictionary {
 
     /// Key in App Group UserDefaults for the learned words dictionary.
     /// Stored as [String: Int] where key = lowercase word, value = usage count.
-    private static let storageKey = "dictus.userDictionary"
+    ///
+    /// WHY the keys are internal rather than private: the tests seed a store
+    /// through this exact key to reproduce a dictionary written by an earlier
+    /// build. Doing it that way exercises the real load path instead of adding
+    /// a test-only entry point to the production API.
+    static let storageKey = "dictus.userDictionary"
 
     /// Key for the repetition counter (words being "observed" before learning).
     /// Stored as [String: Int] where key = lowercase word, value = times typed.
-    private static let pendingKey = "dictus.userDictionary.pending"
+    static let pendingKey = "dictus.userDictionary.pending"
+
+    /// Key for the per-entry last-used timestamps.
+    /// Stored as [String: Int] where key = lowercase word, value = seconds
+    /// since 1970.
+    ///
+    /// WHY a parallel key instead of a richer value inside `storageKey`:
+    /// `storageKey` has to keep its exact [String: Int] shape. #103's iCloud
+    /// key-value merge strategy reads it as word → count and resolves conflicts
+    /// with max(count), and an older build of the app or the extension must
+    /// still decode the store it finds. Splitting recency into its own key
+    /// leaves both of those working unchanged — a reader that knows nothing
+    /// about recency simply ignores this key. It is also the cheapest shape to
+    /// serialise, which matters because `saveToDefaults()` runs on every word
+    /// boundary.
+    static let lastUsedKey = "dictus.userDictionary.lastUsed"
 
     /// Number of times an unknown word must be typed/rejected before it's learned.
     /// 1 = learn immediately. Safe now that autocorrect undo requires an intentional
     /// tap in the suggestion bar (no more accidental backspace-undo learning).
     public static let repetitionThreshold = 1
 
-    /// Maximum number of learned words. When exceeded, the least-used words
-    /// are dropped. 1000 words ≈ 30 KB in UserDefaults — negligible for memory.
+    /// Maximum number of learned words. When exceeded, the least-recently-used
+    /// words are dropped — see `shouldEvictFirst()`.
+    /// 1000 words ≈ 30 KB in UserDefaults — negligible for memory.
     /// Generous cap for personal vocabulary (names, slang, jargon, brands).
     /// Prevents unbounded growth from accidental learning over months/years.
     public static let maxLearnedWords = 1000
 
     /// In-memory cache of learned words. Synced to UserDefaults on mutation.
     private var learnedWords: [String: Int] = [:]
+
+    /// Last-used timestamp per learned word, in seconds since 1970.
+    ///
+    /// INVARIANT: every key of `learnedWords` has an entry here. The invariant
+    /// is repaired on load rather than assumed — see `stampEntriesMissingATimestamp()`.
+    private var lastUsed: [String: Int] = [:]
 
     /// Temporary counter for words being observed (not yet learned).
     private var pendingWords: [String: Int] = [:]
@@ -75,6 +107,7 @@ public final class UserDictionary {
         let key = word.lowercased()
         guard !key.isEmpty, key.count > 1 else { return }
         learnedWords[key, default: 0] += 1
+        lastUsed[key] = Self.nowStamp()
         // Remove from pending if it was being tracked
         pendingWords.removeValue(forKey: key)
         saveToDefaults()
@@ -91,6 +124,7 @@ public final class UserDictionary {
         // Already learned — just bump usage count
         if let learnedCount = learnedWords[key] {
             learnedWords[key] = learnedCount + 1
+            lastUsed[key] = Self.nowStamp()
             saveToDefaults()
             return false
         }
@@ -102,6 +136,7 @@ public final class UserDictionary {
         if pendingCount >= Self.repetitionThreshold {
             // Threshold reached — promote to learned
             learnedWords[key] = pendingCount
+            lastUsed[key] = Self.nowStamp()
             pendingWords.removeValue(forKey: key)
             saveToDefaults()
             print("[UserDictionary] Learned '\(key)' after \(Self.repetitionThreshold) uses")
@@ -116,6 +151,7 @@ public final class UserDictionary {
     public func forget(_ word: String) {
         let key = word.lowercased()
         learnedWords.removeValue(forKey: key)
+        lastUsed.removeValue(forKey: key)
         pendingWords.removeValue(forKey: key)
         saveToDefaults()
     }
@@ -124,6 +160,7 @@ public final class UserDictionary {
     /// Useful for a "Reset keyboard dictionary" option in settings.
     public func resetAll() {
         learnedWords.removeAll()
+        lastUsed.removeAll()
         pendingWords.removeAll()
         saveToDefaults()
         print("[UserDictionary] Reset — all learned words cleared")
@@ -136,27 +173,143 @@ public final class UserDictionary {
 
     // MARK: - Persistence
 
+    /// Current time as stored in `lastUsed`. Second resolution: the eviction
+    /// order only needs to tell days apart, and same-second ties have a defined
+    /// tiebreak anyway.
+    private static func nowStamp() -> Int {
+        Int(Date().timeIntervalSince1970)
+    }
+
     private func loadFromDefaults() {
         let defaults = AppGroup.defaults
         learnedWords = defaults.dictionary(forKey: Self.storageKey) as? [String: Int] ?? [:]
         pendingWords = defaults.dictionary(forKey: Self.pendingKey) as? [String: Int] ?? [:]
+        lastUsed = defaults.dictionary(forKey: Self.lastUsedKey) as? [String: Int] ?? [:]
+        stampEntriesMissingATimestamp()
+    }
+
+    /// MIGRATION RULE for entries written before recency existed: a learned word
+    /// found without a timestamp is stamped with the moment the gap was noticed,
+    /// and that stamp is persisted. In other words, **the update itself counts as
+    /// their last use.**
+    ///
+    /// WHY not "maximally old", the obvious alternative: it would put the user's
+    /// entire existing dictionary at the front of the eviction queue, so the
+    /// first overflow after shipping this change would delete their personal
+    /// vocabulary wholesale — the exact damage this change exists to stop.
+    ///
+    /// WHY the migrated cohort is still safe when it eventually gets cut: every
+    /// legacy entry shares one timestamp, so they are all ties, and ties break by
+    /// descending usage count (see `shouldEvictFirst()`). The first legacy entries
+    /// to go are therefore the most-typed ones — ordinary words the trie already
+    /// knows — and the low-count names and jargon are the last of the cohort to
+    /// go. Anything the user types after the update gets a fresh stamp and leaves
+    /// the cohort entirely.
+    ///
+    /// WHY the stamp is persisted rather than recomputed on each load: a stamp
+    /// recomputed as "now" every time would keep legacy entries permanently
+    /// fresh, so they would never age out and newer words would be evicted
+    /// instead — the policy inverted.
+    ///
+    /// WHY this runs on every load and not behind a one-shot migration flag: it
+    /// is an invariant repair, not a version step. It also covers an entry
+    /// written by an older build of the other process, which knows nothing about
+    /// `lastUsedKey`.
+    private func stampEntriesMissingATimestamp() {
+        let before = lastUsed
+        let stamp = Self.nowStamp()
+        for word in learnedWords.keys where lastUsed[word] == nil {
+            lastUsed[word] = stamp
+        }
+        // Drop stamps whose word is no longer learned, so this map cannot
+        // outgrow the dictionary it describes.
+        lastUsed = lastUsed.filter { learnedWords[$0.key] != nil }
+
+        guard lastUsed != before else { return }
+        AppGroup.defaults.set(lastUsed, forKey: Self.lastUsedKey)
+    }
+
+    /// One entry as the eviction order sees it. Materialised once per eviction so
+    /// the comparison below reads plain fields instead of hashing a string into
+    /// two dictionaries every time it runs.
+    private struct EvictionEntry {
+        let word: String
+        let count: Int
+        let used: Int
+    }
+
+    /// Whether `lhs` should be evicted before `rhs`.
+    ///
+    /// WHY recency first, not usage count: the dictionary exists to hold words
+    /// the base lexicon does not know — a colleague's name, a project name, a
+    /// technical term. Those are typed a handful of times and sit at a count of
+    /// 2 or 3, while every correctly-spelled word the user types is also learned
+    /// and climbs into the hundreds. Evicting by lowest count therefore deleted
+    /// exactly the vocabulary the feature protects and kept the words that never
+    /// needed protecting (#304). Recency is what AOSP LatinIME protects too
+    /// (`EntryInfoToTurncate::Comparator`).
+    ///
+    /// WHY the count tiebreak runs DESCENDING, the opposite of AOSP's: a learned
+    /// word's only effect here is that autocorrect leaves it alone
+    /// (`TextPredictionEngine.spellCheck`, the single read site of `isLearned`).
+    /// A word with a high count is almost certainly an ordinary word the trie
+    /// already knows, so dropping it changes nothing the user can observe — the
+    /// trie still spells it and autocorrect still leaves it alone. Dropping a
+    /// name typed twice is what the user notices. Between two entries of equal
+    /// recency, the most-typed one is the cheapest to lose.
+    ///
+    /// The final comparison on the word itself only makes the order total, so
+    /// the same dictionary always evicts the same entry.
+    private static func shouldEvictFirst(_ lhs: EvictionEntry, _ rhs: EvictionEntry) -> Bool {
+        if lhs.used != rhs.used { return lhs.used < rhs.used }
+        if lhs.count != rhs.count { return lhs.count > rhs.count }
+        return lhs.word < rhs.word
+    }
+
+    /// The `limit` words that should be evicted first.
+    ///
+    /// WHY repeated minimum scans and not a sort: `saveToDefaults()` runs on
+    /// every word boundary, and the dictionary overflows one word at a time, so
+    /// `limit` is 1 in normal use. That makes this a single O(n) pass over the
+    /// entries, where sorting the whole dictionary to read one element off the
+    /// front is O(n log n). A larger `limit` only happens if something dumps many
+    /// entries at once, and O(n · limit) is still acceptable there.
+    private func evictionCandidates(limit: Int) -> [String] {
+        // `?? 0` is unreachable by construction: every learned word is stamped on
+        // load and on every mutation. Treating an unstamped entry as the oldest
+        // possible is the safe reading if that ever breaks — it only affects
+        // which word is dropped, never correctness.
+        var remaining = learnedWords.map {
+            EvictionEntry(word: $0.key, count: $0.value, used: lastUsed[$0.key] ?? 0)
+        }
+        var candidates: [String] = []
+        while candidates.count < limit, !remaining.isEmpty {
+            var worstIndex = 0
+            for index in 1..<remaining.count where Self.shouldEvictFirst(remaining[index], remaining[worstIndex]) {
+                worstIndex = index
+            }
+            candidates.append(remaining[worstIndex].word)
+            remaining.remove(at: worstIndex)
+        }
+        return candidates
     }
 
     private func saveToDefaults() {
-        // Evict least-used words if we exceed the cap.
+        // Evict least-recently-used words if we exceed the cap.
         // Keeps the dictionary bounded so it can't grow indefinitely from
-        // accidental learning. Drops the words with the lowest usage count.
+        // accidental learning.
         if learnedWords.count > Self.maxLearnedWords {
-            let sorted = learnedWords.sorted { $0.value < $1.value }
             let toRemove = learnedWords.count - Self.maxLearnedWords
-            for (key, _) in sorted.prefix(toRemove) {
+            for key in evictionCandidates(limit: toRemove) {
                 learnedWords.removeValue(forKey: key)
+                lastUsed.removeValue(forKey: key)
             }
-            print("[UserDictionary] Evicted \(toRemove) least-used words (cap: \(Self.maxLearnedWords))")
+            print("[UserDictionary] Evicted \(toRemove) least-recently-used words (cap: \(Self.maxLearnedWords))")
         }
 
         let defaults = AppGroup.defaults
         defaults.set(learnedWords, forKey: Self.storageKey)
+        defaults.set(lastUsed, forKey: Self.lastUsedKey)
         defaults.set(pendingWords, forKey: Self.pendingKey)
     }
 

--- a/DictusCore/Tests/DictusCoreTests/UserDictionaryTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/UserDictionaryTests.swift
@@ -84,4 +84,206 @@ final class UserDictionaryTests: XCTestCase {
         XCTAssertFalse(UserDictionary.shared.recordUsage("a"))
         XCTAssertEqual(UserDictionary.shared.count, 0)
     }
+
+    // MARK: - Seeding a store (#304)
+
+    /// WHY the tests write App Group UserDefaults directly instead of calling
+    /// `learn()`: the eviction order turns on last-used timestamps, and
+    /// `nowStamp()` has second resolution, so a test that learned its words
+    /// normally would stamp all of them within the same second and could never
+    /// tell a recent entry from an old one. Seeding the store and calling
+    /// `reload()` also exercises the real load path, which is where the
+    /// migration rule lives.
+    ///
+    /// Pass `lastUsed: nil` to seed a store written before recency existed.
+    private func seedStore(words: [String: Int], lastUsed: [String: Int]?) {
+        let defaults = AppGroup.defaults
+        defaults.set(words, forKey: UserDictionary.storageKey)
+        defaults.removeObject(forKey: UserDictionary.pendingKey)
+        if let lastUsed {
+            defaults.set(lastUsed, forKey: UserDictionary.lastUsedKey)
+        } else {
+            defaults.removeObject(forKey: UserDictionary.lastUsedKey)
+        }
+        UserDictionary.shared.reload()
+    }
+
+    private var persistedTimestamps: [String: Int] {
+        AppGroup.defaults.dictionary(forKey: UserDictionary.lastUsedKey) as? [String: Int] ?? [:]
+    }
+
+    private static let now = Int(Date().timeIntervalSince1970)
+    private static let aMinuteAgo = now - 60
+    private static let tenDaysAgo = now - 10 * 86_400
+    private static let threeHundredDaysAgo = now - 300 * 86_400
+
+    /// `count` filler words, named so they never collide with the words a test
+    /// makes assertions about.
+    private func fillers(count: Int, usageCount: Int) -> [String: Int] {
+        var words: [String: Int] = [:]
+        for index in 0..<count {
+            words["filler\(index)"] = usageCount
+        }
+        return words
+    }
+
+    private func stamp(_ words: [String: Int], at time: Int) -> [String: Int] {
+        words.mapValues { _ in time }
+    }
+
+    // MARK: - Eviction order (#304)
+
+    /// AC 1: overflowing the cap no longer removes entries chosen by lowest count.
+    /// "kubernetes" has the lowest usage count in the store by a wide margin —
+    /// under the old ascending-count policy it was guaranteed to be the first
+    /// word deleted. It is also the most recently used, so it must survive.
+    func testEvictionKeepsTheLowestCountWordWhenItIsTheMostRecentlyUsed() {
+        var words = fillers(count: UserDictionary.maxLearnedWords - 1, usageCount: 500)
+        words["kubernetes"] = 1
+        var timestamps = stamp(words, at: Self.tenDaysAgo)
+        timestamps["kubernetes"] = Self.aMinuteAgo
+        seedStore(words: words, lastUsed: timestamps)
+
+        UserDictionary.shared.learn("nouveau")
+
+        XCTAssertEqual(UserDictionary.shared.count, UserDictionary.maxLearnedWords)
+        XCTAssertTrue(
+            UserDictionary.shared.isLearned("kubernetes"),
+            "The lowest-count word was the most recently used, so it must not be the one evicted"
+        )
+    }
+
+    /// AC 2: an entry used recently survives an eviction that removes an entry
+    /// not used for a long time, regardless of their relative counts.
+    func testEvictionRemovesTheOldestEntryEvenWhenItHasTheHighestCount() {
+        var words = fillers(count: UserDictionary.maxLearnedWords - 2, usageCount: 50)
+        words["bonjour"] = 999
+        words["kubernetes"] = 2
+        var timestamps = stamp(words, at: Self.aMinuteAgo)
+        timestamps["bonjour"] = Self.tenDaysAgo
+        seedStore(words: words, lastUsed: timestamps)
+
+        UserDictionary.shared.learn("nouveau")
+
+        XCTAssertFalse(
+            UserDictionary.shared.isLearned("bonjour"),
+            "The least recently used entry is evicted even though it has the highest count"
+        )
+        XCTAssertTrue(UserDictionary.shared.isLearned("kubernetes"))
+        XCTAssertEqual(UserDictionary.shared.count, UserDictionary.maxLearnedWords)
+    }
+
+    /// The tiebreak, and the reason the migrated cohort is safe: among entries of
+    /// equal recency the most-typed one goes first, because a word with a high
+    /// count is almost certainly one the trie already knows, so losing it changes
+    /// nothing the user can observe.
+    func testEvictionBreaksATimestampTieByRemovingTheMostUsedEntry() {
+        var words = fillers(count: UserDictionary.maxLearnedWords - 2, usageCount: 100)
+        words["bonjour"] = 900
+        words["kubernetes"] = 2
+        seedStore(words: words, lastUsed: stamp(words, at: Self.aMinuteAgo))
+
+        UserDictionary.shared.learn("nouveau")
+
+        XCTAssertFalse(UserDictionary.shared.isLearned("bonjour"))
+        XCTAssertTrue(UserDictionary.shared.isLearned("kubernetes"))
+    }
+
+    // MARK: - Migration of entries written before recency existed (#304)
+
+    /// AC 3, first half: a store with no timestamps at all gets every entry
+    /// stamped as of the moment the gap was noticed, and the stamps are written
+    /// back — not recomputed on each load, which would keep legacy entries
+    /// permanently fresh and invert the policy.
+    func testLoadingALegacyStoreStampsEveryEntryAsOfTheUpdate() {
+        let words = ["kubernetes": 2, "bonjour": 900, "zorglub": 3]
+        seedStore(words: words, lastUsed: nil)
+
+        let stamps = persistedTimestamps
+        XCTAssertEqual(Set(stamps.keys), Set(words.keys), "Every learned word must carry a stamp")
+        XCTAssertEqual(Set(stamps.values).count, 1, "The legacy entries form one cohort of equal recency")
+
+        let elapsed = Self.now - (stamps["kubernetes"] ?? 0)
+        XCTAssertTrue(
+            (-5...60).contains(elapsed),
+            "The stamp must be the moment of the update, not the epoch (elapsed: \(elapsed)s)"
+        )
+    }
+
+    /// AC 3, and the constraint the migration rule exists to satisfy: shipping
+    /// this change must not wipe a user's existing personal vocabulary on the
+    /// first eviction. The seeded store is what a real install looks like — a
+    /// mass of ordinary words with high counts plus a couple of personal words
+    /// with low ones — and 100 evictions later the personal words are still there.
+    ///
+    /// This holds whether the new words are stamped later than the migration
+    /// cohort or in the very same second: if later, the cohort is evicted oldest
+    /// first; if tied, the descending-count tiebreak takes the common words first.
+    /// Either way the low-count personal entries are last in line.
+    func testTheFirstEvictionsAfterMigrationRemoveCommonWordsAndKeepPersonalOnes() {
+        var words: [String: Int] = [:]
+        for index in 0..<(UserDictionary.maxLearnedWords - 2) {
+            words["common\(index)"] = 100 + index
+        }
+        words["kubernetes"] = 2
+        words["zorglub"] = 3
+        seedStore(words: words, lastUsed: nil)
+
+        for index in 0..<100 {
+            UserDictionary.shared.learn("nouveau\(index)")
+        }
+
+        XCTAssertEqual(UserDictionary.shared.count, UserDictionary.maxLearnedWords)
+        XCTAssertTrue(UserDictionary.shared.isLearned("kubernetes"), "Personal vocabulary must survive")
+        XCTAssertTrue(UserDictionary.shared.isLearned("zorglub"), "Personal vocabulary must survive")
+        XCTAssertFalse(
+            UserDictionary.shared.isLearned("common997"),
+            "The highest-count entry of the migrated cohort is the first to go"
+        )
+    }
+
+    /// AC 3, the rejected alternative made explicit: migrated entries are treated
+    /// as used at the update, NOT as maximally old. "legacy" arrives without a
+    /// stamp and "ancient" arrives with a genuinely old one — the genuinely old
+    /// one is what gets evicted. Had migration meant "maximally old", "legacy"
+    /// would have gone first.
+    func testAMigratedEntryOutranksAnEntryThatIsGenuinelyOld() {
+        var words = fillers(count: UserDictionary.maxLearnedWords - 2, usageCount: 100)
+        words["legacy"] = 5
+        words["ancient"] = 5
+        var timestamps = stamp(words, at: Self.aMinuteAgo)
+        timestamps["ancient"] = Self.threeHundredDaysAgo
+        timestamps.removeValue(forKey: "legacy")
+        seedStore(words: words, lastUsed: timestamps)
+
+        UserDictionary.shared.learn("nouveau")
+
+        XCTAssertFalse(UserDictionary.shared.isLearned("ancient"))
+        XCTAssertTrue(
+            UserDictionary.shared.isLearned("legacy"),
+            "An entry migrated on load counts as used at the update, not as maximally old"
+        )
+    }
+
+    // MARK: - Timestamp bookkeeping (#304)
+
+    func testForgettingAWordAlsoDropsItsTimestamp() {
+        UserDictionary.shared.learn("zorglub")
+        XCTAssertNotNil(persistedTimestamps["zorglub"])
+
+        UserDictionary.shared.forget("zorglub")
+
+        XCTAssertNil(persistedTimestamps["zorglub"])
+    }
+
+    /// A stamp whose word is no longer learned is dropped on load, so the
+    /// timestamp map cannot outgrow the dictionary it describes.
+    func testLoadingPrunesStampsForWordsThatAreNoLongerLearned() {
+        seedStore(
+            words: ["zorglub": 3],
+            lastUsed: ["zorglub": Self.aMinuteAgo, "ghost": Self.aMinuteAgo]
+        )
+
+        XCTAssertEqual(Set(persistedTimestamps.keys), ["zorglub"])
+    }
 }

--- a/DictusCore/Tests/DictusCoreTests/UserDictionaryWriteCostTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/UserDictionaryWriteCostTests.swift
@@ -1,0 +1,72 @@
+// DictusCore/Tests/DictusCoreTests/UserDictionaryWriteCostTests.swift
+// Measures what a word-boundary write costs when the dictionary sits at its cap.
+import XCTest
+@testable import DictusCore
+
+/// WHY this exists: `saveToDefaults()` re-serialises the whole dictionary on
+/// every word boundary, so it is on the typing hot path. #304 added a second
+/// persisted map (the last-used timestamps), and the acceptance criterion is
+/// that a dictionary at the cap still writes within the same order of magnitude
+/// of time. That is a measurement, not something an assertion can settle.
+///
+/// WHY the tests assert nothing about the elapsed time: absolute timings depend
+/// on the machine, so a threshold here would either be meaningless or flaky.
+/// They print the number and assert the structural invariant instead. To compare
+/// against a revision, run this file on both:
+///
+///     cd DictusCore && swift test --filter UserDictionaryWriteCostTests
+final class UserDictionaryWriteCostTests: XCTestCase {
+
+    private let iterations = 200
+
+    override func setUp() {
+        super.setUp()
+        UserDictionary.shared.resetAll()
+    }
+
+    override func tearDown() {
+        UserDictionary.shared.resetAll()
+        super.tearDown()
+    }
+
+    private func fillToCap() {
+        for index in 0..<UserDictionary.maxLearnedWords {
+            UserDictionary.shared.learn("perfword\(index)")
+        }
+        XCTAssertEqual(UserDictionary.shared.count, UserDictionary.maxLearnedWords)
+    }
+
+    private func measureWrites(_ label: String, _ body: (Int) -> Void) {
+        let start = CFAbsoluteTimeGetCurrent()
+        for index in 0..<iterations {
+            body(index)
+        }
+        let elapsed = CFAbsoluteTimeGetCurrent() - start
+        let perWrite = elapsed / Double(iterations) * 1000
+        print("MEASURE \(label): \(iterations) writes in \(elapsed)s -> \(perWrite) ms/write")
+    }
+
+    /// The common case: the dictionary is at the cap and the user types a word it
+    /// already knows. No eviction fires; this is the plain serialisation cost.
+    func testSteadyStateWriteAtTheCap() {
+        fillToCap()
+
+        measureWrites("steady-state") { _ in
+            UserDictionary.shared.recordUsage("perfword0")
+        }
+
+        XCTAssertEqual(UserDictionary.shared.count, UserDictionary.maxLearnedWords)
+    }
+
+    /// The overflow case: every write adds a new word, exceeds the cap and runs
+    /// one eviction. This is the path the ordering change lands on.
+    func testEvictingWriteAtTheCap() {
+        fillToCap()
+
+        measureWrites("evicting") { index in
+            UserDictionary.shared.learn("overflowword\(index)")
+        }
+
+        XCTAssertEqual(UserDictionary.shared.count, UserDictionary.maxLearnedWords)
+    }
+}


### PR DESCRIPTION
## What this was for

The user dictionary caps itself at 1000 learned words and, on overflow, deleted the entries with the **lowest usage count**. That is backwards for this feature. The dictionary exists to hold the words the base lexicon does not know — a colleague's name, a project name, a technical term — and those are typed a handful of times, so they sit at a count of 2 or 3. Meanwhile every correctly-spelled word the user types is also learned and climbs into the hundreds.

So reaching the cap deleted exactly the vocabulary the feature protects and kept the dictionary words that never needed protecting. Concretely, the damage was not a lost suggestion: a learned word's only runtime effect is that autocorrect leaves it alone, so a name **starts being autocorrected again** once the user has typed enough other words to fill the cap.

Found while researching #287 (`docs/research/287-user-dictionary-learning.md` §1.4), split out because it depends on none of #287's open decisions.

## To test by hand

The simulator provably cannot enable this keyboard (`docs/agents/simulator.md` §7, established by experiment), so everything below needs a device. The important one is 1: it is the criterion no test can settle, because it needs a real **upgrade** over an existing install, not a fresh install.

1. **An existing install's learned vocabulary survives the update.** On a device that already has Dictus with a real learned dictionary, note the number shown on the Settings button "Forget N learned words" **before** updating. Install this branch **over** the existing app — do not delete it first, and do not use a fresh install. Reopen Settings. The number must be the same. Nothing should have been forgotten by the update itself.
2. **A learned name still bypasses autocorrect after the update.** Same install, same session: type a personal word the keyboard had already learned (a name, a project name). It must not be autocorrected.
3. **Typing feels the same at a full dictionary.** Type a few normal sentences with the keyboard. There must be no new hesitation or lag on the space key. The write cost was measured (see below), but only a device can say whether it is felt.
4. **Reset still works.** Settings → "Reset learned words" → confirm. The count goes to 0, and a word the keyboard had learned starts being autocorrected again.
5. **Learning still works after a reset.** Type an unusual word once, then type it again in a context where autocorrect would have changed it. It must be left alone.

## What changed and why

`DictusCore/Sources/DictusCore/UserDictionary.swift`

- **Eviction orders by ascending last-used timestamp**, the way AOSP LatinIME does (`EntryInfoToTurncate::Comparator`). The usage count survives only as a tiebreak.
- **The count tiebreak runs descending, the opposite of AOSP's.** Deliberate, and it rests on the same fact that makes this a bug: a learned word's only effect here is autocorrect immunity (`TextPredictionEngine.swift:165`, the single read site of `isLearned`). A word with a high count is almost certainly an ordinary word the trie already spells, so dropping it changes nothing the user can observe — the trie still knows it and autocorrect still leaves it alone. Dropping a name typed twice is what the user notices. Between two entries of equal recency, the most-typed one is the cheapest to lose.
- **Recency lives in its own App Group key** (`dictus.userDictionary.lastUsed`, `[String: Int]` word → epoch seconds) rather than inside the learned-words value. `dictus.userDictionary` keeps its exact `[String: Int]` shape, so #103's iCloud KVS `max(count)` merge reads it unchanged, an older build of either process still decodes the store it finds, and the hot-path serialisation stays two flat plists instead of 1000 nested objects.
- **Eviction picks candidates by repeated minimum scans instead of sorting.** `saveToDefaults()` runs on every word boundary and the dictionary overflows one word at a time, so this is a single O(n) pass where sorting the whole dictionary to read one element off the front was measurably slower (2.6 ms/write vs 0.8; see the measurement below).

## The migration rule, and why

**A learned word found without a timestamp is stamped with the moment the gap was noticed, and the stamp is persisted. The update itself counts as their last use.**

- **Not "maximally old"**, the obvious alternative: that would put a user's entire existing dictionary at the front of the eviction queue, so the first overflow after shipping would delete their personal vocabulary wholesale — the exact damage this change exists to stop.
- **The migrated cohort is still safe when it does get cut.** Every legacy entry shares one timestamp, so they are all ties, and ties break by descending count. The first legacy entries to go are the most-typed ones, and the low-count names and jargon are the last of the cohort to go. Anything the user types after the update gets a fresh stamp and leaves the cohort entirely.
- **The stamp is persisted, not recomputed on each load.** A stamp recomputed as "now" every time would keep legacy entries permanently fresh, so they would never age out and newer words would be evicted instead — the policy inverted.
- **It runs on every load, not behind a one-shot migration flag.** It is an invariant repair ("every learned word carries a stamp"), not a version step, so it also covers an entry written by an older build of the other process.

## Acceptance criteria

Commands: `cd DictusCore && swift test`, then `swiftlint lint --strict` from the repo root.

| # | Criterion | Status | Evidence |
|---|---|---|---|
| 1 | Overflow no longer removes entries chosen by lowest usage count | Met | `testEvictionKeepsTheLowestCountWordWhenItIsTheMostRecentlyUsed` — the lowest-count word in the store is the most recent and survives. Confirmed discriminating: with the comparator temporarily reverted to ascending count, this test and the two below fail. |
| 2 | A recently used entry survives an eviction that removes a long-unused one, regardless of counts | Met | `testEvictionRemovesTheOldestEntryEvenWhenItHasTheHighestCount` — count 999 and stale is evicted, count 2 and recent survives. |
| 3 | Entries written before this change are handled by a stated, tested migration rule | Met | Rule stated above and in the code comment on `stampEntriesMissingATimestamp()`. Three tests: `testLoadingALegacyStoreStampsEveryEntryAsOfTheUpdate`, `testTheFirstEvictionsAfterMigrationRemoveCommonWordsAndKeepPersonalOnes` (1000 legacy entries, 100 evictions, personal words still there), `testAMigratedEntryOutranksAnEntryThatIsGenuinelyOld` (the rejected "maximally old" reading made explicit). |
| 4 | A dictionary at the cap still writes within the same order of magnitude of time | Met | Measured on this machine, 200 writes at the 1000-word cap, before vs after. Steady state (no eviction): **0.38–0.40 → 0.53–0.61 ms/write**. Overflow (one eviction per write): **0.46–0.47 → 0.54–1.10 ms/write**. Reproduce with `swift test --filter UserDictionaryWriteCostTests`. |
| 5 | Unit tests cover the overflow ordering and the migration rule | Met | 8 new tests in `UserDictionaryTests.swift`. Whole package: 628 tests, 0 failures, 1 skipped (the pre-existing below-threshold skip). |

Build, from the worktree root: `xcodebuild -resolvePackageDependencies` → `./scripts/patch-fluidaudio-swift5.sh build/DerivedData` → `xcodebuild build -scheme DictusApp -destination 'generic/platform=iOS Simulator'` → **BUILD SUCCEEDED**, with `DictusKeyboard.appex` and `DictusWidgets.appex` embedded and validated. `swiftlint lint --strict`: 0 violations in 161 files.

App-side launch smoke, headless: installed on the iPhone 17 simulator, `simctl launch` returned a pid and the process was still alive 6 seconds later. That is a launch smoke and nothing more — it does not exercise the keyboard, which the simulator cannot enable.

## Things worth flagging

- **LRU does not by itself stop the cap filling with ordinary words.** Learning fires on every word the pipeline evaluated and declined to correct, so correctly-spelled common words keep arriving and keep getting refreshed by ordinary typing. This change stops the cap deleting the *right* words; it does not stop the *wrong* words arriving. That is #287, explicitly out of scope here.
- **The count tiebreak deviates from AOSP**, which breaks ties by keeping the higher count. The reasoning for inverting it is above and in the code; it is the one place this does not simply follow the prior art.
- **Timestamps have second resolution.** Words typed within the same second are ties, resolved by the count tiebreak and then by the word itself so the order is total and the same dictionary always evicts the same entry.
- No consumer outside `UserDictionary.swift` reads the persisted schema today — verified by grep. The storage keys became internal rather than private so the tests can seed a legacy store through the real load path instead of adding a test-only entry point to the production API.

Refs #304.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved learned-word management with recency-based storage.
  * When the dictionary reaches capacity, least recently used words are removed first, with usage frequency used to resolve ties.
  * Personal vocabulary is preserved during automatic cleanup.
  * Existing dictionaries are upgraded automatically, with outdated tracking data cleaned up.

* **Bug Fixes**
  * Improved consistency when words are learned, used, forgotten, or dictionary data is reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->