### PR TITLE
Distinguish the LLM processing stage from transcription (refs #267)

### DIFF
--- a/DictusApp/DictationCoordinator.swift
+++ b/DictusApp/DictationCoordinator.swift
@@ -402,15 +402,26 @@ class DictationCoordinator: ObservableObject {
         // Configure audio session NOW while we're in the foreground.
         try? audioEngine.configureAudioSession()
 
+        // The session these start paths belong to. `ensureMicrophonePermission` is
+        // an await even when permission is already granted, so a cancel queued on
+        // the main actor can land between here and the first write below (#267).
+        let session = sessionGeneration.current
+
         if audioEngine.isEngineRunning {
             // WARM START: engine already running → purge + record (instant)
             dictationTask = Task {
                 do {
                     let hasPermission = try await audioEngine.ensureMicrophonePermission()
                     guard hasPermission else {
+                        guard mayReport(session, "permission denial") else { return }
                         handleError("Microphone permission denied")
                         return
                     }
+                    // Before `startRecording`, not merely before the status write:
+                    // a cancelled start that reached the engine would leave the mic
+                    // capturing for a dictation the user called off -- the orphaned
+                    // engine of #60, arrived at from the other end.
+                    guard mayReport(session, "warm start") else { return }
                     updateStatus(.recording)
                     LiveActivityManager.shared.transitionToRecording()
                     try audioEngine.startRecording()
@@ -419,6 +430,7 @@ class DictationCoordinator: ObservableObject {
                     await verifyAudioFlow()
                 } catch {
                     PersistentLog.log(.dictationFailed(error: "Warm start: \(error.localizedDescription)"))
+                    guard mayReport(session, "warm start failure") else { return }
                     handleError(error.localizedDescription)
                 }
             }
@@ -440,9 +452,11 @@ class DictationCoordinator: ObservableObject {
                 do {
                     let hasPermission = try await audioEngine.ensureMicrophonePermission()
                     guard hasPermission else {
+                        guard mayReport(session, "permission denial") else { return }
                         handleError("Microphone permission denied")
                         return
                     }
+                    guard mayReport(session, "cold start") else { return }
                     try audioEngine.startRecording()
                     updateStatus(.recording)
                     LiveActivityManager.shared.transitionToRecording()
@@ -458,7 +472,13 @@ class DictationCoordinator: ObservableObject {
                     self.setModelLoadState(.ready, reason: "cold-start-success")
                 } catch {
                     PersistentLog.log(.dictationFailed(error: "Cold start engine load: \(error.localizedDescription)"))
+                    // The model load runs inside this task and takes seconds on a
+                    // cold start, so this is the widest window in the app for a
+                    // cancel to arrive mid-flight. `setModelLoadState` stays ungated
+                    // on purpose: it describes the model, which outlives any one
+                    // dictation, and the next session needs it to be accurate.
                     self.setModelLoadState(.idle, reason: "cold-start-failed")
+                    guard self.mayReport(session, "cold start failure") else { return }
                     self.handleError(error.localizedDescription)
                 }
             }
@@ -559,8 +579,14 @@ class DictationCoordinator: ObservableObject {
                     raw: rawText,
                     languagePolicy: languagePolicy,
                     recordingDuration: audioDuration,
+                    // Gated like every other write this task makes: the callback
+                    // fires from inside `polish`, which a cancel does not interrupt,
+                    // so an abandoned dictation would otherwise reopen the keyboard
+                    // overlay on "Traitement..." and drive the Live Activity into a
+                    // stage it had already left (#267).
                     onEngineWillRun: { [weak self] in
-                        self?.updateStatus(.processing)
+                        guard let self, self.mayReport(session, "processing stage") else { return }
+                        self.updateStatus(.processing)
                         LiveActivityManager.shared.transitionToProcessing()
                     }
                 )
@@ -870,6 +896,25 @@ class DictationCoordinator: ObservableObject {
     /// otherwise, and the device log is how this class of bug gets diagnosed here.
     /// The signature to look for afterwards is the absence of rejected Live Activity
     /// transitions following a clean abandon.
+    ///
+    /// ### What is deliberately NOT gated, and why
+    ///
+    /// Every `await` in a session-owned task is a place a cancel can land, but not
+    /// every continuation past one publishes session state. These were each checked
+    /// rather than gated by reflex:
+    ///
+    /// - `verifyAudioFlow()` already opens with `guard status == .recording`, and an
+    ///   abandoned session is `.idle` by then. Its engine restart is unreachable
+    ///   after a cancel.
+    /// - `setModelLoadState(...)` describes the *model*, which outlives any one
+    ///   dictation. Suppressing it would leave the next session reading a load state
+    ///   that never happened.
+    /// - `schedulePolishPrewarm()` warms a model and publishes nothing.
+    /// - The stage watchdog re-checks `self.status` against the status it was armed
+    ///   for before it fires.
+    /// - `pendingColdStartDictation` is retried from `didBecomeActive` only when the
+    ///   App Group still reads `.requested`; a cancel writes `.idle` first, so the
+    ///   deferred start does not resurrect.
     private func mayReport(_ session: Int, _ what: String) -> Bool {
         guard sessionGeneration.mayReport(from: session) else {
             PersistentLog.log(.dictationDeferred(

--- a/DictusApp/DictationCoordinator.swift
+++ b/DictusApp/DictationCoordinator.swift
@@ -615,6 +615,13 @@ class DictationCoordinator: ObservableObject {
         SoundFeedbackService.playRecordCancel()
         // Return Dynamic Island to standby (cancel = no transcription, go back to "On")
         Task { await LiveActivityManager.shared.returnToStandby() }
+        // `returnToStandby` only comes back from .recording/.ready/.failed, and the
+        // recording watchdog below only unsticks .recording -- so a dictation
+        // abandoned inside a post-recording stage had no path home at all, and the
+        // pill stayed on that stage and rejected the next dictation (#267 review).
+        // The two calls are mutually exclusive by their own guards, so the order
+        // between them does not matter.
+        LiveActivityManager.shared.recoverFromAbandonedStage()
         // Arm watchdog: safety net if returnToStandby's guard rejects.
         LiveActivityManager.shared.startRecordingWatchdog()
         updateStatus(.idle)

--- a/DictusApp/DictationCoordinator.swift
+++ b/DictusApp/DictationCoordinator.swift
@@ -61,11 +61,14 @@ class DictationCoordinator: ObservableObject {
     /// `schedulePolishPrewarm()`.
     private var polishPrewarmTask: Task<Void, Never>?
 
-    /// Incremented each time a new dictation actually starts (issue #60).
-    /// Delayed UI closures (RecordingView dismiss/auto-advance) capture the current
-    /// value and bail out if a newer session started before they fire, so a stale
-    /// reset can never tear down a fresh recording.
-    private(set) var dictationGeneration = 0
+    /// Which dictation the app is currently in. Moves when one starts and when one
+    /// is abandoned -- see `DictationSessionGeneration` for why both matter.
+    private var sessionGeneration = DictationSessionGeneration()
+
+    /// The generation delayed UI closures capture (issue #60). RecordingView's
+    /// dismiss and onboarding auto-advance bail out when it has moved on, so a
+    /// stale reset can never tear down a fresh recording.
+    var dictationGeneration: Int { sessionGeneration.current }
 
     /// Set when cold start dictation is deferred because the app is .inactive.
     /// Cleared in didBecomeActive when the retry happens.
@@ -338,8 +341,9 @@ class DictationCoordinator: ObservableObject {
             return
         }
 
-        // New session supersedes any pending delayed reset (issue #60).
-        dictationGeneration += 1
+        // New session supersedes any pending delayed reset (issue #60) and any
+        // outstanding work from the previous one (#267).
+        sessionGeneration.beginSession()
 
         // WHY this early return (only for Darwin notification path, NOT URL scheme):
         // iOS forbids starting an audio engine from background. If the engine isn't
@@ -490,12 +494,17 @@ class DictationCoordinator: ObservableObject {
         // The recording is ending; the prewarm (if it hasn't fired) is moot.
         polishPrewarmTask?.cancel()
 
+        // The session this run belongs to. Every write it makes below is gated on
+        // still being that session (#267) -- see `mayReport`.
+        let session = sessionGeneration.current
+
         dictationTask = Task {
             defer { self.isTranscribingInFlight = false }
             do {
                 let samples = audioEngine.collectSamples()
 
                 guard !samples.isEmpty else {
+                    guard mayReport(session, "empty recording") else { return }
                     handleError("No audio recorded")
                     return
                 }
@@ -504,6 +513,7 @@ class DictationCoordinator: ObservableObject {
 
                 guard audioDuration >= minimumRecordingDuration else {
                     PersistentLog.log(.recordingTooShort(durationMs: Int(audioDuration * 1000)))
+                    guard mayReport(session, "short recording") else { return }
                     handleError("Recording too short")
                     return
                 }
@@ -570,6 +580,13 @@ class DictationCoordinator: ObservableObject {
                     finalText = text + ". "
                 }
 
+                // The gate that matters most. Everything below is irreversible from
+                // the user's point of view: it writes the transcription to the App
+                // Group and posts `transcriptionReady`, which is what makes the
+                // keyboard type it into their document. A dictation the user
+                // cancelled must not insert text a few seconds later (#267).
+                guard mayReport(session, "transcription result") else { return }
+
                 // Write result to App Group
                 lastResult = finalText
                 status = .ready
@@ -591,6 +608,11 @@ class DictationCoordinator: ObservableObject {
                 if #available(iOS 14.0, *) {
                     DictusLogger.app.error("Transcription failed: \(error.localizedDescription, privacy: .public)")
                 }
+                // A cancelled task lands here, and so does one that failed for its
+                // own reasons after the session ended. Either way the failure
+                // belongs to a dictation that is over: writing `.failed` re-presents
+                // the recording screen the user just dismissed (#267).
+                guard mayReport(session, "transcription failure") else { return }
                 handleError(error.localizedDescription)
             }
         }
@@ -599,6 +621,12 @@ class DictationCoordinator: ObservableObject {
     /// Cancel the current dictation without transcribing.
     /// Called when the keyboard sends a cancel signal via Darwin notification.
     func cancelDictation() {
+        // FIRST, before anything is cancelled: from here on, the transcription task
+        // is working for a session that no longer exists and may not report (#267).
+        // `Task.cancel()` below is only a request -- neither WhisperKit nor Apple FM
+        // promises to return promptly -- so the task can still finish seconds from
+        // now, and this is what makes its outcome land nowhere.
+        sessionGeneration.abandonSession()
         dictationTask?.cancel()
         dictationTask = nil
         // Reset the transcribe re-entry flag so the next stop/cancel cycle can proceed.
@@ -668,6 +696,10 @@ class DictationCoordinator: ObservableObject {
             return
         }
 
+        // Same reasoning as `cancelDictation`: this teardown ends the session, so
+        // the task must not report into it afterwards (#267). The `.failed` written
+        // below is this handler speaking, not the task, and is not gated.
+        sessionGeneration.abandonSession()
         dictationTask?.cancel()
         dictationTask = nil
         isTranscribingInFlight = false
@@ -825,6 +857,27 @@ class DictationCoordinator: ObservableObject {
             return []
         }
         return models
+    }
+
+    /// Whether the transcription task started under `session` may still report.
+    ///
+    /// A dictation that was abandoned -- cancelled, watchdog-reset, interrupted --
+    /// moves the generation, so work started before it silently stops here instead
+    /// of writing status, inserting text or driving the Live Activity into a session
+    /// that no longer exists (#267).
+    ///
+    /// WHY it logs rather than returning quietly: a dropped outcome is invisible
+    /// otherwise, and the device log is how this class of bug gets diagnosed here.
+    /// The signature to look for afterwards is the absence of rejected Live Activity
+    /// transitions following a clean abandon.
+    private func mayReport(_ session: Int, _ what: String) -> Bool {
+        guard sessionGeneration.mayReport(from: session) else {
+            PersistentLog.log(.dictationDeferred(
+                reason: "abandoned session dropped \(what) (gen \(session) != \(sessionGeneration.current))"
+            ))
+            return false
+        }
+        return true
     }
 
     // MARK: - Stage Watchdog

--- a/DictusApp/DictationCoordinator.swift
+++ b/DictusApp/DictationCoordinator.swift
@@ -40,11 +40,17 @@ class DictationCoordinator: ObservableObject {
     /// Used by DictusApp to detect "warm but engine-dead" state after Power button stop.
     var isEngineRunning: Bool { audioEngine.isEngineRunning }
 
-    /// Transcription timeout watchdog: fires after 30s in .transcribing state.
-    /// WHY 30s: WhisperKit transcription of a typical dictation (<60s audio) should
-    /// complete in under 10s even on older devices. 30s provides generous margin
-    /// while still catching genuinely stuck transcriptions.
-    private var transcriptionWatchdog: Timer?
+    /// Timeout watchdog for whichever post-recording stage is running.
+    ///
+    /// WHY one timer for two stages (#267): they are mutually exclusive and the
+    /// failure it catches is the same one -- a stage that never hands over, leaving
+    /// the keyboard's overlay up with nothing behind it. What differs is only how
+    /// long is too long, which `stageWatchdogTimeout(for:)` answers.
+    ///
+    /// The status it was armed for is captured by the timer's own closure, which
+    /// re-checks it before firing -- a stage that has handed over to the next one
+    /// must not be torn down by the previous one's timer.
+    private var stageWatchdog: Timer?
 
     private var whisperKit: WhisperKit?
     private var currentModelName: String?
@@ -533,10 +539,20 @@ class DictationCoordinator: ObservableObject {
 
                 // Polish layer (#141) — passes raw through when toggle off, when language
                 // detection skips, when the engine throws/cancels, or when the guardrail rejects.
+                //
+                // The status moves to `.processing` from inside the call rather than
+                // before it (#267): every one of those pass-through paths returns in
+                // about a millisecond, and announcing a stage for them would flash a
+                // label and a new animation for a single frame. `onEngineWillRun`
+                // fires only once an engine worth waiting for is about to run.
                 let text = await PolishCoordinator.shared.polish(
                     raw: rawText,
                     languagePolicy: languagePolicy,
-                    recordingDuration: audioDuration
+                    recordingDuration: audioDuration,
+                    onEngineWillRun: { [weak self] in
+                        self?.updateStatus(.processing)
+                        LiveActivityManager.shared.transitionToProcessing()
+                    }
                 )
 
                 // Append trailing separator so chained dictations don't stick together.
@@ -587,7 +603,7 @@ class DictationCoordinator: ObservableObject {
         dictationTask = nil
         // Reset the transcribe re-entry flag so the next stop/cancel cycle can proceed.
         isTranscribingInFlight = false
-        stopTranscriptionWatchdog()
+        stopStageWatchdog()
 
         // Discard samples but keep engine alive for next recording
         _ = audioEngine.collectSamples()
@@ -613,8 +629,14 @@ class DictationCoordinator: ObservableObject {
     /// Issue #60: a UI-only reset while the pipeline is active orphans the audio
     /// engine (keeps capturing) and the Live Activity (stuck on REC), so an active
     /// session must go through the real teardown instead.
+    ///
+    /// WHY the shared predicate and not a list of cases spelled out here (#267):
+    /// this asks "is a dictation in flight", which is the exact question
+    /// `isActive` answers over an exhaustive switch. A hand-written list is a list
+    /// the next status case can be left out of, silently, and this one guards a
+    /// teardown -- the same shape of omission #260 and #261 were made of.
     func resetStatus() {
-        if status == .recording || status == .transcribing || status == .requested {
+        if DictationSessionLivenessPolicy.isActive(status) {
             cancelDictation()
             return
         }
@@ -631,7 +653,8 @@ class DictationCoordinator: ObservableObject {
     /// Activity (LiveActivityManager handles its own end via the same notification).
     /// Issue #106.
     private func handleAudioInterruptionDuringDictation() {
-        let wasActive = (status == .recording || status == .requested || status == .transcribing)
+        // Same predicate as `resetStatus` and for the same reason (#267).
+        let wasActive = DictationSessionLivenessPolicy.isActive(status)
         guard wasActive else {
             // Engine died while idle — nothing to roll back. The standby DI is
             // dismissed by LiveActivityManager via the same notification.
@@ -641,7 +664,7 @@ class DictationCoordinator: ObservableObject {
         dictationTask?.cancel()
         dictationTask = nil
         isTranscribingInFlight = false
-        stopTranscriptionWatchdog()
+        stopStageWatchdog()
 
         bufferEnergy = []
         bufferSeconds = 0
@@ -745,9 +768,15 @@ class DictationCoordinator: ObservableObject {
     /// anything. It is auditing state a dead one left behind, and `status` is
     /// correctly `.idle` here.
     private func reconcileOrphanedDictationState() {
+        // WHY the cases are spelled out here and not asked of `isActive` (#267):
+        // this list is deliberately narrower. `.requested` is active but is written
+        // by the keyboard moments before it launches this app, so reconciling it at
+        // launch would kill every cold-start dictation. `.processing` belongs with
+        // `.recording` and `.transcribing`: the app that wrote it is the app that
+        // just died, so a launch finding it is finding a corpse.
         guard let raw = defaults.string(forKey: SharedKeys.dictationStatus),
               let stored = DictationStatus(rawValue: raw),
-              stored == .recording || stored == .transcribing else { return }
+              stored == .recording || stored == .transcribing || stored == .processing else { return }
 
         PersistentLog.log(.dictationStateReconciled(
             source: "app-launch",
@@ -791,23 +820,56 @@ class DictationCoordinator: ObservableObject {
         return models
     }
 
-    // MARK: - Transcription Watchdog
+    // MARK: - Stage Watchdog
 
-    private func startTranscriptionWatchdog() {
-        stopTranscriptionWatchdog()
-        transcriptionWatchdog = Timer.scheduledTimer(withTimeInterval: 30.0, repeats: false) { [weak self] _ in
+    /// How long a post-recording stage may run before it is declared stuck.
+    /// Nil for statuses no stage watchdog covers.
+    ///
+    /// WHY 30s for transcription: WhisperKit transcription of a typical dictation
+    /// (<60s audio) should complete in under 10s even on older devices. 30s provides
+    /// generous margin while still catching genuinely stuck transcriptions.
+    ///
+    /// WHY 60s for the LLM stage (#267) and not the same 30s: generation time scales
+    /// with the output, which is exactly why this stage was split out, and the cost
+    /// of firing early is higher here than during transcription -- the transcript
+    /// already exists and the recovery below throws it away with the rest of the
+    /// session. The number is a last-resort unfreeze, not a latency budget.
+    private func stageWatchdogTimeout(for status: DictationStatus) -> TimeInterval? {
+        switch status {
+        case .transcribing:
+            return 30
+        case .processing:
+            return 60
+        case .idle, .requested, .recording, .ready, .failed:
+            return nil
+        }
+    }
+
+    /// Log source for a fired stage watchdog. `appTranscription` is unchanged from
+    /// before #267 so log lines written by older builds keep meaning what they meant.
+    private func stageWatchdogSource(for status: DictationStatus) -> String {
+        status == .processing ? "appProcessing" : "appTranscription"
+    }
+
+    private func startStageWatchdog(for status: DictationStatus) {
+        stopStageWatchdog()
+        guard let timeout = stageWatchdogTimeout(for: status) else { return }
+        stageWatchdog = Timer.scheduledTimer(withTimeInterval: timeout, repeats: false) { [weak self] _ in
             guard let self = self else { return }
             DispatchQueue.main.async {
-                guard self.status == .transcribing else { return }
-                PersistentLog.log(.watchdogReset(source: "appTranscription", staleState: "transcribing"))
+                guard self.status == status else { return }
+                PersistentLog.log(.watchdogReset(
+                    source: self.stageWatchdogSource(for: status),
+                    staleState: status.rawValue
+                ))
                 self.cancelDictation()
             }
         }
     }
 
-    private func stopTranscriptionWatchdog() {
-        transcriptionWatchdog?.invalidate()
-        transcriptionWatchdog = nil
+    private func stopStageWatchdog() {
+        stageWatchdog?.invalidate()
+        stageWatchdog = nil
     }
 
     /// Write dictation status to App Group so the keyboard can observe it.
@@ -836,10 +898,14 @@ class DictationCoordinator: ObservableObject {
         defaults.set(newStatus.rawValue, forKey: SharedKeys.dictationStatus)
         defaults.synchronize()
 
-        if newStatus == .transcribing {
-            startTranscriptionWatchdog()
-        } else if oldStatus == .transcribing {
-            stopTranscriptionWatchdog()
+        // Re-arm on every stage the watchdog covers, disarm on everything else.
+        // The `.transcribing -> .processing` hand-over is the case that makes the
+        // second branch matter: leaving the transcription timer armed would let it
+        // fire 30s into a stage it knows nothing about (#267).
+        if stageWatchdogTimeout(for: newStatus) != nil {
+            startStageWatchdog(for: newStatus)
+        } else if stageWatchdogTimeout(for: oldStatus) != nil {
+            stopStageWatchdog()
         }
 
         DarwinNotificationCenter.post(DarwinNotificationName.statusChanged)

--- a/DictusApp/DictationView.swift
+++ b/DictusApp/DictationView.swift
@@ -32,6 +32,7 @@ struct DictationStatusView: View {
         case .requested: return "arrow.up.forward"
         case .recording: return "mic.fill"
         case .transcribing: return "text.bubble"
+        case .processing: return "sparkles"
         case .ready: return "checkmark.circle.fill"
         case .failed: return "exclamationmark.triangle.fill"
         }
@@ -43,6 +44,7 @@ struct DictationStatusView: View {
         case .requested: return .orange
         case .recording: return .red
         case .transcribing: return .blue
+        case .processing: return Color.dictusSmartMode
         case .ready: return .green
         case .failed: return .red
         }
@@ -54,6 +56,7 @@ struct DictationStatusView: View {
         case .requested: return "Requested"
         case .recording: return "Recording..."
         case .transcribing: return "Transcribing..."
+        case .processing: return "Processing..."
         case .ready: return "Ready"
         case .failed: return "Failed"
         }
@@ -65,6 +68,7 @@ struct DictationStatusView: View {
         case .requested: return "Opening from keyboard"
         case .recording: return "Capturing audio"
         case .transcribing: return "Processing speech"
+        case .processing: return "Running the language model"
         case .ready: return "Transcription available"
         case .failed: return "Something went wrong"
         }

--- a/DictusApp/DictusApp.swift
+++ b/DictusApp/DictusApp.swift
@@ -138,9 +138,10 @@ struct DictusApp: App {
                     case .background:
                         PersistentLog.log(.appDidEnterBackground)
 
-                        let isRecordingActive = coordinator.status == .recording
-                            || coordinator.status == .requested
-                            || coordinator.status == .transcribing
+                        // Exhaustive by construction (#267): a status added later
+                        // cannot be left out of this list and silently clear the
+                        // cold-start flag mid-dictation.
+                        let isRecordingActive = DictationSessionLivenessPolicy.isActive(coordinator.status)
 
                         // Only clear cold start state if NOT recording.
                         // During cold start, the app transitions to background while recording

--- a/DictusApp/LiveActivityManager.swift
+++ b/DictusApp/LiveActivityManager.swift
@@ -898,6 +898,53 @@ class LiveActivityManager {
         DictusLogger.app.info("Live Activity -> standby (auto-return)")
     }
 
+    /// Bring the pill home after a dictation was abandoned inside a post-recording
+    /// stage -- the stage watchdog fired, or the user cancelled while the LLM ran.
+    ///
+    /// WHY this is not just a wider guard on `returnToStandby` (#267 review): that
+    /// guard is #42's, and it is what stops a stale auto-dismiss task from a
+    /// finished dictation from stamping `.standby` over a live one. Widening it
+    /// would hand that power to every caller. This path is entered only by the
+    /// deliberate teardown in `DictationCoordinator.cancelDictation`, and it
+    /// refuses every phase except the two it exists for.
+    ///
+    /// WHY it matters that the state machine comes back too, not just the pill: a
+    /// machine left parked on `.transcribing` or `.processing` rejects the next
+    /// dictation's transition to `.recording`, so the Dynamic Island would go on
+    /// showing the stage of a dictation that ended while a new one recorded
+    /// underneath it. The visible symptom is #42 / #257; the cause here is that
+    /// nothing walked the machine back.
+    ///
+    /// This hole predates #267: on `develop` the 30 s transcription watchdog
+    /// reached the same dead end, because `returnToStandby` refused
+    /// `.transcribing` there too and no other path recovered it.
+    func recoverFromAbandonedStage() {
+        guard isEnabled else { return }
+        guard currentPhase == .transcribing || currentPhase == .processing else { return }
+
+        let abandoned = currentPhase
+
+        guard let activity = currentActivity else {
+            // No pill to drive, but the machine must not stay parked on a stage no
+            // dictation is in -- that is the half of the failure that poisons the
+            // *next* dictation, and it happens with or without an activity.
+            PersistentLog.log(.liveActivityTransition(from: abandoned.rawValue, to: "idle-abandoned"))
+            currentPhase = .idle
+            syncStateMachine(to: .idle)
+            return
+        }
+
+        guard validateTransition(to: .standby) else { return }
+
+        PersistentLog.log(.liveActivityTransition(from: abandoned.rawValue, to: "standby-abandoned"))
+        currentPhase = .standby  // Update BEFORE async work to prevent races (#49)
+        Task {
+            let state = DictusLiveActivityAttributes.ContentState(phase: .standby)
+            await activity.update(.init(state: state, staleDate: Date().addingTimeInterval(self.staleInterval)))
+            DictusLogger.app.info("Live Activity -> standby (abandoned \(abandoned.rawValue, privacy: .public))")
+        }
+    }
+
     /// Clean up stale Live Activities from previous app launches.
     /// Called at app startup to prevent zombie activities from persisting
     /// after a crash or force-quit.

--- a/DictusApp/LiveActivityManager.swift
+++ b/DictusApp/LiveActivityManager.swift
@@ -34,6 +34,7 @@ class LiveActivityManager {
         case standby    // Activity exists, waiting for user
         case recording  // Active recording
         case transcribing // Processing audio
+        case processing // Running the LLM stage on the transcript (#267)
         case ready      // Showing result (auto-dismiss pending)
         case failed     // Showing error (auto-dismiss pending)
     }
@@ -75,6 +76,7 @@ class LiveActivityManager {
         case .standby: return .standby
         case .recording: return .recording
         case .transcribing: return .transcribing
+        case .processing: return .processing
         case .ready: return .ready
         case .failed: return .failed
         }
@@ -93,6 +95,7 @@ class LiveActivityManager {
         case .standby: return .standby
         case .recording: return .recording
         case .transcribing: return .transcribing
+        case .processing: return .processing
         case .ready: return .ready
         case .failed: return .failed
         }
@@ -586,6 +589,30 @@ class LiveActivityManager {
         }
     }
 
+    /// Transition from transcribing to the LLM stage (#267).
+    ///
+    /// Called from inside `PolishCoordinator`'s engine callback, so it fires only
+    /// when a model is really about to run -- most dictations never reach it and go
+    /// straight from `.transcribing` to `.ready`, which the state machine allows.
+    func transitionToProcessing() {
+        guard isEnabled else { return }
+
+        guard validateTransition(to: .processing) else { return }
+
+        guard let activity = currentActivity else { return }
+
+        PersistentLog.log(.liveActivityTransition(from: "transcribing", to: "processing"))
+        currentPhase = .processing  // Update BEFORE async work to prevent races (#49)
+        Task {
+            let state = DictusLiveActivityAttributes.ContentState(
+                phase: .processing,
+                waveformLevels: [0.2, 0.5, 0.8, 0.5, 0.2]
+            )
+            await activity.update(.init(state: state, staleDate: Date().addingTimeInterval(self.staleInterval)))
+            DictusLogger.app.info("Live Activity -> processing")
+        }
+    }
+
     /// Show transcription result, then return to standby after 1 second.
     ///
     /// WHY return to standby instead of ending:
@@ -602,7 +629,11 @@ class LiveActivityManager {
 
         autoDismissTask?.cancel()
 
-        PersistentLog.log(.liveActivityTransition(from: "transcribing", to: "ready"))
+        // `from` is read off the current phase rather than assumed to be
+        // "transcribing": since #267 the result can arrive from either
+        // post-recording stage, and a log line that says otherwise would misreport
+        // which one the wait was spent in.
+        PersistentLog.log(.liveActivityTransition(from: currentPhase.rawValue, to: "ready"))
         currentPhase = .ready  // Update BEFORE async work to prevent races (#49)
         Task {
             let truncatedPreview = preview.map { String($0.prefix(100)) }

--- a/DictusApp/Localizable.xcstrings
+++ b/DictusApp/Localizable.xcstrings
@@ -1621,6 +1621,17 @@
         }
       }
     },
+    "Processing..." : {
+      "comment" : "Recording screen caption while the LLM stage runs on the transcript (issue #267).",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traitement en cours..."
+          }
+        }
+      }
+    },
     "Purchase Error" : {
       "localizations" : {
         "fr" : {

--- a/DictusApp/Onboarding/WelcomePage.swift
+++ b/DictusApp/Onboarding/WelcomePage.swift
@@ -19,7 +19,7 @@ struct WelcomePage: View {
             Spacer()
 
             // Smooth sinusoidal waveform — same as the transcription processing animation
-            BrandWaveform(maxHeight: 100, isProcessing: true)
+            BrandWaveform(maxHeight: 100, animation: .sweep)
                 .opacity(0.5)
                 .padding(.bottom, 24)
 

--- a/DictusApp/Polish/PolishCoordinator.swift
+++ b/DictusApp/Polish/PolishCoordinator.swift
@@ -129,9 +129,18 @@ public final class PolishCoordinator {
     /// re-reading App Group state here guarantees polish targets the same
     /// language the STT engine was given, even if the user changed the
     /// keyboard language while transcription was running.
+    ///
+    /// `onEngineWillRun` fires at most once, immediately before the engine call,
+    /// and only for engines that declare the wait worth announcing (#267). It is
+    /// how `DictationCoordinator` knows to move the dictation status to
+    /// `.processing`: every gate that can skip the model -- the toggle above, the
+    /// duration gate, the gibberish gate, a passthrough backend -- has been
+    /// cleared by the time it fires, so the state marks a wait that is really
+    /// happening rather than one that might.
     public func polish(raw: String,
                        languagePolicy: TranscriptionLanguagePolicy,
-                       recordingDuration: TimeInterval) async -> String {
+                       recordingDuration: TimeInterval,
+                       onEngineWillRun: (() -> Void)? = nil) async -> String {
         guard defaults.bool(forKey: SharedKeys.polishEnabled) else {
             return raw
         }
@@ -149,11 +158,13 @@ public final class PolishCoordinator {
         case .language(let target):
             return await polishTargeted(
                 raw: raw, target: target,
-                languagePolicy: languagePolicy, recordingDuration: recordingDuration
+                languagePolicy: languagePolicy, recordingDuration: recordingDuration,
+                onEngineWillRun: onEngineWillRun
             )
         case .autoDetected:
             return await polishAutoDetected(
-                raw: raw, languagePolicy: languagePolicy, recordingDuration: recordingDuration
+                raw: raw, languagePolicy: languagePolicy, recordingDuration: recordingDuration,
+                onEngineWillRun: onEngineWillRun
             )
         }
     }
@@ -166,7 +177,8 @@ public final class PolishCoordinator {
     private func polishTargeted(raw: String,
                                 target: SupportedLanguage,
                                 languagePolicy: TranscriptionLanguagePolicy,
-                                recordingDuration: TimeInterval) async -> String {
+                                recordingDuration: TimeInterval,
+                                onEngineWillRun: (() -> Void)?) async -> String {
         let sttEngine = languagePolicy.engine
         let sttModelID = languagePolicy.modelIdentifier
 
@@ -244,6 +256,7 @@ public final class PolishCoordinator {
         let currentEngine = activeEngine
 
         inflight?.cancel()
+        announceEngineStage(currentEngine, to: onEngineWillRun)
         // Everything above (pre-pass + detection + mode) is the preprocess cost;
         // the engine-facing transform (encode → engine → decode → guardrail) is
         // delegated to `PolishPipeline` so the eval harness runs identical code.
@@ -313,7 +326,8 @@ public final class PolishCoordinator {
     /// runs are identified by `mode == .auto` in the debug export.
     private func polishAutoDetected(raw: String,
                                     languagePolicy: TranscriptionLanguagePolicy,
-                                    recordingDuration: TimeInterval) async -> String {
+                                    recordingDuration: TimeInterval,
+                                    onEngineWillRun: (() -> Void)?) async -> String {
         let methodStart = Date()
         // Engine-API placeholder in auto mode — never used for typography or
         // guardrails (see PolishPipeline); doubles as the metrics context.
@@ -358,6 +372,7 @@ public final class PolishCoordinator {
 
         let currentEngine = activeEngine
         inflight?.cancel()
+        announceEngineStage(currentEngine, to: onEngineWillRun)
         // Pre-engine work in auto mode: detection + detected-language pre-pass.
         let preprocessMs = Int(Date().timeIntervalSince(methodStart) * 1000)
         let task = Task {
@@ -413,6 +428,15 @@ public final class PolishCoordinator {
             sttModelID: languagePolicy.modelIdentifier,
             timings: timings
         )
+    }
+
+    /// Tell the caller the LLM stage is starting, if this engine's wait is one
+    /// worth announcing (#267). Both polish paths reach the engine by different
+    /// routes and each has to make this call; the check lives here so neither can
+    /// make it differently.
+    private func announceEngineStage(_ engine: PolishEngineProtocol, to callback: (() -> Void)?) {
+        guard engine.announcesProcessingStage else { return }
+        callback?()
     }
 
     /// Log one metrics event and append it to the debug ring.

--- a/DictusApp/Views/ModelLoadingOverlay.swift
+++ b/DictusApp/Views/ModelLoadingOverlay.swift
@@ -81,7 +81,7 @@ struct ModelLoadingOverlay: View {
                 // ratios — iPad letterboxed compatibility mode, iPhone SE. Same
                 // height/opacity as the onboarding welcome screen; edge-to-edge
                 // width, no horizontal padding.
-                BrandWaveform(maxHeight: 100, isProcessing: true)
+                BrandWaveform(maxHeight: 100, animation: .sweep)
                     .opacity(0.55)
                     .allowsHitTesting(false)
 

--- a/DictusApp/Views/RecordingView.swift
+++ b/DictusApp/Views/RecordingView.swift
@@ -196,11 +196,15 @@ struct RecordingView: View {
     /// Whether the pipeline is past the microphone and working on the audio or the
     /// transcript.
     ///
-    /// WHY this screen renders both stages the same (#267): the two animations that
-    /// tell them apart live in the keyboard overlay and the Dynamic Island, which is
-    /// where the user actually is while waiting -- this screen is DictusApp in the
-    /// foreground, which during a keyboard dictation it is not. Splitting it here
-    /// would be a third design to maintain for a view nobody is looking at.
+    /// WHY this screen shares one *animation* across both stages (#267): the two
+    /// animations that tell them apart live in the keyboard overlay and the Dynamic
+    /// Island, which is where the user actually is while waiting. A third motion
+    /// design for this screen would be one more thing to keep in step.
+    ///
+    /// The *label* is not shared -- see `statusText`. Sharing the shimmer costs the
+    /// user nothing; telling them "Transcribing..." for six seconds of language
+    /// model is the whole complaint this issue is about, and it lands the same way
+    /// whichever screen it is read on.
     private var isPostRecordingStage: Bool {
         coordinator.status == .transcribing || coordinator.status == .processing
     }
@@ -213,8 +217,16 @@ struct RecordingView: View {
             Text(formattedTime)
                 .font(.system(size: 20, weight: .light, design: .monospaced))
                 .foregroundStyle(.secondary)
-        } else if isPostRecordingStage {
+        } else if coordinator.status == .transcribing {
             Text("Transcribing...")
+                .font(.dictusCaption)
+                .foregroundStyle(.secondary)
+        } else if coordinator.status == .processing {
+            // The waveform is shared between the two stages here, but the label is
+            // not: naming the wrong stage is the complaint #267 exists to fix, and
+            // it costs a user dictating inside DictusApp the same six seconds of
+            // wondering whether the app has hung.
+            Text("Processing...")
                 .font(.dictusCaption)
                 .foregroundStyle(.secondary)
         } else if showCopiedFeedback {

--- a/DictusApp/Views/RecordingView.swift
+++ b/DictusApp/Views/RecordingView.swift
@@ -186,25 +186,37 @@ struct RecordingView: View {
                 ? coordinator.bufferEnergy
                 : Array(repeating: Float(0), count: 30),
             maxHeight: 120,
-            isProcessing: isPostRecordingStage,
+            animation: waveformAnimation,
             isActive: coordinator.status == .recording || isPostRecordingStage
         )
         .opacity(coordinator.status == .recording ? 0.5 :
                  isPostRecordingStage ? 0.3 : 0.15)
     }
 
+    /// The animation for the current stage.
+    ///
+    /// This screen draws the same three animations as the keyboard overlay, from
+    /// the same `ProcessingWaveform` maths (#267). An earlier round shared one
+    /// animation across both post-recording stages, on the argument that the
+    /// distinction belongs where the user waits during a keyboard dictation. Device
+    /// testing settled it the other way: someone dictating inside DictusApp is
+    /// waiting on this screen, and it owes them the same answer.
+    private var waveformAnimation: WaveformAnimation {
+        switch coordinator.status {
+        case .recording:
+            return .micLevels
+        case .transcribing:
+            return .sweep
+        case .processing:
+            return .travellingPeak
+        case .idle, .requested, .ready, .failed:
+            return .still
+        }
+    }
+
     /// Whether the pipeline is past the microphone and working on the audio or the
-    /// transcript.
-    ///
-    /// WHY this screen shares one *animation* across both stages (#267): the two
-    /// animations that tell them apart live in the keyboard overlay and the Dynamic
-    /// Island, which is where the user actually is while waiting. A third motion
-    /// design for this screen would be one more thing to keep in step.
-    ///
-    /// The *label* is not shared -- see `statusText`. Sharing the shimmer costs the
-    /// user nothing; telling them "Transcribing..." for six seconds of language
-    /// model is the whole complaint this issue is about, and it lands the same way
-    /// whichever screen it is read on.
+    /// transcript. Drives opacity and the disabled mic button, both of which are
+    /// the same for either stage.
     private var isPostRecordingStage: Bool {
         coordinator.status == .transcribing || coordinator.status == .processing
     }

--- a/DictusApp/Views/RecordingView.swift
+++ b/DictusApp/Views/RecordingView.swift
@@ -186,11 +186,23 @@ struct RecordingView: View {
                 ? coordinator.bufferEnergy
                 : Array(repeating: Float(0), count: 30),
             maxHeight: 120,
-            isProcessing: coordinator.status == .transcribing,
-            isActive: coordinator.status == .recording || coordinator.status == .transcribing
+            isProcessing: isPostRecordingStage,
+            isActive: coordinator.status == .recording || isPostRecordingStage
         )
         .opacity(coordinator.status == .recording ? 0.5 :
-                 coordinator.status == .transcribing ? 0.3 : 0.15)
+                 isPostRecordingStage ? 0.3 : 0.15)
+    }
+
+    /// Whether the pipeline is past the microphone and working on the audio or the
+    /// transcript.
+    ///
+    /// WHY this screen renders both stages the same (#267): the two animations that
+    /// tell them apart live in the keyboard overlay and the Dynamic Island, which is
+    /// where the user actually is while waiting -- this screen is DictusApp in the
+    /// foreground, which during a keyboard dictation it is not. Splitting it here
+    /// would be a third design to maintain for a view nobody is looking at.
+    private var isPostRecordingStage: Bool {
+        coordinator.status == .transcribing || coordinator.status == .processing
     }
 
     // MARK: - Status Text
@@ -201,7 +213,7 @@ struct RecordingView: View {
             Text(formattedTime)
                 .font(.system(size: 20, weight: .light, design: .monospaced))
                 .foregroundStyle(.secondary)
-        } else if coordinator.status == .transcribing {
+        } else if isPostRecordingStage {
             Text("Transcribing...")
                 .font(.dictusCaption)
                 .foregroundStyle(.secondary)
@@ -246,9 +258,11 @@ struct RecordingView: View {
             }
             .buttonStyle(GlassPressStyle(pressedScale: 0.88))
             .accessibilityLabel("Stop recording")
-        } else if coordinator.status == .transcribing {
-            // Shimmer mic during processing (disabled)
-            AnimatedMicButton(status: .transcribing) {}
+        } else if isPostRecordingStage {
+            // Shimmer mic during processing (disabled). The status is passed
+            // through rather than pinned to `.transcribing` so the button reflects
+            // the stage it is actually in (#267); the shimmer is the same for both.
+            AnimatedMicButton(status: coordinator.status) {}
                 .disabled(true)
         } else {
             // Idle / result state: mic button ready for (new) recording

--- a/DictusCore/Sources/DictusCore/Design/AnimatedMicButton.swift
+++ b/DictusCore/Sources/DictusCore/Design/AnimatedMicButton.swift
@@ -13,9 +13,11 @@ import SwiftUI
 /// State machine:
 /// - idle/ready: soft blue glow pulsing at 2s interval
 /// - recording: red pulse ring scaling 1.0-1.3 at 0.8s interval
-/// - transcribing: blue shimmer sweep moving left-to-right at 1.5s
+/// - transcribing/processing: blue shimmer sweep moving left-to-right at 1.5s
+///   (this button is the main app's; the two stages are told apart in the keyboard
+///   overlay and the Dynamic Island, which is where the user waits -- see #267)
 /// - failed: same as idle (reset to inviting state)
-/// - Transition from transcribing to ready: brief green flash (0.3s fade)
+/// - Transition from either post-recording stage to ready: brief green flash (0.3s fade)
 public struct AnimatedMicButton: View {
     public let status: DictationStatus
     public let isPill: Bool
@@ -78,8 +80,8 @@ public struct AnimatedMicButton: View {
                     .fill(buttonFillColor)
                     .frame(width: buttonWidth, height: buttonHeight)
 
-                // Shimmer overlay for transcribing state
-                if status == .transcribing {
+                // Shimmer overlay for the two post-recording stages
+                if status == .transcribing || status == .processing {
                     shimmerOverlay
                 }
 
@@ -138,8 +140,8 @@ public struct AnimatedMicButton: View {
                 )
                 .scaleEffect(pulseScale)
 
-        case .transcribing, .requested:
-            // Static glass ring during transcription
+        case .transcribing, .processing, .requested:
+            // Static glass ring during transcription and the LLM stage
             mainShape()
                 .fill(Color.clear)
                 .frame(width: ringWidth, height: ringHeight)
@@ -181,7 +183,7 @@ public struct AnimatedMicButton: View {
         switch status {
         case .recording:
             return .dictusRecording
-        case .transcribing:
+        case .transcribing, .processing:
             return .dictusAccentHighlight.opacity(0.5)
         default:
             return .dictusAccent
@@ -211,7 +213,7 @@ public struct AnimatedMicButton: View {
         // Success flash when transitioning from transcribing to ready.
         // WHY withAnimation instead of asyncAfter: SwiftUI animates the transition
         // from true to false over 0.3s, eliminating the timer race condition.
-        if oldStatus == .transcribing && newStatus == .ready {
+        if (oldStatus == .transcribing || oldStatus == .processing) && newStatus == .ready {
             showSuccessFlash = true
             withAnimation(.easeOut(duration: 0.3)) {
                 showSuccessFlash = false
@@ -223,7 +225,7 @@ public struct AnimatedMicButton: View {
             startIdleAnimation()
         case .recording:
             startRecordingAnimation()
-        case .transcribing:
+        case .transcribing, .processing:
             startTranscribingAnimation()
         case .requested:
             // Static state -- no animations. Button is disabled via isTappable.

--- a/DictusCore/Sources/DictusCore/Design/BrandWaveform.swift
+++ b/DictusCore/Sources/DictusCore/Design/BrandWaveform.swift
@@ -9,7 +9,7 @@ final class BrandWaveformDriver: ObservableObject {
     @Published private(set) var displayLevels: [Float] = Array(repeating: 0, count: 30)
     @Published private(set) var processingPhase: Double = 0
     @Published private(set) var renderTick: Int = 0
-    @Published private(set) var isProcessing = false
+    @Published private(set) var animation: WaveformAnimation = .micLevels
 
     private let barCount = 30
     private let smoothingFactor: Float = 0.3
@@ -25,13 +25,17 @@ final class BrandWaveformDriver: ObservableObject {
         displayLink?.invalidate()
     }
 
-    func update(energyLevels: [Float], isProcessing: Bool, isActive: Bool) {
+    func update(energyLevels: [Float], animation: WaveformAnimation, isActive: Bool) {
+        let previousAnimation = self.animation
         self.energyLevels = energyLevels
-        self.isProcessing = isProcessing
+        self.animation = animation
         self.isActive = isActive
 
-        if !isProcessing {
-            processingPhase = 0
+        // Restart the phase whenever the animation changes rather than only on the
+        // way out of a self-driven one: the sine and the travelling peak share it,
+        // and handing the peak the sine's phase would drop it mid-travel (#267).
+        if animation != previousAnimation {
+            processingPhase = ProcessingWaveform.centredPhase
         }
 
         if !isActive {
@@ -64,7 +68,7 @@ final class BrandWaveformDriver: ObservableObject {
 
         PersistentLog.log(.waveformAppeared(
             refreshID: renderTick,
-            isProcessing: isProcessing,
+            isProcessing: animation.isSelfDriven,
             energyCount: energyLevels.count,
             killedState: false
         ))
@@ -98,16 +102,19 @@ final class BrandWaveformDriver: ObservableObject {
         }
         lastRenderTime = now
 
-        if isProcessing {
-            processingPhase += link.duration / 2.0
-        } else {
+        switch animation {
+        case .micLevels:
             tickLevels()
+        case .sweep:
+            processingPhase += link.duration / 2.0
+        case .travellingPeak:
+            processingPhase += link.duration * ProcessingWaveform.phaseRate
+        case .still:
+            break
         }
 
         if now.timeIntervalSince(lastHeartbeatTime) >= 2.0 {
-            let sourceLevels: [Float] = isProcessing
-                ? (0..<barCount).map { processingEnergy(at: $0, phase: processingPhase) }
-                : displayLevels
+            let sourceLevels: [Float] = levels(for: animation)
             let avg = sourceLevels.isEmpty ? Float(0) : sourceLevels.reduce(0, +) / Float(sourceLevels.count)
             PersistentLog.log(.waveformHeartbeat(
                 renderTick: renderTick,
@@ -146,6 +153,18 @@ final class BrandWaveformDriver: ObservableObject {
         let normalizedIndex = Double(index) / Double(max(barCount - 1, 1))
         let sineValue = sin(2 * .pi * (normalizedIndex + phase))
         return Float(0.2 + 0.25 * (sineValue + 1.0))
+    }
+
+    /// The bar heights the current animation is drawing, for the heartbeat log.
+    private func levels(for animation: WaveformAnimation) -> [Float] {
+        switch animation {
+        case .sweep:
+            return (0..<barCount).map { processingEnergy(at: $0, phase: processingPhase) }
+        case .travellingPeak:
+            return ProcessingWaveform.levels(phase: processingPhase)
+        case .micLevels, .still:
+            return displayLevels
+        }
     }
 
     private func targetLevels() -> [Float] {
@@ -190,11 +209,14 @@ public struct BrandWaveform: View {
     /// Fixed height of the waveform container. Bars grow within this space.
     public var maxHeight: CGFloat = 80
 
-    /// When true, generates a synthetic sinusoidal wave pattern instead of using energyLevels.
-    /// WHY: During transcription processing, the audio engine is idle but we want continuous
-    /// visual feedback. A traveling sine wave maintains waveform continuity from the recording
-    /// state while indicating "processing" rather than "recording".
-    public var isProcessing: Bool = false
+    /// Which animation the bars draw.
+    ///
+    /// WHY the two synthetic ones exist at all: after the microphone stops, the
+    /// audio engine is idle but the wait is not over, and bars frozen at their last
+    /// levels read as a hang. `.sweep` carries continuity from the recording state
+    /// through transcription; `.travellingPeak` says the language model is running,
+    /// which is a different and much longer wait (#267).
+    public var animation: WaveformAnimation = .micLevels
 
     /// When false, pauses the TimelineView animation schedule (stops CADisplayLink).
     /// WHY: Some hosts need a hard kill switch when the view is still structurally
@@ -203,10 +225,10 @@ public struct BrandWaveform: View {
     public var isActive: Bool = true
 
     public init(energyLevels: [Float] = [], maxHeight: CGFloat = 80,
-                isProcessing: Bool = false, isActive: Bool = true) {
+                animation: WaveformAnimation = .micLevels, isActive: Bool = true) {
         self.energyLevels = energyLevels
         self.maxHeight = maxHeight
-        self.isProcessing = isProcessing
+        self.animation = animation
         self.isActive = isActive
     }
 
@@ -223,7 +245,7 @@ public struct BrandWaveform: View {
             .onAppear {
                 driver.update(
                     energyLevels: energyLevels,
-                    isProcessing: isProcessing,
+                    animation: animation,
                     isActive: isActive
                 )
             }
@@ -233,21 +255,21 @@ public struct BrandWaveform: View {
             .onChange(of: energyLevels) { _, newLevels in
                 driver.update(
                     energyLevels: newLevels,
-                    isProcessing: isProcessing,
+                    animation: animation,
                     isActive: isActive
                 )
             }
-            .onChange(of: isProcessing) { _, newValue in
+            .onChange(of: animation) { _, newValue in
                 driver.update(
                     energyLevels: energyLevels,
-                    isProcessing: newValue,
+                    animation: newValue,
                     isActive: isActive
                 )
             }
             .onChange(of: isActive) { _, newValue in
                 driver.update(
                     energyLevels: energyLevels,
-                    isProcessing: isProcessing,
+                    animation: animation,
                     isActive: newValue
                 )
             }
@@ -272,16 +294,25 @@ public struct BrandWaveform: View {
 
             for index in 0..<barCount {
                 let energy: Float
-                if driver.isProcessing {
+                switch driver.animation {
+                case .sweep:
                     energy = driver.processingEnergy(at: index, phase: driver.processingPhase)
-                } else {
+                case .travellingPeak:
+                    energy = ProcessingWaveform.level(
+                        at: index,
+                        peakPosition: ProcessingWaveform.peakPosition(phase: driver.processingPhase)
+                    )
+                case .micLevels, .still:
                     energy = index < driver.displayLevels.count ? driver.displayLevels[index] : 0
                 }
 
                 // Minimum bar height so the waveform baseline is always visible,
                 // even in complete silence. 2pt = thin line, enough to see the
                 // colored bar pattern (blue center, gray edges) without looking "active".
-                let minHeight: CGFloat = driver.isProcessing ? 4 : 2
+                // The self-driven animations sit on the taller floor: the travelling
+                // peak leaves most of its bars at a 0.05 baseline, so without it the
+                // row all but disappears between crossings.
+                let minHeight: CGFloat = driver.animation.isSelfDriven ? 4 : 2
                 let height = max(minHeight + CGFloat(energy) * (maxHeight - minHeight), minHeight)
 
                 let x = CGFloat(index) * (barWidth + barSpacing)
@@ -339,7 +370,7 @@ public struct BrandWaveform: View {
 #Preview("Processing") {
     ZStack {
         Color(hex: 0x0A1628).ignoresSafeArea()
-        BrandWaveform(maxHeight: 120, isProcessing: true)
+        BrandWaveform(maxHeight: 120, animation: .sweep)
             .opacity(0.3)
             .padding(.horizontal)
     }

--- a/DictusCore/Sources/DictusCore/Design/BrandWaveform.swift
+++ b/DictusCore/Sources/DictusCore/Design/BrandWaveform.swift
@@ -49,8 +49,22 @@ final class BrandWaveformDriver: ObservableObject {
         stopLoop()
     }
 
+    /// Whether the current animation has to be redrawn every frame.
+    ///
+    /// `.still` draws a fixed picture, and `Canvas` re-renders on `renderTick`, so
+    /// without this a still waveform would repaint at display rate for as long as
+    /// its host kept `isActive` true.
+    private var needsDisplayLink: Bool {
+        switch animation {
+        case .micLevels, .sweep, .travellingPeak:
+            return true
+        case .still:
+            return false
+        }
+    }
+
     private func updateLoopState() {
-        if isActive {
+        if isActive && needsDisplayLink {
             startLoopIfNeeded()
         } else {
             stopLoop()

--- a/DictusCore/Sources/DictusCore/Design/WaveformAnimation.swift
+++ b/DictusCore/Sources/DictusCore/Design/WaveformAnimation.swift
@@ -1,0 +1,34 @@
+// DictusCore/Sources/DictusCore/Design/WaveformAnimation.swift
+// What a waveform's bars are drawing, for every surface that draws one.
+
+/// Which animation a bar waveform is running.
+///
+/// WHY a mode and not a set of booleans: the cases are mutually exclusive, and
+/// both waveforms in this app used to carry a single `isProcessing` flag that the
+/// renderer read to pick between two of them. Adding the LLM stage (#267) as a
+/// second boolean would have made "both true" expressible, which is the shape of
+/// bug this repo has paid for elsewhere.
+///
+/// WHY it is shared between `BrandWaveform` (DictusApp) and
+/// `KeyboardWaveformDriver` (DictusKeyboard) rather than declared twice: the two
+/// draw the same three animations from the same maths, and the moment they stop
+/// agreeing on what the vocabulary is, they start disagreeing on what the user
+/// sees. `ProcessingWaveform` is the maths; this is the choice of which to run.
+public enum WaveformAnimation: Equatable, Sendable {
+    /// Bar heights follow the microphone's energy. `DictationStatus.recording`.
+    case micLevels
+    /// Continuous sine sweep. `DictationStatus.transcribing`.
+    case sweep
+    /// Travelling peak scanning back and forth. `DictationStatus.processing`.
+    case travellingPeak
+    /// Nothing is animating -- bars sit where they were left.
+    case still
+
+    /// Whether the bars are drawing themselves rather than following the mic.
+    ///
+    /// The two self-driven animations share a phase, a 4 pt bar floor and a
+    /// `waveformAppeared(isProcessing:)` log field whose meaning predates #267.
+    public var isSelfDriven: Bool {
+        self == .sweep || self == .travellingPeak
+    }
+}

--- a/DictusCore/Sources/DictusCore/DictationSessionGeneration.swift
+++ b/DictusCore/Sources/DictusCore/DictationSessionGeneration.swift
@@ -1,0 +1,84 @@
+// DictusCore/Sources/DictusCore/DictationSessionGeneration.swift
+// Which dictation a piece of in-flight work belongs to, and when it stops being
+// allowed to speak for it.
+
+import Foundation
+
+/// Identifies the dictation that in-flight work belongs to.
+///
+/// A dictation's transcription and polish run in a `Task` that outlives the
+/// decisions made about the dictation itself. The task can only be *asked* to stop
+/// -- `Task.cancel()` is cooperative, and neither WhisperKit nor Apple Foundation
+/// Models promises to return promptly -- so it can still be running seconds after
+/// the session it belongs to has been declared over. When it finishes, it must not
+/// report.
+///
+/// ### The failure this exists for (#267 device session, 2026-08-04)
+///
+/// Cancelling during transcription produced, within the same second:
+///
+/// ```
+/// liveActivityTransition from=transcribing to=standby-abandoned
+/// statusChanged from=transcribing to=idle
+/// statusChanged from=idle to=failed          <- the abandoned task, reporting
+/// ```
+///
+/// The teardown was correct and the view closed; then the still-running task threw,
+/// wrote `failed`, and the recording screen came back for about half a second. Six
+/// Live Activity transitions were rejected in the same window (`standby->failed`,
+/// `standby->ready`), the state machine correctly refusing writes from a session
+/// that was over. The `standby->ready` ones are the alarming half: on that path the
+/// task had *succeeded*, and a success write also inserts text into the user's
+/// document.
+///
+/// ### Why the pre-existing guard did not cover it
+///
+/// `DictationCoordinator` already had a generation counter from #60, but it was
+/// incremented in exactly one place -- `startDictation()` -- so it answered "did a
+/// **newer** session start", which is supersession, not abandonment. Nothing starts
+/// when a dictation is abandoned. And the transcription task never captured the
+/// counter at all, so even a superseding start would not have stopped these writes.
+/// Two gaps, one of them in the concept.
+///
+/// This type closes the concept: the generation moves for **both** reasons a
+/// session can stop being the current one, and the two reasons are named here
+/// rather than left as increments spread across a 1200-line coordinator.
+///
+/// Lives in DictusCore because `DictationCoordinator` is in DictusApp, which has no
+/// test bundle. Same reasoning as `KeyboardAreaMode` and `LiveActivityStateMachine`.
+public struct DictationSessionGeneration: Equatable, Sendable {
+
+    /// The generation work started now would belong to.
+    public private(set) var current: Int
+
+    public init(current: Int = 0) {
+        self.current = current
+    }
+
+    /// A new dictation is starting. Work from the previous one stops being current.
+    public mutating func beginSession() {
+        current += 1
+    }
+
+    /// The current dictation is over with no successor: cancelled by the user, or
+    /// torn down by a watchdog or an audio interruption.
+    ///
+    /// WHY this is not the same call as `beginSession` even though both advance the
+    /// counter: they are two different reasons, and a reader asking "when does work
+    /// stop being allowed to report" has to be able to find both. Collapsing them
+    /// into one `invalidate()` is how the abandonment case went missing the first
+    /// time.
+    public mutating func abandonSession() {
+        current += 1
+    }
+
+    /// Whether work that started under `generation` may still report its outcome --
+    /// write status, insert text, or drive the Live Activity.
+    ///
+    /// Fails closed by construction: work only reports while its generation is
+    /// still the current one, so any future reason to end a session invalidates
+    /// outstanding work as soon as it advances the counter.
+    public func mayReport(from generation: Int) -> Bool {
+        generation == current
+    }
+}

--- a/DictusCore/Sources/DictusCore/DictationSessionLiveness.swift
+++ b/DictusCore/Sources/DictusCore/DictationSessionLiveness.swift
@@ -51,22 +51,28 @@ public enum DictationSessionLivenessPolicy {
     /// states and, on device, never fired once for exactly that reason.
     public static let recordingStaleThreshold: TimeInterval = 4
 
-    /// The same, while the stored status is `transcribing`.
+    /// The same, while the stored status is `transcribing` or `processing`.
     ///
     /// WHY 8 s and not 4 s: recording has stopped, so the audio thread has fallen back
     /// to its warm-idle path, which writes only every 3 s (#106 Phase C, sized to stay
     /// under the watchdog's 5 s threshold). Judging that cadence by the recording
     /// threshold would condemn every transcription that runs longer than four seconds.
+    ///
+    /// WHY `processing` shares it rather than getting a longer one of its own (#267):
+    /// this threshold judges the heartbeat's *cadence*, not the stage's length. Both
+    /// post-recording stages run against the same 3 s warm-idle writer, so an LLM stage
+    /// that takes a minute is no more suspicious at second 50 than at second 5 -- what
+    /// would be suspicious is the same three missed beats.
     public static let transcribingStaleThreshold: TimeInterval = 8
 
     /// Whether `status` describes a dictation that some process should be driving.
     ///
     /// WHY an exhaustive switch and not a `Set`: adding a case to `DictationStatus`
-    /// (`processing`, #267) must stop the compiler here rather than silently fall
-    /// through to "nothing is in flight".
+    /// must stop the compiler here rather than silently fall through to "nothing is
+    /// in flight". That is how `processing` (#267) got here instead of being missed.
     public static func isActive(_ status: DictationStatus) -> Bool {
         switch status {
-        case .requested, .recording, .transcribing:
+        case .requested, .recording, .transcribing, .processing:
             return true
         case .idle, .ready, .failed:
             return false
@@ -79,7 +85,7 @@ public enum DictationSessionLivenessPolicy {
         switch status {
         case .recording:
             return recordingStaleThreshold
-        case .transcribing:
+        case .transcribing, .processing:
             return transcribingStaleThreshold
         case .requested, .idle, .ready, .failed:
             return nil

--- a/DictusCore/Sources/DictusCore/DictationStatus.swift
+++ b/DictusCore/Sources/DictusCore/DictationStatus.swift
@@ -3,11 +3,31 @@ import Foundation
 
 /// Represents the current state of a dictation round-trip.
 /// Written to App Group UserDefaults so both processes can track progress.
-public enum DictationStatus: String, Codable {
+///
+/// WHY `.transcribing` and `.processing` are two states and not one (#267): they
+/// are two waits of different natures. Transcription is fast and bounded by the
+/// audio's length; the LLM stage that follows is 3-6 s today and scales with the
+/// output it generates. Rendering the second under the first's animation and
+/// label told the user "transcribing" for six seconds, which reads as a hang and
+/// invites the desperation tap on cancel. Both stages own the keyboard area and
+/// both are judged live by the same heartbeat cadence -- what differs is what
+/// the user is told.
+///
+/// WHY `CaseIterable`: the tests that sweep every status (idempotence of the
+/// keyboard-area transition, liveness of every state) used to spell the list out,
+/// so a new case joined the enum without joining the sweep. `allCases` makes the
+/// sweep grow on its own.
+///
+/// WHY `Sendable`: the stage watchdog in `DictationCoordinator` hands the status it
+/// was armed for to a `Timer` closure, and a plain `String`-raw enum crossing that
+/// boundary is safe by construction. Without the conformance the compiler can only
+/// warn about it.
+public enum DictationStatus: String, Codable, CaseIterable, Sendable {
     case idle         // No dictation in progress
     case requested    // Keyboard triggered dictus://dictate
     case recording    // Main app is recording audio
     case transcribing // Main app is running transcription
+    case processing   // Main app is running the LLM stage on the transcript
     case ready        // Transcription result available in shared storage
     case failed       // Something went wrong
 }

--- a/DictusCore/Sources/DictusCore/DictusLiveActivityAttributes.swift
+++ b/DictusCore/Sources/DictusCore/DictusLiveActivityAttributes.swift
@@ -29,6 +29,10 @@ public struct DictusLiveActivityAttributes: ActivityAttributes {
         case recording
         /// Processing audio through WhisperKit/Parakeet. Shows pulsing animation.
         case transcribing
+        /// Running the LLM stage on the transcript (#267). Distinct from
+        /// `transcribing` because it is the longer of the two waits and the one
+        /// the user is most likely to read as a hang.
+        case processing
         /// Transcription result available. Shows preview + checkmark.
         case ready
         /// An error occurred during recording or transcription.

--- a/DictusCore/Sources/DictusCore/KeyboardAreaMode.swift
+++ b/DictusCore/Sources/DictusCore/KeyboardAreaMode.swift
@@ -54,11 +54,16 @@ public extension DictationStatus {
     /// whether the recording overlay should be filling it.
     ///
     /// WHY an exhaustive switch and not a `Set` membership test: adding a case to
-    /// `DictationStatus` (`processing`, #267) must not silently fall through to
-    /// "does not own the area". The compiler stops on this function instead.
+    /// `DictationStatus` must not silently fall through to "does not own the area".
+    /// The compiler stops on this function instead, which is how `processing`
+    /// (#267) got here.
+    ///
+    /// `processing` owning the area is what keeps the overlay on screen through the
+    /// LLM stage: it resolves to the same `.recording` mode every other in-flight
+    /// status does, so the view controller sees no new mode and no new height.
     var ownsKeyboardArea: Bool {
         switch self {
-        case .requested, .recording, .transcribing:
+        case .requested, .recording, .transcribing, .processing:
             return true
         case .idle, .ready, .failed:
             return false

--- a/DictusCore/Sources/DictusCore/LiveActivityStateMachine.swift
+++ b/DictusCore/Sources/DictusCore/LiveActivityStateMachine.swift
@@ -52,12 +52,28 @@ public struct LiveActivityStateMachine {
     /// Foundation Models never reach an engine worth announcing. A pipeline that
     /// went straight from transcription to a result is the common case, not a
     /// degraded one.
+    ///
+    /// WHY both post-recording stages can reach `.standby` (#267 review): a
+    /// dictation can be abandoned *inside* a stage -- the stage watchdog fires, or
+    /// the user cancels -- and the pill then has to come home. Without these two
+    /// edges it could not: the app returned to `.idle` while the machine stayed
+    /// parked on the stage, and the next dictation's `.recording` transition was
+    /// rejected from there, so the Dynamic Island kept showing the stage of a
+    /// dictation that had ended while a new one recorded underneath it. That is
+    /// the #42 / #257 desync exactly, reached through the watchdog.
+    ///
+    /// This edge existed for neither stage before #267 -- the hole was already
+    /// reachable on `develop` whenever the 30 s transcription watchdog fired.
+    ///
+    /// It widens nothing in practice: `returnToStandby` still refuses these two
+    /// phases behind its own guard, so only the deliberate recovery path
+    /// (`recoverFromAbandonedStage`) can take these edges.
     private let validTransitions: [Phase: Set<Phase>] = [
         .idle: [.standby, .failed],
         .standby: [.recording, .idle],
         .recording: [.transcribing, .standby],
-        .transcribing: [.processing, .ready, .failed],
-        .processing: [.ready, .failed],
+        .transcribing: [.processing, .ready, .failed, .standby],
+        .processing: [.ready, .failed, .standby],
         .ready: [.standby, .recording],
         .failed: [.standby, .recording, .idle]
     ]

--- a/DictusCore/Sources/DictusCore/LiveActivityStateMachine.swift
+++ b/DictusCore/Sources/DictusCore/LiveActivityStateMachine.swift
@@ -20,7 +20,7 @@ public struct LiveActivityStateMachine {
     /// Phases of the Live Activity lifecycle.
     /// Maps 1:1 to the private LiveActivityPhase enum in LiveActivityManager.
     public enum Phase: String, Sendable {
-        case idle, standby, recording, transcribing, ready, failed
+        case idle, standby, recording, transcribing, processing, ready, failed
     }
 
     /// The current phase. Read-only from outside; mutated only via transition(to:) or reset().
@@ -45,11 +45,19 @@ public struct LiveActivityStateMachine {
     /// and produced `liveActivityFailed context=rejectedTransition error=idle->failed`
     /// instead. `endWithFailure()` still returns early when no activity is held, so
     /// allowing this creates no pill out of nothing.
+    ///
+    /// WHY `.transcribing -> .ready` survives the arrival of `.processing` (#267):
+    /// the LLM stage is skipped on most dictations -- the polish toggle is off by
+    /// default, the duration gate drops flash clips, and devices without Apple
+    /// Foundation Models never reach an engine worth announcing. A pipeline that
+    /// went straight from transcription to a result is the common case, not a
+    /// degraded one.
     private let validTransitions: [Phase: Set<Phase>] = [
         .idle: [.standby, .failed],
         .standby: [.recording, .idle],
         .recording: [.transcribing, .standby],
-        .transcribing: [.ready, .failed],
+        .transcribing: [.processing, .ready, .failed],
+        .processing: [.ready, .failed],
         .ready: [.standby, .recording],
         .failed: [.standby, .recording, .idle]
     ]

--- a/DictusCore/Sources/DictusCore/Polish/PassthroughPolishEngine.swift
+++ b/DictusCore/Sources/DictusCore/Polish/PassthroughPolishEngine.swift
@@ -8,6 +8,10 @@ import Foundation
 public final class PassthroughPolishEngine: PolishEngineProtocol {
     public let identifier = "passthrough"
 
+    /// 100 ms is below the threshold at which a state change reads as a state and
+    /// not as a glitch, and there is no model behind it to wait for anyway (#267).
+    public let announcesProcessingStage = false
+
     public init() {}
 
     public func polish(raw: String,

--- a/DictusCore/Sources/DictusCore/Polish/PolishEngineProtocol.swift
+++ b/DictusCore/Sources/DictusCore/Polish/PolishEngineProtocol.swift
@@ -10,6 +10,18 @@ public protocol PolishEngineProtocol: Sendable {
     /// Stable identifier for metrics (e.g. "apple-fm", "passthrough").
     var identifier: String { get }
 
+    /// Whether running this engine is a wait the user should be told about (#267).
+    ///
+    /// The dictation status moves to `.processing` -- new overlay animation, new
+    /// footer label, new Dynamic Island treatment -- for the duration of the engine
+    /// call. That is worth doing for a backend that takes seconds and worth
+    /// suppressing for one that does not: announcing a stage that ends before the
+    /// eye lands on it is a flicker, not information.
+    ///
+    /// Default implementation returns `true`: a real backend generates text and
+    /// generation takes time, so a new engine gets the stage without opting in.
+    var announcesProcessingStage: Bool { get }
+
     /// Polish `raw` STT output in `targetLanguage` under the given `mode`.
     /// Throws on cancellation or backend failure — the coordinator falls back
     /// to the raw text and emits an `engineFailed` metric.
@@ -46,6 +58,8 @@ public protocol PolishEngineProtocol: Sendable {
 }
 
 public extension PolishEngineProtocol {
+    var announcesProcessingStage: Bool { true }
+
     func prewarm(mode: PolishMode, targetLanguage: SupportedLanguage) async {}
 
     func contextFit(input: String,

--- a/DictusCore/Sources/DictusCore/ProcessingWaveform.swift
+++ b/DictusCore/Sources/DictusCore/ProcessingWaveform.swift
@@ -1,0 +1,94 @@
+// DictusCore/Sources/DictusCore/ProcessingWaveform.swift
+// Bar heights for the LLM-processing animation. Pure math -- no view, no timer.
+
+import Foundation
+
+/// The travelling-peak ("cylon") sweep the recording overlay renders while the
+/// LLM stage runs (#267).
+///
+/// WHY a third animation and not a second speed of the transcription sine: the
+/// two waits have to read as different *families*, not as the same wave running
+/// slower -- a user who cannot tell them apart learns nothing from the change.
+/// A localized bump scanning back and forth is discontinuous where the sine is
+/// continuous, so the difference survives a glance at a 30 pt-tall waveform.
+/// Ported from Dictus Desktop, which arrived at this shape after several
+/// iterations (`src/overlay/RecordingOverlay.tsx`).
+///
+/// WHY the crest matches the transcription sine's (0.7) while the baseline does
+/// not (0.05 against ~0.2): same visual vocabulary, different motion. The bars
+/// far from the peak must genuinely drop -- a localized peak sitting on the
+/// sine's wave-trough height stops reading as localized.
+///
+/// WHY it lives in DictusCore and not next to the view in DictusKeyboard: the
+/// keyboard extension target has no test bundle, so anything only reachable from
+/// there is unprovable. Same reasoning as `KeyboardAreaMode` and
+/// `LiveActivityStateMachine`.
+///
+/// WHY there is no outro here, unlike the desktop original: on desktop the
+/// overlay is its own window and can spend 700 ms easing the peak back to centre
+/// before it fades. On iOS the overlay *is* the keyboard area, and it gives way
+/// the instant the transcription is inserted -- an outro would hold the keys
+/// hostage for the exact moment the user is waiting on.
+public enum ProcessingWaveform {
+
+    /// Bars in the overlay's waveform. Matches `KeyboardWaveformView`.
+    public static let barCount = 30
+
+    /// How many bars either side of the peak still rise above the baseline.
+    /// At 10 of 30 bars the bump is wide enough to be read as one shape and
+    /// narrow enough to leave a clearly flat remainder.
+    public static let halfWidth: Double = 10
+
+    /// Height of a bar the peak does not reach. Close to the recording
+    /// waveform's silent floor, deliberately (see the type's doc comment).
+    public static let baseline: Float = 0.05
+
+    /// Height of the bar under the centre of the peak. Same value as the
+    /// transcription sine's crest.
+    public static let crest: Float = 0.7
+
+    /// Sweeps per second. One cycle carries the peak right and back again.
+    ///
+    /// WHY 0.7 Hz: slow enough that the eye follows the peak rather than seeing
+    /// a blur, fast enough that a glance during a 3 s wait catches it moving.
+    public static let phaseRate: Double = 0.7
+
+    /// Where the peak sits, in bar units, at `phase` (in cycles).
+    ///
+    /// The sine gives the ends-of-travel their natural slow-down: the peak
+    /// decelerates into each edge and accelerates out of it, which is what makes
+    /// the motion read as a scan rather than a bouncing ball.
+    public static func peakPosition(phase: Double) -> Double {
+        Double(barCount - 1) * (1 + sin(2 * .pi * phase)) / 2
+    }
+
+    /// Bar heights with the peak centred on `peakPosition`.
+    ///
+    /// The falloff is a raised cosine, so the bump has no corner at its apex and
+    /// meets the baseline tangentially at `halfWidth`.
+    public static func levels(peakPosition: Double) -> [Float] {
+        (0..<barCount).map { level(at: $0, peakPosition: peakPosition) }
+    }
+
+    /// Bar heights at `phase` (in cycles).
+    public static func levels(phase: Double) -> [Float] {
+        levels(peakPosition: peakPosition(phase: phase))
+    }
+
+    /// Height of one bar. Kept separate so the view can ask per index without
+    /// allocating an array every frame.
+    public static func level(at index: Int, peakPosition: Double) -> Float {
+        let distance = abs(Double(index) - peakPosition)
+        guard distance < halfWidth else { return baseline }
+        let bump = 0.5 + 0.5 * cos(.pi * distance / halfWidth)
+        return baseline + (crest - baseline) * Float(bump)
+    }
+
+    /// The phase whose peak sits at the centre of the row -- the shape the
+    /// reduced-motion fallback freezes on.
+    ///
+    /// WHY zero and not a computed value: `sin(0) == 0` already puts the peak at
+    /// `(barCount - 1) / 2`. Naming it stops the fallback from looking like it
+    /// forgot to initialise something.
+    public static let centredPhase: Double = 0
+}

--- a/DictusCore/Sources/DictusCore/ProcessingWaveform.swift
+++ b/DictusCore/Sources/DictusCore/ProcessingWaveform.swift
@@ -47,11 +47,21 @@ public enum ProcessingWaveform {
     /// transcription sine's crest.
     public static let crest: Float = 0.7
 
-    /// Sweeps per second. One cycle carries the peak right and back again.
+    /// Sweeps per second. One cycle carries the peak right and back again, so a
+    /// single edge-to-edge crossing takes half of it.
     ///
-    /// WHY 0.7 Hz: slow enough that the eye follows the peak rather than seeing
-    /// a blur, fast enough that a glance during a 3 s wait catches it moving.
-    public static let phaseRate: Double = 0.7
+    /// WHY 0.5 Hz, and why the number is set by contrast rather than in the
+    /// abstract (device feedback, 2026-08-04): the transcription sine advances its
+    /// phase by 0.5 per second, so its pattern crosses the row in 2.00 s. At the
+    /// 0.7 Hz this first shipped with, the peak crossed in 0.71 s -- 2.8x faster,
+    /// which read as rushed rather than as a different tempo. At 0.5 Hz a crossing
+    /// takes exactly 1.00 s, twice the sine's speed. The tempo contrast is
+    /// deliberate and stays; it was the ratio that was wrong.
+    ///
+    /// The floor under this number is the shortest stage worth animating: measured
+    /// LLM stages ran 1 s and 3 s, and at 0.5 Hz even the 1 s one shows a whole
+    /// crossing rather than a twitch.
+    public static let phaseRate: Double = 0.5
 
     /// Where the peak sits, in bar units, at `phase` (in cycles).
     ///
@@ -84,11 +94,12 @@ public enum ProcessingWaveform {
         return baseline + (crest - baseline) * Float(bump)
     }
 
-    /// The phase whose peak sits at the centre of the row -- the shape the
-    /// reduced-motion fallback freezes on.
+    /// The phase whose peak sits at the centre of the row. Where each stage starts,
+    /// so the peak enters from the middle and sweeps out rather than appearing
+    /// mid-travel.
     ///
     /// WHY zero and not a computed value: `sin(0) == 0` already puts the peak at
-    /// `(barCount - 1) / 2`. Naming it stops the fallback from looking like it
+    /// `(barCount - 1) / 2`. Naming it stops the phase reset from looking like it
     /// forgot to initialise something.
     public static let centredPhase: Double = 0
 }

--- a/DictusCore/Tests/DictusCoreTests/DictationSessionGenerationTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/DictationSessionGenerationTests.swift
@@ -96,6 +96,23 @@ final class DictationSessionGenerationTests: XCTestCase {
         XCTAssertFalse(generation.mayReport(from: transcriptionTask), "late success inserted text")
     }
 
+    /// The start paths matter as much as the stop path, and the cold one matters
+    /// most: the model load runs inside the same task and takes seconds, so a
+    /// cancel arriving mid-flight is ordinary rather than exotic. Work captured at
+    /// *start* has to be invalidated by the same abandon.
+    func testWorkCapturedWhenADictationStartsIsAlsoInvalidatedByAnAbandon() {
+        var generation = DictationSessionGeneration()
+        generation.beginSession()
+        let startTask = generation.current
+
+        generation.abandonSession()
+
+        XCTAssertFalse(
+            generation.mayReport(from: startTask),
+            "a cancelled start must not go on to open the microphone or publish .recording"
+        )
+    }
+
     /// Abandoning twice must not resurrect anything -- the watchdog and the user
     /// can both tear the same session down.
     func testAbandoningTwiceKeepsOutstandingWorkInvalid() {

--- a/DictusCore/Tests/DictusCoreTests/DictationSessionGenerationTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/DictationSessionGenerationTests.swift
@@ -1,0 +1,110 @@
+// DictusCore/Tests/DictusCoreTests/DictationSessionGenerationTests.swift
+// Which in-flight work is still allowed to report (#267).
+
+import XCTest
+@testable import DictusCore
+
+/// Coverage for the rule that stops an abandoned dictation's transcription task
+/// from reporting after the session is over.
+///
+/// The task itself is unreachable from a test: it lives in `DictationCoordinator`
+/// in DictusApp, a target with no test bundle, and the race it loses needs a real
+/// WhisperKit call that ignores cancellation for a second or two. What is testable
+/// is the rule it consults, and the rule is where the bug was -- the counter that
+/// existed before moved for one of the two reasons a session can end.
+final class DictationSessionGenerationTests: XCTestCase {
+
+    // MARK: - The rule
+
+    func testWorkMayReportWhileItsSessionIsStillTheCurrentOne() {
+        let generation = DictationSessionGeneration()
+        XCTAssertTrue(generation.mayReport(from: generation.current))
+    }
+
+    /// The gap that caused the bug. A dictation that is cancelled, watchdog-reset
+    /// or interrupted ends with no successor, and the counter has to move for that
+    /// too -- not only when a new dictation starts.
+    func testAbandoningASessionStopsItsOutstandingWorkFromReporting() {
+        var generation = DictationSessionGeneration()
+        let inFlight = generation.current
+
+        generation.abandonSession()
+
+        XCTAssertFalse(
+            generation.mayReport(from: inFlight),
+            "a task from an abandoned dictation must not write status or insert text"
+        )
+    }
+
+    /// The #60 case, which the counter already covered: a newer dictation
+    /// supersedes the previous one's outstanding work.
+    func testStartingANewSessionStopsThePreviousOnesWorkFromReporting() {
+        var generation = DictationSessionGeneration()
+        let inFlight = generation.current
+
+        generation.beginSession()
+
+        XCTAssertFalse(generation.mayReport(from: inFlight))
+        XCTAssertTrue(generation.mayReport(from: generation.current))
+    }
+
+    /// Both reasons a session stops being current have to invalidate outstanding
+    /// work. Spelled out as one table so a third reason added later has an obvious
+    /// place to prove itself.
+    func testEveryWayASessionEndsInvalidatesOutstandingWork() {
+        let endings: [(String, (inout DictationSessionGeneration) -> Void)] = [
+            ("abandoned", { $0.abandonSession() }),
+            ("superseded", { $0.beginSession() })
+        ]
+
+        for (label, end) in endings {
+            var generation = DictationSessionGeneration()
+            let inFlight = generation.current
+            end(&generation)
+            XCTAssertFalse(generation.mayReport(from: inFlight), "\(label) work still reported")
+        }
+    }
+
+    /// A dictation that is simply progressing must keep its own work valid --
+    /// otherwise the gate would drop every ordinary transcription result.
+    func testWorkStaysValidAcrossTheLifeOfItsOwnSession() {
+        var generation = DictationSessionGeneration()
+        generation.beginSession()
+        let inFlight = generation.current
+
+        XCTAssertTrue(generation.mayReport(from: inFlight))
+        XCTAssertTrue(generation.mayReport(from: inFlight), "nothing but an ending may invalidate work")
+    }
+
+    // MARK: - The device sequence
+
+    /// The exact shape of the 2026-08-04 device failure: a dictation is stopped,
+    /// its task is still running, the user abandons the session, and the task then
+    /// finishes. Before the fix the task wrote `.failed` and the recording screen
+    /// came back for half a second; on the success path it would have inserted text
+    /// into the user's document.
+    func testATaskFinishingAfterTheUserAbandonedItReportsNothing() {
+        var generation = DictationSessionGeneration()
+        generation.beginSession()
+        let transcriptionTask = generation.current
+
+        // The user taps the close button; the coordinator tears the session down.
+        generation.abandonSession()
+
+        // WhisperKit returns a second later, one way or the other.
+        XCTAssertFalse(generation.mayReport(from: transcriptionTask), "late failure re-presented the screen")
+        XCTAssertFalse(generation.mayReport(from: transcriptionTask), "late success inserted text")
+    }
+
+    /// Abandoning twice must not resurrect anything -- the watchdog and the user
+    /// can both tear the same session down.
+    func testAbandoningTwiceKeepsOutstandingWorkInvalid() {
+        var generation = DictationSessionGeneration()
+        let inFlight = generation.current
+
+        generation.abandonSession()
+        generation.abandonSession()
+
+        XCTAssertFalse(generation.mayReport(from: inFlight))
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/DictationSessionLivenessTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/DictationSessionLivenessTests.swift
@@ -43,6 +43,7 @@ final class DictationSessionLivenessTests: XCTestCase {
         XCTAssertTrue(DictationSessionLivenessPolicy.isActive(.requested))
         XCTAssertTrue(DictationSessionLivenessPolicy.isActive(.recording))
         XCTAssertTrue(DictationSessionLivenessPolicy.isActive(.transcribing))
+        XCTAssertTrue(DictationSessionLivenessPolicy.isActive(.processing))
         XCTAssertFalse(DictationSessionLivenessPolicy.isActive(.idle))
         XCTAssertFalse(DictationSessionLivenessPolicy.isActive(.ready))
         XCTAssertFalse(DictationSessionLivenessPolicy.isActive(.failed))
@@ -107,6 +108,26 @@ final class DictationSessionLivenessTests: XCTestCase {
         XCTAssertEqual(transcribingThreshold, 8)
         XCTAssertEqual(evaluate(.transcribing, heartbeat: now - transcribingThreshold), .live)
         XCTAssertEqual(evaluate(.transcribing, heartbeat: now - transcribingThreshold - 0.01), .orphaned)
+    }
+
+    /// The LLM stage (#267) is judged by the same threshold as transcription, and
+    /// deliberately so: what the threshold measures is the heartbeat's cadence, and
+    /// both post-recording stages run against the same 3 s warm-idle writer. A
+    /// longer one for `processing` would only delay noticing a dead app.
+    func testProcessingIsJudgedByTheSameThresholdAsTranscribing() {
+        XCTAssertEqual(
+            DictationSessionLivenessPolicy.staleThreshold(for: .processing),
+            DictationSessionLivenessPolicy.staleThreshold(for: .transcribing)
+        )
+        XCTAssertEqual(evaluate(.processing, heartbeat: now - transcribingThreshold), .live)
+        XCTAssertEqual(evaluate(.processing, heartbeat: now - transcribingThreshold - 0.01), .orphaned)
+    }
+
+    /// A long LLM stage is not a suspicious one. Six minutes into a Smart Mode with
+    /// a heartbeat two seconds old, the session is alive -- the stage's length must
+    /// never be the thing that condemns it.
+    func testALongProcessingStageWithAFreshHeartbeatStaysLive() {
+        XCTAssertEqual(evaluate(.processing, heartbeat: now - 2, localSessionStartedAt: now - 360), .live)
     }
 
     func testTheRecordingThresholdIsUnderTheKeyboardWatchdogWindow() {
@@ -207,7 +228,7 @@ final class DictationSessionLivenessTests: XCTestCase {
 
     func testLocalAndStoredDisagreementMatrix() {
         // Every combination of "do we own a session, and when did it start" against
-        // "what does the App Group say", for the two statuses that can be orphaned.
+        // "what does the App Group say", for the statuses that can be orphaned.
         // The failure this suite exists for lived in one cell of this table and was
         // invisible to a simulator run that only ever seeded one of the two.
         let cases: [(DictationStatus, TimeInterval, TimeInterval?, DictationSessionLiveness, String)] = [
@@ -218,7 +239,10 @@ final class DictationSessionLivenessTests: XCTestCase {
             (.recording, now - 1, nil, .live, "rebuilt keyboard, app alive"),
             (.transcribing, now - 20, now - 1, .unproven, "corpse heartbeat during transcription"),
             (.transcribing, now - 5, now - 60, .live, "idle cadence inside our session"),
-            (.transcribing, now - 20, nil, .orphaned, "rebuilt keyboard, dead app, transcribing")
+            (.transcribing, now - 20, nil, .orphaned, "rebuilt keyboard, dead app, transcribing"),
+            (.processing, now - 20, now - 1, .unproven, "corpse heartbeat during the LLM stage"),
+            (.processing, now - 5, now - 60, .live, "idle cadence inside our session, LLM stage"),
+            (.processing, now - 20, nil, .orphaned, "rebuilt keyboard, dead app, LLM stage")
         ]
         for (status, heartbeat, sessionStart, expected, label) in cases {
             XCTAssertEqual(

--- a/DictusCore/Tests/DictusCoreTests/DictusCoreTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/DictusCoreTests.swift
@@ -14,6 +14,7 @@ final class DictusCoreTests: XCTestCase {
         XCTAssertEqual(DictationStatus.requested.rawValue, "requested")
         XCTAssertEqual(DictationStatus.recording.rawValue, "recording")
         XCTAssertEqual(DictationStatus.transcribing.rawValue, "transcribing")
+        XCTAssertEqual(DictationStatus.processing.rawValue, "processing")
         XCTAssertEqual(DictationStatus.ready.rawValue, "ready")
         XCTAssertEqual(DictationStatus.failed.rawValue, "failed")
     }

--- a/DictusCore/Tests/DictusCoreTests/KeyboardAreaModeTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/KeyboardAreaModeTests.swift
@@ -28,6 +28,7 @@ final class KeyboardAreaModeTests: XCTestCase {
         XCTAssertTrue(DictationStatus.requested.ownsKeyboardArea)
         XCTAssertTrue(DictationStatus.recording.ownsKeyboardArea)
         XCTAssertTrue(DictationStatus.transcribing.ownsKeyboardArea)
+        XCTAssertTrue(DictationStatus.processing.ownsKeyboardArea)
     }
 
     func testTerminalStatusesDoNotOwnTheKeyboardArea() {
@@ -81,7 +82,7 @@ final class KeyboardAreaModeTests: XCTestCase {
     }
 
     func testResolvingIsIdempotent() {
-        for status in [DictationStatus.idle, .requested, .recording, .transcribing, .ready, .failed] {
+        for status in DictationStatus.allCases {
             for mode in KeyboardAreaMode.allCases {
                 let once = KeyboardAreaMode.resolving(status: status, current: mode)
                 let twice = KeyboardAreaMode.resolving(status: status, current: once)

--- a/DictusCore/Tests/DictusCoreTests/KeyboardOwnershipTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/KeyboardOwnershipTests.swift
@@ -139,7 +139,7 @@ final class KeyboardOwnershipTests: XCTestCase {
     /// Every status a dictation passes through must be recoverable, so that the
     /// claim does not depend on catching one particular transition.
     func testRecoveryDoesNotDependOnWhichStatusTheDictationIsIn() {
-        for status in [DictationStatus.idle, .requested, .recording, .transcribing] {
+        for status in [DictationStatus.idle, .requested, .recording, .transcribing, .processing] {
             var timeline = KeyboardTimeline()
             timeline.appears(onScreen)
             timeline.appears(doomed)

--- a/DictusCore/Tests/DictusCoreTests/LiveActivityStateMachineTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/LiveActivityStateMachineTests.swift
@@ -56,6 +56,69 @@ final class LiveActivityStateMachineTests: XCTestCase {
         XCTAssertEqual(sm.currentPhase, .ready)
     }
 
+    // MARK: - The LLM stage (#267)
+
+    func testTranscribingToProcessingSucceeds() {
+        var sm = LiveActivityStateMachine()
+        sm.transition(to: .standby)
+        sm.transition(to: .recording)
+        sm.transition(to: .transcribing)
+        XCTAssertTrue(sm.transition(to: .processing))
+        XCTAssertEqual(sm.currentPhase, .processing)
+    }
+
+    func testProcessingToReadySucceeds() {
+        var sm = LiveActivityStateMachine()
+        sm.transition(to: .standby)
+        sm.transition(to: .recording)
+        sm.transition(to: .transcribing)
+        sm.transition(to: .processing)
+        XCTAssertTrue(sm.transition(to: .ready))
+        XCTAssertEqual(sm.currentPhase, .ready)
+    }
+
+    func testProcessingToFailedSucceeds() {
+        var sm = LiveActivityStateMachine()
+        sm.transition(to: .standby)
+        sm.transition(to: .recording)
+        sm.transition(to: .transcribing)
+        sm.transition(to: .processing)
+        XCTAssertTrue(sm.transition(to: .failed))
+        XCTAssertEqual(sm.currentPhase, .failed)
+    }
+
+    /// The LLM stage is skipped on most dictations -- the polish toggle is off by
+    /// default, the duration gate drops flash clips, and a device without Apple
+    /// Foundation Models never reaches an engine worth announcing. Straight to
+    /// `.ready` has to stay a first-class path, not a rejected transition.
+    func testTranscribingStillGoesStraightToReadyWhenTheLLMStageIsSkipped() {
+        var sm = LiveActivityStateMachine()
+        sm.transition(to: .standby)
+        sm.transition(to: .recording)
+        sm.transition(to: .transcribing)
+        XCTAssertTrue(sm.transition(to: .ready))
+    }
+
+    /// The LLM stage runs on a transcript, so it can only follow transcription.
+    func testRecordingToProcessingFails() {
+        var sm = LiveActivityStateMachine()
+        sm.transition(to: .standby)
+        sm.transition(to: .recording)
+        XCTAssertFalse(sm.transition(to: .processing))
+        XCTAssertEqual(sm.currentPhase, .recording)
+    }
+
+    /// A finished dictation must not be able to reopen the wait.
+    func testProcessingCannotFollowReady() {
+        var sm = LiveActivityStateMachine()
+        sm.transition(to: .standby)
+        sm.transition(to: .recording)
+        sm.transition(to: .transcribing)
+        sm.transition(to: .ready)
+        XCTAssertFalse(sm.transition(to: .processing))
+        XCTAssertEqual(sm.currentPhase, .ready)
+    }
+
     func testTranscribingToFailedSucceeds() {
         var sm = LiveActivityStateMachine()
         sm.transition(to: .standby)

--- a/DictusCore/Tests/DictusCoreTests/LiveActivityStateMachineTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/LiveActivityStateMachineTests.swift
@@ -119,6 +119,72 @@ final class LiveActivityStateMachineTests: XCTestCase {
         XCTAssertEqual(sm.currentPhase, .ready)
     }
 
+    // MARK: - A dictation abandoned inside a stage (#267 review)
+
+    /// The property the whole recovery rests on. Before this edge existed, a
+    /// dictation abandoned during transcription left the machine parked there, and
+    /// the pill could never be walked back.
+    func testAnAbandonedTranscriptionCanReturnToStandby() {
+        var sm = LiveActivityStateMachine()
+        sm.transition(to: .standby)
+        sm.transition(to: .recording)
+        sm.transition(to: .transcribing)
+        XCTAssertTrue(sm.transition(to: .standby))
+        XCTAssertEqual(sm.currentPhase, .standby)
+    }
+
+    func testAnAbandonedProcessingStageCanReturnToStandby() {
+        var sm = LiveActivityStateMachine()
+        sm.transition(to: .standby)
+        sm.transition(to: .recording)
+        sm.transition(to: .transcribing)
+        sm.transition(to: .processing)
+        XCTAssertTrue(sm.transition(to: .standby))
+        XCTAssertEqual(sm.currentPhase, .standby)
+    }
+
+    /// The user-visible consequence, and the reason the edge above is not a
+    /// cosmetic tidy-up: the next dictation has to be able to record.
+    ///
+    /// Without the recovery, the machine sat on the abandoned stage and this
+    /// `.recording` transition was rejected -- so the Dynamic Island kept showing
+    /// the stage of a dictation that had ended, while a new one recorded
+    /// underneath it. That is the #42 / #257 desync, reached through the watchdog.
+    func testTheNextDictationCanRecordAfterAnAbandonedStage() {
+        for abandoned in [LiveActivityStateMachine.Phase.transcribing, .processing] {
+            var sm = LiveActivityStateMachine()
+            sm.transition(to: .standby)
+            sm.transition(to: .recording)
+            sm.transition(to: .transcribing)
+            if abandoned == .processing {
+                sm.transition(to: .processing)
+            }
+            XCTAssertEqual(sm.currentPhase, abandoned)
+
+            XCTAssertTrue(
+                sm.transition(to: .standby),
+                "a dictation abandoned in \(abandoned.rawValue) must be able to come home"
+            )
+            XCTAssertTrue(
+                sm.transition(to: .recording),
+                "the dictation after one abandoned in \(abandoned.rawValue) must be able to record"
+            )
+        }
+    }
+
+    /// The recovery must not become a way for a finished dictation to reopen the
+    /// wait: standby still leads forward, never back into a stage.
+    func testRecoveringToStandbyDoesNotReopenAStage() {
+        var sm = LiveActivityStateMachine()
+        sm.transition(to: .standby)
+        sm.transition(to: .recording)
+        sm.transition(to: .transcribing)
+        sm.transition(to: .standby)
+        XCTAssertFalse(sm.transition(to: .transcribing))
+        XCTAssertFalse(sm.transition(to: .processing))
+        XCTAssertEqual(sm.currentPhase, .standby)
+    }
+
     func testTranscribingToFailedSucceeds() {
         var sm = LiveActivityStateMachine()
         sm.transition(to: .standby)

--- a/DictusCore/Tests/DictusCoreTests/ProcessingWaveformTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/ProcessingWaveformTests.swift
@@ -120,10 +120,14 @@ final class ProcessingWaveformTests: XCTestCase {
         XCTAssertGreaterThan(shortlyAfter, start)
     }
 
-    /// The reduced-motion fallback freezes the phase rather than flattening the
-    /// bars, so the frozen pose has to be the centred one -- a peak parked against
-    /// an edge would read as a rendering fault.
-    func testTheFrozenReducedMotionPoseIsCentred() {
+    /// Each stage starts from `centredPhase`, so the peak has to enter from the
+    /// middle rather than appear mid-travel against an edge.
+    ///
+    /// This assertion outlived the reduced-motion fallback it was first written
+    /// for: that freeze was removed by maintainer decision after device testing
+    /// (see `KeyboardWaveformDriver.needsDisplayLink`). The starting pose is still
+    /// worth pinning.
+    func testTheStartingPoseIsCentred() {
         XCTAssertEqual(
             ProcessingWaveform.peakPosition(phase: ProcessingWaveform.centredPhase),
             centre,
@@ -131,10 +135,34 @@ final class ProcessingWaveformTests: XCTestCase {
         )
     }
 
-    /// 0.7 Hz means a round trip in about 1.4 s, so a 3 s wait -- the short end of
-    /// today's polish -- shows two full sweeps.
-    func testACycleFitsTwiceIntoTheShortestExpectedWait() {
-        let cycleSeconds = 1 / ProcessingWaveform.phaseRate
-        XCTAssertLessThan(cycleSeconds * 2, 3.0)
+    /// The tempo is set by contrast with the animation it follows, not in the
+    /// abstract. The peak crosses the row in half a cycle; the sine crosses it in
+    /// one phase unit. Shipping 0.7 Hz made the peak 2.8x faster than the sine,
+    /// which read as rushed on device -- 0.5 Hz makes it exactly twice.
+    func testThePeakCrossesTheRowTwiceAsFastAsTheTranscriptionSweep() {
+        XCTAssertEqual(peakCrossingSeconds, 1.0, accuracy: 0.0001)
+        XCTAssertEqual(transcriptionSweepCrossingSeconds, 2.0, accuracy: 0.0001)
+        XCTAssertEqual(
+            transcriptionSweepCrossingSeconds / peakCrossingSeconds, 2, accuracy: 0.0001
+        )
+    }
+
+    /// The shortest LLM stage measured on device ran 1 s. It has to show a whole
+    /// crossing, or the animation reads as a twitch and says nothing.
+    func testTheShortestMeasuredStageStillShowsAWholeCrossing() {
+        XCTAssertLessThanOrEqual(peakCrossingSeconds, 1.0)
+    }
+
+    /// Seconds for the peak to travel from one edge to the other: half a cycle,
+    /// since a full cycle is out and back.
+    private var peakCrossingSeconds: Double {
+        1 / (2 * ProcessingWaveform.phaseRate)
+    }
+
+    /// Seconds for the transcription sine's pattern to cross the row. Its phase
+    /// advances by `link.duration / 2` per frame, i.e. 0.5 per second, and the
+    /// pattern translates by one full row per unit of phase.
+    private var transcriptionSweepCrossingSeconds: Double {
+        1 / 0.5
     }
 }

--- a/DictusCore/Tests/DictusCoreTests/ProcessingWaveformTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/ProcessingWaveformTests.swift
@@ -53,7 +53,8 @@ final class ProcessingWaveformTests: XCTestCase {
             )
 
             let sweepLevels = (0..<barCount).map { transcriptionSweepLevel(at: $0, phase: phase) }
-            let flatUnderSweep = sweepLevels.filter { abs($0 - sweepLevels.min()!) < 0.0001 }.count
+            let sweepFloor = sweepLevels.min() ?? 0
+            let flatUnderSweep = sweepLevels.filter { abs($0 - sweepFloor) < 0.0001 }.count
             XCTAssertLessThanOrEqual(
                 flatUnderSweep, 2,
                 "phase \(phase): the sine is supposed to have no flat run, it has \(flatUnderSweep)"

--- a/DictusCore/Tests/DictusCoreTests/ProcessingWaveformTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/ProcessingWaveformTests.swift
@@ -1,0 +1,139 @@
+// DictusCore/Tests/DictusCoreTests/ProcessingWaveformTests.swift
+// The shape and the travel of the LLM-stage animation (#267).
+
+import XCTest
+@testable import DictusCore
+
+/// Coverage for the travelling-peak sweep.
+///
+/// These tests exist because the animation itself is unreachable from a test: it
+/// lives behind a `CADisplayLink` in `DictusKeyboard`, a target with no test
+/// bundle, inside a keyboard extension a simulator cannot even enable. What can be
+/// pinned is the arithmetic that decides every bar's height, and that is where the
+/// property the issue asks for lives -- "reads as a different family from the
+/// transcription sine" is, concretely, "localized peak" against "continuous wave".
+final class ProcessingWaveformTests: XCTestCase {
+
+    private var barCount: Int { ProcessingWaveform.barCount }
+    private var centre: Double { Double(ProcessingWaveform.barCount - 1) / 2 }
+
+    // MARK: - The shape is a localized peak
+
+    func testTheBarUnderThePeakIsAtTheCrest() {
+        let levels = ProcessingWaveform.levels(peakPosition: 0)
+        XCTAssertEqual(levels[0], ProcessingWaveform.crest, accuracy: 0.0001)
+    }
+
+    func testBarsBeyondTheHalfWidthSitAtTheBaseline() {
+        let levels = ProcessingWaveform.levels(peakPosition: 0)
+        let firstOutside = Int(ProcessingWaveform.halfWidth)
+        for index in firstOutside..<barCount {
+            XCTAssertEqual(
+                levels[index], ProcessingWaveform.baseline, accuracy: 0.0001,
+                "bar \(index) is \(ProcessingWaveform.halfWidth) or more from the peak"
+            )
+        }
+    }
+
+    /// The defining difference from the transcription sine, stated as the issue
+    /// states it: one is a localized peak, the other a continuous wave. Concretely,
+    /// at every instant the peak leaves a large run of bars sitting at exactly the
+    /// same floor, which a sine never does -- it is somewhere on its curve
+    /// everywhere. This is the property that survives a glance at a 120 pt-tall
+    /// waveform, and the reason the two states can be told apart at all.
+    func testThePeakAlwaysLeavesAFlatRunThatTheTranscriptionSweepNeverHas() {
+        for step in 0..<20 {
+            let phase = Double(step) / 20
+
+            let peakLevels = ProcessingWaveform.levels(phase: phase)
+            let flatUnderPeak = peakLevels.filter { abs($0 - ProcessingWaveform.baseline) < 0.0001 }.count
+            XCTAssertGreaterThanOrEqual(
+                flatUnderPeak, barCount / 3,
+                "phase \(phase): only \(flatUnderPeak) of \(barCount) bars are at the floor"
+            )
+
+            let sweepLevels = (0..<barCount).map { transcriptionSweepLevel(at: $0, phase: phase) }
+            let flatUnderSweep = sweepLevels.filter { abs($0 - sweepLevels.min()!) < 0.0001 }.count
+            XCTAssertLessThanOrEqual(
+                flatUnderSweep, 2,
+                "phase \(phase): the sine is supposed to have no flat run, it has \(flatUnderSweep)"
+            )
+        }
+    }
+
+    /// `KeyboardWaveformDriver.processingEnergy`, duplicated because the driver
+    /// lives in the keyboard target this bundle cannot import. Kept to one call
+    /// site: the test above, which exists to contrast the two curves.
+    private func transcriptionSweepLevel(at index: Int, phase: Double) -> Float {
+        let normalizedIndex = Double(index) / Double(max(barCount - 1, 1))
+        let sineValue = sin(2 * .pi * (normalizedIndex + phase))
+        return Float(0.2 + 0.25 * (sineValue + 1.0))
+    }
+
+    /// Heights fall away monotonically from the peak, which is what makes the shape
+    /// read as one bump rather than as noise.
+    func testHeightsDecreaseMonotonicallyAwayFromThePeak() {
+        let levels = ProcessingWaveform.levels(peakPosition: centre)
+        let peakIndex = Int(centre.rounded())
+        for index in (peakIndex + 1)..<barCount {
+            XCTAssertLessThanOrEqual(levels[index], levels[index - 1], "rising again at bar \(index)")
+        }
+        for index in stride(from: peakIndex - 1, through: 0, by: -1) {
+            XCTAssertLessThanOrEqual(levels[index], levels[index + 1], "rising again at bar \(index)")
+        }
+    }
+
+    func testEveryLevelStaysBetweenBaselineAndCrest() {
+        for step in 0..<40 {
+            for level in ProcessingWaveform.levels(phase: Double(step) / 40) {
+                XCTAssertGreaterThanOrEqual(level, ProcessingWaveform.baseline)
+                XCTAssertLessThanOrEqual(level, ProcessingWaveform.crest)
+            }
+        }
+    }
+
+    /// The issue's reason for reusing the transcription crest: same visual
+    /// vocabulary, different motion. `KeyboardWaveformDriver.processingEnergy`
+    /// tops out at 0.2 + 0.25 * 2 = 0.7.
+    func testTheCrestMatchesTheTranscriptionSweep() {
+        XCTAssertEqual(ProcessingWaveform.crest, 0.7, accuracy: 0.0001)
+    }
+
+    // MARK: - The peak travels
+
+    func testThePeakSweepsTheFullWidthAndComesBack() {
+        var positions: [Double] = []
+        for step in 0...100 {
+            positions.append(ProcessingWaveform.peakPosition(phase: Double(step) / 100))
+        }
+        XCTAssertEqual(positions.min() ?? -1, 0, accuracy: 0.01)
+        XCTAssertEqual(positions.max() ?? -1, Double(barCount - 1), accuracy: 0.01)
+        // One cycle ends where it began: the travel is a round trip, not a jump
+        // back to the start.
+        XCTAssertEqual(positions.first ?? 0, positions.last ?? -1, accuracy: 0.0001)
+    }
+
+    func testThePeakIsMovingAtTheStartOfACycle() {
+        let start = ProcessingWaveform.peakPosition(phase: 0)
+        let shortlyAfter = ProcessingWaveform.peakPosition(phase: 0.01)
+        XCTAssertGreaterThan(shortlyAfter, start)
+    }
+
+    /// The reduced-motion fallback freezes the phase rather than flattening the
+    /// bars, so the frozen pose has to be the centred one -- a peak parked against
+    /// an edge would read as a rendering fault.
+    func testTheFrozenReducedMotionPoseIsCentred() {
+        XCTAssertEqual(
+            ProcessingWaveform.peakPosition(phase: ProcessingWaveform.centredPhase),
+            centre,
+            accuracy: 0.0001
+        )
+    }
+
+    /// 0.7 Hz means a round trip in about 1.4 s, so a 3 s wait -- the short end of
+    /// today's polish -- shows two full sweeps.
+    func testACycleFitsTwiceIntoTheShortestExpectedWait() {
+        let cycleSeconds = 1 / ProcessingWaveform.phaseRate
+        XCTAssertLessThan(cycleSeconds * 2, 3.0)
+    }
+}

--- a/DictusKeyboard/KeyboardRootView.swift
+++ b/DictusKeyboard/KeyboardRootView.swift
@@ -328,6 +328,14 @@ struct KeyboardRootView: View {
         .onChange(of: state.isKeyboardVisible) { _, _ in
             syncWaveformDriver()
         }
+        // The driver holds its own copy of the setting and decides from it whether
+        // to run a display link at all, so a toggle that arrives while the overlay
+        // is already up has to be pushed to it. Without this, turning Reduce Motion
+        // on mid-dictation leaves the peak sweeping, and turning it off leaves the
+        // bars frozen until the next status change.
+        .onChange(of: reduceMotion) { _, _ in
+            syncWaveformDriver()
+        }
         .onAppear {
             PersistentLog.log(.diagnosticProbe(
                 component: "KeyboardRootView",

--- a/DictusKeyboard/KeyboardRootView.swift
+++ b/DictusKeyboard/KeyboardRootView.swift
@@ -66,12 +66,6 @@ struct KeyboardRootView: View {
     /// chain. We capture it here and inject it into KeyboardState via .onAppear.
     @Environment(\.openURL) private var openURL
 
-    /// Forwarded to the waveform driver so it can drop the travelling-peak
-    /// animation's motion (#267). Read here rather than in `KeyboardWaveformView`
-    /// because the driver decides whether to run a display link at all, and a
-    /// setting only the view knows about cannot stop one from starting.
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-
     /// Fixed toolbar height, matching `KeyboardViewController.toolbarHeight`.
     private let toolbarHeight: CGFloat = 52
 
@@ -328,14 +322,6 @@ struct KeyboardRootView: View {
         .onChange(of: state.isKeyboardVisible) { _, _ in
             syncWaveformDriver()
         }
-        // The driver holds its own copy of the setting and decides from it whether
-        // to run a display link at all, so a toggle that arrives while the overlay
-        // is already up has to be pushed to it. Without this, turning Reduce Motion
-        // on mid-dictation leaves the peak sweeping, and turning it off leaves the
-        // bars frozen until the next status change.
-        .onChange(of: reduceMotion) { _, _ in
-            syncWaveformDriver()
-        }
         .onAppear {
             PersistentLog.log(.diagnosticProbe(
                 component: "KeyboardRootView",
@@ -380,8 +366,7 @@ struct KeyboardRootView: View {
             presenterID: controllerID,
             status: state.dictationStatus,
             energyLevels: state.waveformEnergy,
-            isVisible: !forceHidden && presentedMode == .recording,
-            reduceMotion: reduceMotion
+            isVisible: !forceHidden && presentedMode == .recording
         )
     }
 

--- a/DictusKeyboard/KeyboardRootView.swift
+++ b/DictusKeyboard/KeyboardRootView.swift
@@ -66,6 +66,12 @@ struct KeyboardRootView: View {
     /// chain. We capture it here and inject it into KeyboardState via .onAppear.
     @Environment(\.openURL) private var openURL
 
+    /// Forwarded to the waveform driver so it can drop the travelling-peak
+    /// animation's motion (#267). Read here rather than in `KeyboardWaveformView`
+    /// because the driver decides whether to run a display link at all, and a
+    /// setting only the view knows about cannot stop one from starting.
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     /// Fixed toolbar height, matching `KeyboardViewController.toolbarHeight`.
     private let toolbarHeight: CGFloat = 52
 
@@ -366,7 +372,8 @@ struct KeyboardRootView: View {
             presenterID: controllerID,
             status: state.dictationStatus,
             energyLevels: state.waveformEnergy,
-            isVisible: !forceHidden && presentedMode == .recording
+            isVisible: !forceHidden && presentedMode == .recording,
+            reduceMotion: reduceMotion
         )
     }
 

--- a/DictusKeyboard/KeyboardState.swift
+++ b/DictusKeyboard/KeyboardState.swift
@@ -344,8 +344,10 @@ class KeyboardState: ObservableObject {
         lastWaveformUpdate = Date()
         watchdogTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
             guard let self = self else { return }
-            let activeStates: [DictationStatus] = [.requested, .recording, .transcribing]
-            guard activeStates.contains(self.dictationStatus) else {
+            // The shared predicate, not a literal list: it is an exhaustive switch
+            // over `DictationStatus`, so a status added later cannot quietly stop
+            // being watched. That is how `.processing` (#267) got here.
+            guard DictationSessionLivenessPolicy.isActive(self.dictationStatus) else {
                 self.stopWatchdog()
                 return
             }
@@ -543,9 +545,12 @@ class KeyboardState: ObservableObject {
             // WHY restart (not just start): transitioning .requested → .recording
             // must reset lastWaveformUpdate. Without this, the watchdog fires
             // immediately because it still has the timestamp from markRequested().
-            let activeStates: [DictationStatus] = [.requested, .recording, .transcribing]
-            if activeStates.contains(status) {
-                if !activeStates.contains(oldStatus) || status != oldStatus {
+            //
+            // `.transcribing → .processing` (#267) is one such transition: it
+            // restarts the watchdog, which is what gives the LLM stage its own
+            // fresh 5 s window instead of inheriting the transcription's.
+            if DictationSessionLivenessPolicy.isActive(status) {
+                if !DictationSessionLivenessPolicy.isActive(oldStatus) || status != oldStatus {
                     startWatchdog()
                 }
                 // During cold start, the app is transitioning between foreground/background.
@@ -581,7 +586,7 @@ class KeyboardState: ObservableObject {
             // from suspension (e.g., swipe-back during cold start recording).
             // WHY: If oldStatus == status == .recording, SwiftUI skips re-render
             // because no @Published value changed. objectWillChange forces it.
-            if isKeyboardVisible && oldStatus == status && activeStates.contains(status) {
+            if isKeyboardVisible && oldStatus == status && DictationSessionLivenessPolicy.isActive(status) {
                 objectWillChange.send()
             }
         }

--- a/DictusKeyboard/Localizable.xcstrings
+++ b/DictusKeyboard/Localizable.xcstrings
@@ -122,6 +122,17 @@
         }
       }
     },
+    "Processing..." : {
+      "comment" : "Recording overlay caption while the LLM stage runs on the transcript (issue #267).",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traitement..."
+          }
+        }
+      }
+    },
     "Recording interrupted. Please try again." : {
       "comment" : "Toolbar message shown when the keyboard clears a recording whose app was terminated (issue #261).",
       "localizations" : {

--- a/DictusKeyboard/Views/KeyboardWaveformView.swift
+++ b/DictusKeyboard/Views/KeyboardWaveformView.swift
@@ -2,13 +2,30 @@ import SwiftUI
 import QuartzCore
 import DictusCore
 
+/// Which of the overlay's three animations the bars are drawing (#267).
+///
+/// WHY a mode and not two booleans: the three are mutually exclusive, and the
+/// pre-#267 code already carried one boolean (`isProcessing`) that the view read
+/// to pick between two of them. A second boolean would have made "both true"
+/// expressible, which is the shape of bug this repo has paid for elsewhere.
+enum KeyboardWaveformAnimation {
+    /// Bar heights follow the microphone's energy. `.recording`.
+    case micLevels
+    /// Continuous sine sweep. `.transcribing`.
+    case sweep
+    /// Travelling peak scanning back and forth. `.processing`.
+    case travellingPeak
+    /// Nothing is animating -- flat bars.
+    case still
+}
+
 @MainActor
 final class KeyboardWaveformDriver: ObservableObject {
     static let shared = KeyboardWaveformDriver()
     private let instanceID = String(UUID().uuidString.prefix(8))
 
     @Published private(set) var displayLevels: [Float] = Array(repeating: 0, count: 30)
-    @Published private(set) var isProcessing = false
+    @Published private(set) var animation: KeyboardWaveformAnimation = .still
     @Published private(set) var processingPhase: Double = 0
     @Published private(set) var renderTick: Int = 0
 
@@ -19,6 +36,7 @@ final class KeyboardWaveformDriver: ObservableObject {
     private var status: DictationStatus = .idle
     private var energyLevels: [Float] = []
     private var isVisible = false
+    private var reduceMotion = false
     private var activePresenterID: String?
     private var displayLink: CADisplayLink?
     private var lastTickTime: CFTimeInterval?
@@ -32,7 +50,13 @@ final class KeyboardWaveformDriver: ObservableObject {
         displayLink?.invalidate()
     }
 
-    func sync(presenterID: String, status: DictationStatus, energyLevels: [Float], isVisible: Bool) {
+    func sync(
+        presenterID: String,
+        status: DictationStatus,
+        energyLevels: [Float],
+        isVisible: Bool,
+        reduceMotion: Bool
+    ) {
         let ownsPresentation = activePresenterID == presenterID
         if !isVisible && !ownsPresentation && activePresenterID != nil {
             return
@@ -44,13 +68,22 @@ final class KeyboardWaveformDriver: ObservableObject {
             activePresenterID = nil
         }
 
+        let previousStatus = self.status
         self.status = status
         self.energyLevels = energyLevels
         self.isVisible = isVisible
-        isProcessing = status == .transcribing
+        self.reduceMotion = reduceMotion
+        animation = resolvedAnimation(for: status)
 
-        if status != .transcribing {
-            processingPhase = 0
+        // One phase drives both the transcription sine and the travelling peak, so
+        // it restarts on every status change rather than only on the way out of an
+        // animated state: `.transcribing -> .processing` (#267) hands the phase from
+        // one curve to the other, and inheriting the sine's phase would drop the peak
+        // at an arbitrary point of its travel. Zero is also the pose the
+        // reduced-motion fallback freezes on -- `sin(0) == 0` puts the peak at the
+        // centre of the row (`ProcessingWaveform.centredPhase`).
+        if status != previousStatus {
+            processingPhase = ProcessingWaveform.centredPhase
         }
 
         if status == .requested || status == .idle || status == .ready {
@@ -65,8 +98,45 @@ final class KeyboardWaveformDriver: ObservableObject {
         updateDisplayLinkState()
     }
 
+    /// Which animation `status` calls for.
+    private func resolvedAnimation(for status: DictationStatus) -> KeyboardWaveformAnimation {
+        switch status {
+        case .recording:
+            return .micLevels
+        case .transcribing:
+            return .sweep
+        case .processing:
+            return .travellingPeak
+        case .idle, .requested, .ready, .failed:
+            return .still
+        }
+    }
+
+    /// Whether the current animation has to be redrawn every frame.
+    ///
+    /// WHY reduced motion answers "no" for the travelling peak rather than the
+    /// driver picking a different shape (#267): the shape is fine -- it is the
+    /// travel that has to go. Freezing the phase leaves the peak parked at the
+    /// centre of the row (`ProcessingWaveform.centredPhase`), which is a
+    /// deliberate-looking pose rather than the blank strip a flat fallback gives,
+    /// and it costs no display link at all. The footer still names the stage, so
+    /// the still bars are never the only thing telling the user what is happening.
+    ///
+    /// Recording and transcription are untouched: changing them is out of scope for
+    /// #267, and the mic-driven bars are feedback, not decoration.
+    private var needsDisplayLink: Bool {
+        switch animation {
+        case .micLevels, .sweep:
+            return true
+        case .travellingPeak:
+            return !reduceMotion
+        case .still:
+            return false
+        }
+    }
+
     private func updateDisplayLinkState() {
-        let shouldRun = isVisible && (status == .recording || status == .transcribing)
+        let shouldRun = isVisible && needsDisplayLink
 
         if shouldRun {
             startDisplayLinkIfNeeded()
@@ -82,9 +152,13 @@ final class KeyboardWaveformDriver: ObservableObject {
         link.add(to: .main, forMode: .common)
         displayLink = link
 
+        // `isProcessing` keeps its pre-#267 meaning here -- "the bars are drawing
+        // themselves rather than following the mic" -- so log lines from older
+        // builds stay comparable. Which of the two self-driven animations it is
+        // reads off `status=` on the probe line below.
         PersistentLog.log(.waveformAppeared(
             refreshID: renderTick,
-            isProcessing: status == .transcribing,
+            isProcessing: animation == .sweep || animation == .travellingPeak,
             energyCount: energyLevels.count,
             killedState: false
         ))
@@ -122,12 +196,14 @@ final class KeyboardWaveformDriver: ObservableObject {
             }
         }
 
-        switch status {
-        case .recording:
+        switch animation {
+        case .micLevels:
             tickRecording()
-        case .transcribing:
+        case .sweep:
             processingPhase += link.duration / 2.0
-        default:
+        case .travellingPeak:
+            processingPhase += link.duration * ProcessingWaveform.phaseRate
+        case .still:
             break
         }
 
@@ -164,9 +240,12 @@ final class KeyboardWaveformDriver: ObservableObject {
         let targets = targetLevels()
 
         let sourceLevels: [Float]
-        if status == .transcribing {
+        switch animation {
+        case .sweep:
             sourceLevels = (0..<barCount).map { processingEnergy(at: $0, phase: processingPhase) }
-        } else {
+        case .travellingPeak:
+            sourceLevels = ProcessingWaveform.levels(phase: processingPhase)
+        case .micLevels, .still:
             sourceLevels = displayLevels
         }
 
@@ -176,7 +255,7 @@ final class KeyboardWaveformDriver: ObservableObject {
             avgLevel: average,
             energyCount: energyLevels.count
         ))
-        if status == .recording {
+        if animation == .micLevels {
             logProbe(
                 "waveformShape",
                 details: "target{\(waveformStatsDetails(targets))} display{\(waveformStatsDetails(displayLevels))}"
@@ -255,12 +334,7 @@ struct KeyboardWaveformView: View {
     var body: some View {
         HStack(spacing: barSpacing) {
             ForEach(0..<barCount, id: \.self) { index in
-                let energy: Float = driver.isProcessing
-                    ? driver.processingEnergy(at: index, phase: driver.processingPhase)
-                    : (index < driver.displayLevels.count ? driver.displayLevels[index] : 0)
-
-                let minHeight: CGFloat = driver.isProcessing ? 4 : 2
-                let height = max(minHeight + CGFloat(energy) * (maxHeight - minHeight), minHeight)
+                let height = barHeight(at: index)
 
                 Capsule()
                     .fill(resolvedBarColor(at: index))
@@ -268,6 +342,34 @@ struct KeyboardWaveformView: View {
             }
         }
         .frame(height: maxHeight)
+    }
+
+    /// Height of one bar under whichever animation is running.
+    ///
+    /// The two self-driven animations share the 4 pt floor: it is what keeps the
+    /// row reading as a waveform at rest rather than as a blank strip. The
+    /// travelling peak needs it more than the sine does -- its baseline is 0.05,
+    /// so most of its bars sit on that floor at any instant (#267).
+    private func barHeight(at index: Int) -> CGFloat {
+        let energy: Float
+        let minHeight: CGFloat
+
+        switch driver.animation {
+        case .sweep:
+            energy = driver.processingEnergy(at: index, phase: driver.processingPhase)
+            minHeight = 4
+        case .travellingPeak:
+            energy = ProcessingWaveform.level(
+                at: index,
+                peakPosition: ProcessingWaveform.peakPosition(phase: driver.processingPhase)
+            )
+            minHeight = 4
+        case .micLevels, .still:
+            energy = index < driver.displayLevels.count ? driver.displayLevels[index] : 0
+            minHeight = 2
+        }
+
+        return max(minHeight + CGFloat(energy) * (maxHeight - minHeight), minHeight)
     }
 
     private func resolvedBarColor(at index: Int) -> Color {

--- a/DictusKeyboard/Views/KeyboardWaveformView.swift
+++ b/DictusKeyboard/Views/KeyboardWaveformView.swift
@@ -2,30 +2,13 @@ import SwiftUI
 import QuartzCore
 import DictusCore
 
-/// Which of the overlay's three animations the bars are drawing (#267).
-///
-/// WHY a mode and not two booleans: the three are mutually exclusive, and the
-/// pre-#267 code already carried one boolean (`isProcessing`) that the view read
-/// to pick between two of them. A second boolean would have made "both true"
-/// expressible, which is the shape of bug this repo has paid for elsewhere.
-enum KeyboardWaveformAnimation {
-    /// Bar heights follow the microphone's energy. `.recording`.
-    case micLevels
-    /// Continuous sine sweep. `.transcribing`.
-    case sweep
-    /// Travelling peak scanning back and forth. `.processing`.
-    case travellingPeak
-    /// Nothing is animating -- flat bars.
-    case still
-}
-
 @MainActor
 final class KeyboardWaveformDriver: ObservableObject {
     static let shared = KeyboardWaveformDriver()
     private let instanceID = String(UUID().uuidString.prefix(8))
 
     @Published private(set) var displayLevels: [Float] = Array(repeating: 0, count: 30)
-    @Published private(set) var animation: KeyboardWaveformAnimation = .still
+    @Published private(set) var animation: WaveformAnimation = .still
     @Published private(set) var processingPhase: Double = 0
     @Published private(set) var renderTick: Int = 0
 
@@ -36,7 +19,6 @@ final class KeyboardWaveformDriver: ObservableObject {
     private var status: DictationStatus = .idle
     private var energyLevels: [Float] = []
     private var isVisible = false
-    private var reduceMotion = false
     private var activePresenterID: String?
     private var displayLink: CADisplayLink?
     private var lastTickTime: CFTimeInterval?
@@ -54,8 +36,7 @@ final class KeyboardWaveformDriver: ObservableObject {
         presenterID: String,
         status: DictationStatus,
         energyLevels: [Float],
-        isVisible: Bool,
-        reduceMotion: Bool
+        isVisible: Bool
     ) {
         let ownsPresentation = activePresenterID == presenterID
         if !isVisible && !ownsPresentation && activePresenterID != nil {
@@ -72,16 +53,15 @@ final class KeyboardWaveformDriver: ObservableObject {
         self.status = status
         self.energyLevels = energyLevels
         self.isVisible = isVisible
-        self.reduceMotion = reduceMotion
         animation = resolvedAnimation(for: status)
 
         // One phase drives both the transcription sine and the travelling peak, so
         // it restarts on every status change rather than only on the way out of an
         // animated state: `.transcribing -> .processing` (#267) hands the phase from
         // one curve to the other, and inheriting the sine's phase would drop the peak
-        // at an arbitrary point of its travel. Zero is also the pose the
-        // reduced-motion fallback freezes on -- `sin(0) == 0` puts the peak at the
-        // centre of the row (`ProcessingWaveform.centredPhase`).
+        // at an arbitrary point of its travel. `ProcessingWaveform.centredPhase` is
+        // zero, which starts the peak at the centre of the row and lets it sweep
+        // out from there.
         if status != previousStatus {
             processingPhase = ProcessingWaveform.centredPhase
         }
@@ -99,7 +79,7 @@ final class KeyboardWaveformDriver: ObservableObject {
     }
 
     /// Which animation `status` calls for.
-    private func resolvedAnimation(for status: DictationStatus) -> KeyboardWaveformAnimation {
+    private func resolvedAnimation(for status: DictationStatus) -> WaveformAnimation {
         switch status {
         case .recording:
             return .micLevels
@@ -114,22 +94,20 @@ final class KeyboardWaveformDriver: ObservableObject {
 
     /// Whether the current animation has to be redrawn every frame.
     ///
-    /// WHY reduced motion answers "no" for the travelling peak rather than the
-    /// driver picking a different shape (#267): the shape is fine -- it is the
-    /// travel that has to go. Freezing the phase leaves the peak parked at the
-    /// centre of the row (`ProcessingWaveform.centredPhase`), which is a
-    /// deliberate-looking pose rather than the blank strip a flat fallback gives,
-    /// and it costs no display link at all. The footer still names the stage, so
-    /// the still bars are never the only thing telling the user what is happening.
+    /// **There is deliberately no reduced-motion branch here.** An earlier round of
+    /// #267 froze the travelling peak at the centre of the row when Reduce Motion
+    /// was on. The maintainer tested it on device and removed it: the peak moves
+    /// identically whether or not the setting is on.
     ///
-    /// Recording and transcription are untouched: changing them is out of scope for
-    /// #267, and the mic-driven bars are feedback, not decoration.
+    /// That is a decision, not an oversight, and it was taken with the argument
+    /// against it stated -- the setting exists for people for whom a localized
+    /// object crossing the screen is costly, and dropping the fallback gives up
+    /// acceptance criterion 7 of the issue. To be revisited only if a user reports
+    /// it. Do not reinstate the freeze as a tidy-up.
     private var needsDisplayLink: Bool {
         switch animation {
-        case .micLevels, .sweep:
+        case .micLevels, .sweep, .travellingPeak:
             return true
-        case .travellingPeak:
-            return !reduceMotion
         case .still:
             return false
         }
@@ -158,7 +136,7 @@ final class KeyboardWaveformDriver: ObservableObject {
         // reads off `status=` on the probe line below.
         PersistentLog.log(.waveformAppeared(
             refreshID: renderTick,
-            isProcessing: animation == .sweep || animation == .travellingPeak,
+            isProcessing: animation.isSelfDriven,
             energyCount: energyLevels.count,
             killedState: false
         ))

--- a/DictusKeyboard/Views/RecordingOverlay.swift
+++ b/DictusKeyboard/Views/RecordingOverlay.swift
@@ -6,7 +6,8 @@ import DictusCore
 /// Shows different visual states based on DictationStatus:
 /// - .requested: flat waveform bars, "Démarrage..." text, cancel-only button
 /// - .recording: live waveform, elapsed timer, cancel + stop buttons
-/// - .transcribing: shimmer waveform, "Transcription..." text
+/// - .transcribing: sine-sweep waveform, "Transcription..." text
+/// - .processing: travelling-peak waveform, "Traitement..." text (#267)
 ///
 /// WHY this replaces the keyboard:
 /// Wispr Flow-inspired design -- when recording, the keyboard area transforms into
@@ -139,8 +140,10 @@ struct RecordingOverlay: View {
             .padding(.top, 10)
             .padding(.bottom, 6)
 
-        case .transcribing:
-            // Reserve same height as button row so waveform doesn't shift
+        case .transcribing, .processing:
+            // Reserve same height as button row so waveform doesn't shift.
+            // The LLM stage is not cancellable (#267), so it shows the same empty
+            // bar as transcription rather than a button that would do nothing.
             Color.clear
                 .frame(height: 36)
                 .padding(.horizontal, 12)
@@ -196,6 +199,23 @@ struct RecordingOverlay: View {
                 .padding(.bottom, 4)
 
             Text("Transcribing...")
+                .font(.dictusCaption)
+                .foregroundColor(secondaryForeground)
+                .padding(.bottom, 8)
+
+        case .processing:
+            // Same two lines, same heights, same paddings as every other state --
+            // only the caption differs. Naming the stage is half of #267: the
+            // animation says "something else is happening", the label says what.
+            Color.clear
+                .frame(height: timerFontSize)
+                .padding(.bottom, 4)
+
+            // #79 will want the armed Smart Mode's name here instead of the generic
+            // stage name. There is no armed mode to read today -- `ProFeature`
+            // .smartMode is a paywall flag, not a selection -- so this stays one
+            // string until that state exists.
+            Text("Processing...")
                 .font(.dictusCaption)
                 .foregroundColor(secondaryForeground)
                 .padding(.bottom, 8)

--- a/DictusWidgets/DictusLiveActivity.swift
+++ b/DictusWidgets/DictusLiveActivity.swift
@@ -59,6 +59,13 @@ struct DictusLiveActivity: Widget {
             // Pulsing bars at medium height
             MiniLogoBars(levels: [0.4, 0.6, 0.4], animated: true)
                 .frame(width: 20, height: 14)
+        case .processing:
+            // A pronounced centre peak, echoing the localized peak the keyboard
+            // overlay sweeps in this stage (#267). Three bars cannot carry the
+            // sweep itself -- ActivityKit's update budget is ~1/s -- so the shape
+            // and the colour of the trailing label do the distinguishing here.
+            MiniLogoBars(levels: [0.25, 0.85, 0.25], animated: true)
+                .frame(width: 20, height: 14)
         case .ready:
             Image(systemName: "checkmark.circle.fill")
                 .foregroundColor(Color(hex: 0x22C55E))
@@ -86,6 +93,14 @@ struct DictusLiveActivity: Widget {
             // Small spinner-like indicator via SF Symbol
             Image(systemName: "ellipsis")
                 .foregroundColor(.white.opacity(0.7))
+                .font(.system(size: 14))
+        case .processing:
+            // Different glyph AND different colour from transcribing: at compact
+            // size the pill shows one icon, so it has to carry the whole
+            // distinction on its own (#267). Purple is the brand's Smart-mode
+            // colour, which is where this stage is heading (#79).
+            Image(systemName: "sparkles")
+                .foregroundColor(Color(hex: 0x8B5CF6))
                 .font(.system(size: 14))
         case .ready:
             Text("Done")
@@ -132,7 +147,9 @@ struct DictusLiveActivity: Widget {
                 levels: context.state.phase == .recording
                     ? normalizedLevels(context.state.waveformLevels, count: 3)
                     : [0.43, 1.0, 0.64],
-                animated: context.state.phase == .recording || context.state.phase == .transcribing
+                animated: context.state.phase == .recording
+                    || context.state.phase == .transcribing
+                    || context.state.phase == .processing
             )
             .frame(width: 24, height: 18)
 
@@ -154,6 +171,10 @@ struct DictusLiveActivity: Widget {
                     Text("Transcribing...")
                         .font(.system(size: 12))
                         .foregroundColor(Color(hex: 0x3D7EFF))
+                case .processing:
+                    Text("Processing...")
+                        .font(.system(size: 12))
+                        .foregroundColor(Color(hex: 0x8B5CF6))
                 case .ready:
                     Text("Transcription ready")
                         .font(.system(size: 12))
@@ -219,6 +240,9 @@ struct DictusLiveActivity: Widget {
             case .transcribing:
                 ProgressView()
                     .tint(.white)
+            case .processing:
+                ProgressView()
+                    .tint(Color(hex: 0x8B5CF6))
             case .ready, .failed:
                 EmptyView()
             }
@@ -284,6 +308,10 @@ struct DictusLiveActivity: Widget {
                     Text("Transcribing...")
                         .font(.system(size: 13))
                         .foregroundColor(Color(hex: 0x3D7EFF))
+                case .processing:
+                    Text("Processing...")
+                        .font(.system(size: 13))
+                        .foregroundColor(Color(hex: 0x8B5CF6))
                 case .ready:
                     Text(context.state.transcriptionPreview ?? "Transcription ready")
                         .font(.system(size: 13))


### PR DESCRIPTION
Closes nothing automatically — `refs #267`, to be closed by hand after the device test.

## What this was for

Quand tu dictes, la barre d'attente ment. La transcription dure une seconde ou deux, puis la couche LLM (le polish aujourd'hui, les Smart Modes demain) tourne 3 à 6 s de plus — mais l'overlay du clavier continue d'afficher la même animation sinusoïdale et le même mot, « Transcription... ». Une attente de six secondes sous un label qui annonce une seconde se lit comme un plantage, et pousse à taper sur annuler alors que tout va bien.

Le blocage était en amont de l'animation : `DictationStatus` n'avait pas d'état pour cette étape. Le polish tourne dans `stopDictation()` après le retour de `transcribe()`, pendant que le statut dit encore `.transcribing`.

Cette PR ajoute l'état, le fait poser au bon moment, et lui donne son animation, son label et son traitement Dynamic Island.

## To test by hand

Un simulateur ne peut pas activer le clavier Dictus (pas d'injection tactile, pas de dictée sans modèle installé), donc **tout ce qui concerne l'overlay et la Dynamic Island demande le device**.

Prérequis : polish activé dans Réglages DictusApp, iPhone avec Apple Intelligence (sinon le moteur est le passthrough et l'étape ne se déclenche pas, par conception).

1. Ouvre Réglages Dictus, vérifie que le polish est **activé**. Sans ça, rien de ce qui suit ne se déclenche.
2. Dans n'importe quelle app, clavier Dictus, appuie sur le micro et dicte **au moins 3 secondes** (sous 2 s la porte de durée saute le modèle et l'étape n'apparaît pas — c'est voulu).
3. Appuie sur ✓. Attendu, dans l'ordre : les barres passent du niveau micro au **balayage sinusoïdal** avec « Transcription... », puis à un **pic unique qui balaie de gauche à droite et revient** avec « Traitement... ». Le pic doit se lire comme une famille différente du balayage, pas comme la même vague ralentie.
4. Pendant ces deux transitions, **regarde le haut et le bas de l'overlay** : la zone des boutons et la ligne du timer doivent rester exactement à la même hauteur. Aucune barre ne doit sauter verticalement.
5. Le texte s'insère. L'overlay disparaît immédiatement, sans animation de sortie — c'est un choix, voir « Ce qui n'a pas été porté » plus bas.
6. Recommence en gardant l'œil sur la **Dynamic Island** : pastille compacte, « ... » blanc pendant la transcription puis une icône **sparkles violette** pendant le traitement. Appui long : « Transcribing... » en bleu puis « Processing... » en violet, avec le spinner qui change de teinte.
7. Écran verrouillé, même test : la bannière doit afficher les deux libellés dans les deux couleurs.
8. Réglages iOS → Accessibilité → Mouvement → **Réduire les animations : activé**. Redicte. Attendu : le pic balaie **exactement comme avec le réglage désactivé**. Le repli reduced-motion a été retiré par décision explicite du mainteneur, voir le commentaire sur l'issue #267 ; le critère d'acceptation 7 est abandonné, pas rempli.
9. Dicte en anglais avec le clavier en anglais pour vérifier le label EN « Processing... ».
10. Cas où l'étape ne doit **pas** apparaître, à vérifier au moins une fois : dictée très courte (< 2 s) → on passe directement de « Transcription... » au texte inséré, sans « Traitement... » ni clignotement.
11. Exporte le log après quelques dictées et cherche `statusChanged from=transcribing to=processing source=coordinator` puis `liveActivityTransition from=transcribing to=processing`. Ces deux lignes sont la preuve écrite que l'étape a bien été franchie.

Ce que je n'ai pas pu vérifier moi-même et qui est donc entièrement dans cette liste : les trois animations à l'œil, la Dynamic Island, l'écran verrouillé, le réduire-les-animations, et l'absence de saut de layout.

## What changed

Quatre commits, un par surface.

**`DictationStatus.processing`** (core). Les deux prédicats qui décident ce qu'est une dictée en vol — `DictationSessionLivenessPolicy.isActive` et `DictationStatus.ownsKeyboardArea` — sont des `switch` exhaustifs précisément pour ça : ils ont arrêté le compilateur au lieu de laisser le nouveau cas tomber dans « rien ne tourne ». Le seuil de heartbeat est le même que pour la transcription (8 s), et volontairement : ce seuil juge la **cadence** du heartbeat, pas la durée de l'étape, et les deux étapes post-enregistrement tournent contre le même écrivain warm-idle à 3 s. Une étape LLM d'une minute n'est pas plus suspecte à la 50e seconde qu'à la 5e.

**Où l'état est posé.** C'est la décision centrale. Poser `.processing` avant `PolishCoordinator.polish` l'aurait posé sur *toutes* les dictées, y compris la majorité qui reviennent en une milliseconde : toggle désactivé, clip trop court, transcription incompréhensible, moteur passthrough. Un label et une animation pour une frame, ce n'est pas de l'information, c'est un artefact. Le coordinateur passe donc un callback à `polish`, déclenché après toutes ces portes, juste avant la création de la tâche moteur. `announcesProcessingStage` sur le protocole moteur écarte le passthrough (~100 ms, aucun modèle derrière) ; la valeur par défaut est `true`, donc un backend réel ajouté plus tard hérite de l'étape sans rien déclarer.

**Le watchdog.** C'est ce qui aurait régressé en silence. L'ancien timer de 30 s était armé sur `.transcribing` et désarmé en la quittant : le passage à `.processing` l'aurait laissé armé pour tirer 30 s dans une étape qu'il ne connaît pas. Il couvre maintenant les deux, avec 60 s pour l'étape LLM — le temps de génération grandit avec la sortie, ce qui est la raison même de séparer l'étape, et tirer trop tôt jette une transcription qui a déjà réussi.

**L'animation** est portée de Dictus Desktop : un pic localisé qui balaie et revient, crête à 0.7 (la même que la sinusoïde, même vocabulaire visuel) et plancher à 0.05 (bien plus bas, pour que le pic se lise comme localisé). Les cibles sont assignées sans lissage — leçon du desktop : le lisseur efface le grain qui rend le balayage lisible. Les maths vivent dans DictusCore et pas à côté de la vue, parce que la cible DictusKeyboard n'a pas de bundle de test.

**Réduire les animations** gèle la phase au lieu d'aplatir les barres. Ce n'est pas la forme qui pose problème, c'est le déplacement — et à la phase zéro le pic se gare au centre de la rangée, ce qui se lit comme voulu là où une bande plate se lit comme cassé. Le display link ne démarre même pas, donc le repli coûte moins cher que l'animation.

**Nettoyage au passage** : cinq tests « une dictée est-elle en vol ? » écrits à la main (trois dans DictusApp, deux dans `KeyboardState`) sont remplacés par le prédicat exhaustif partagé. C'est exactement la forme d'omission dont #260 et #261 étaient faits.

## Ce qui n'a pas été porté, et pourquoi

**L'outro du desktop.** L'issue la cite comme « worth carrying over » : 300 ms de spline de Hermite pour ramener le pic au centre, puis 400 ms d'effondrement. Sur desktop, l'overlay est sa propre fenêtre et peut s'offrir 700 ms avant de disparaître. Sur iOS, l'overlay **est** la zone clavier : il cède la place à l'instant où le texte est inséré. Une outro retiendrait le clavier pendant les 700 ms exactes que l'utilisateur attend. Elle ne figure dans aucun critère d'acceptation ; si tu la veux quand même, il faudra décider ce qu'elle retarde.

## Acceptance criteria

| # | Critère | Statut | Preuve |
| --- | --- | --- | --- |
| 1 | `processing` existe et est posé pendant l'étape LLM | ✅ | `swift test` (636 tests, 0 échec) ; `testDictationStatusRawValues`, `testActiveStatesAreTheOnesThatOwnADictation` |
| 2 | Animation visuellement distincte dans l'overlay | ✅ code / 👁️ œil | 10 tests `ProcessingWaveformTests` + rendu ASCII ci-dessous ; le rendu réel = étape 3 de la liste manuelle |
| 3 | Le footer nomme l'étape | ✅ partiel | « Processing... » / « Traitement... » ajouté aux xcstrings. **La partie « nomme le mode Smart » n'est pas livrable** : aucun mécanisme d'armement n'existe (`ProFeature.smartMode` est un flag de paywall, pas une sélection). Le point d'accroche est commenté dans `RecordingOverlay.footer` |
| 4 | La Live Activity distingue les deux étapes | ✅ code / 👁️ œil | glyphe, libellé et couleur distincts sur les 5 surfaces du widget ; device requis, étapes 6-7 |
| 5 | Aucun décalage de layout | ✅ par construction / 👁️ œil | `.processing` réserve les mêmes hauteurs que `.transcribing` (36 pt vide + ligne timer + caption) ; rien ne touche `hostingHeightConstraint` ni son timing ; étape 4 |
| 6 | Chaque consommateur gère le cas ; aucun watchdog ne régresse | ✅ | 4 `switch` exhaustifs ont bloqué le compilateur ; 12 sites non exhaustifs traités un par un ; `** BUILD SUCCEEDED **` sur les 4 cibles |
| 7 | Repli réduire-les-animations | ✅ code / 👁️ œil | `testTheFrozenReducedMotionPoseIsCentred` ; étape 8 |

### Preuve du critère 2

Compilé depuis le fichier livré (`swiftc ProcessingWaveform.swift main.swift`), un cycle complet :

```
  phase 0.00  |......._-~=+******+=~-_.......|  peak@ 14.5  flat=10/30
  phase 0.14  |..................__-~=+*****+|  peak@ 25.8  flat=16/30
  phase 0.29  |....................._-~=++***|  peak@ 28.6  flat=19/30
  phase 0.50  |......._-~=+******+=~-_.......|  peak@ 14.5  flat=10/30
  phase 0.71  |***++=~-_.....................|  peak@  0.4  flat=19/30
  phase 1.00  |......._-~=+******+=~-_.......|  peak@ 14.5  flat=10/30

transcription sine, même renderer :
  phase 0.00  |=++*********++==~~---------~~=|  flat= 1/30
  phase 0.25  |#****++==~~--------~~==++****#|  flat= 2/30

réduire les animations, figé :
              |......._-~=+******+=~-_.......|  peak@ 14.5 (centre = 14.5)
```

Le pic laisse 10 à 19 barres exactement au plancher à chaque instant ; la sinusoïde n'en a jamais plus de 2. C'est cette propriété-là qui survit à un coup d'œil sur une forme d'onde de 120 pt, et c'est elle qui est testée.

## Commandes exécutées

```
xcodebuild -resolvePackageDependencies …              → resolved source packages
./scripts/patch-fluidaudio-swift5.sh build/DerivedData → Patched: …/FluidAudio/Package.swift
xcodebuild build -scheme DictusApp -destination 'generic/platform=iOS Simulator'
                                                     → ** BUILD SUCCEEDED **
cd DictusCore && swift test                          → 636 tests, 1 skipped, 0 failures
swiftlint lint --strict                              → 0 violations, 0 serious in 162 files
```

Smoke simulateur (iPhone 17, iOS 26.5, headless) : build, install, launch, `ps` confirme le process vivant, `pluginkit` confirme l'extension clavier enregistrée, capture d'écran de l'onboarding. Le simulateur ne peut pas aller plus loin — voir `docs/agents/simulator.md` §7. App désinstallée après coup, device laissé booté, apparence et status bar inchangées.

Un avertissement de compilation subsiste dans `LiveActivityManager` (`switch must be exhaustive`, ligne 708) : vérifié présent à l'identique sur `develop` (ligne 677), il porte sur `ActivityState` d'Apple et non sur le code de cette PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a distinct “Processing...” stage after transcription for smart-mode language processing.
  * Added animated processing indicators across the app, keyboard, recording overlay, and Live Activity.
  * Improved status messaging and visual feedback during transcription and processing.
* **Bug Fixes**
  * Prevented cancelled, interrupted, or timed-out sessions from applying stale results.
  * Improved recovery of abandoned transcription and processing sessions.
  * Kept dictation activity monitored reliably during longer processing operations with shared timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

# Review round 1 — CodeRabbit

Quatre remarques, quatre traitées. Trois commits : `75ef40c`, `5119c85`, `7517a86`.

## La Live Activity restait en rade (Major) — bug pré-existant, pas une régression

**C'est le point important, et il ne vient pas de cette PR.**

Une dictée abandonnée *pendant* une étape post-enregistrement laissait la pastille bloquée. `cancelDictation` demande deux choses au manager, et aucune ne pouvait aider : `returnToStandby` refuse toute phase autre que `.recording`/`.ready`/`.failed`, et le watchdog d'enregistrement ne débloque que `.recording`. L'app repartait donc en `.idle` pendant que la Live Activity restait sur l'étape — et, moitié qui fait vraiment mal, la state machine restait garée là aussi, ce qui rendait invalide la transition vers `.recording` de la dictée **suivante**. La Dynamic Island affichait alors l'étape d'une dictée terminée pendant qu'une nouvelle enregistrait dessous. C'est #42 et #257 à nouveau, atteints par le watchdog.

Vérifié sur `develop`, pas sur parole :

- garde de `returnToStandby` sur `develop` : `currentPhase == .ready || .failed || .recording` — inchangée par cette PR, elle refusait déjà `.transcribing` ;
- table de transitions sur `develop` : `.transcribing: [.ready, .failed]` — ni `.standby`, ni `.recording`.

Donc le watchdog de transcription de 30 s tombait déjà dans exactement le même cul-de-sac avant #267. Cette PR a seulement rendu la même récupération cassée atteignable depuis un second état, ce qui l'a mise sous les yeux du relecteur.

**Le correctif n'élargit pas la garde de `returnToStandby`** : cette garde est celle de #42, c'est elle qui empêche une tâche d'auto-dismiss périmée d'écraser un enregistrement en cours, et l'élargir donnerait ce pouvoir à tous les appelants. `recoverFromAbandonedStage()` est un chemin séparé qui refuse toute phase sauf les deux pour lesquelles il existe, appelé uniquement depuis le teardown délibéré. Il ramène la state machine même quand aucune activité n'est détenue, parce que la machine garée est ce qui empoisonne la dictée suivante, avec ou sans pastille à montrer.

Les deux nouvelles arêtes `.standby` n'élargissent rien en pratique : `returnToStandby` refuse toujours ces phases derrière sa propre garde avant d'atteindre la validation, donc seul le nouveau chemin peut les emprunter.

Quatre tests dans `LiveActivityStateMachineTests`, **vérifiés en échec sans les arêtes** (10 assertions rouges avec la table remise comme avant). Celui qui compte teste la conséquence et pas la règle : `testTheNextDictationCanRecordAfterAnAbandonedStage`.

## Le label dans DictusApp (Minor)

Juste. La branche était clavetée sur « après le micro » et disait toujours « Transcription en cours... ». Le label se scinde maintenant par statut ; la forme d'onde reste partagée. Partager le shimmer ne coûte rien à l'utilisateur ; lui annoncer la mauvaise étape pendant six secondes est exactement la plainte de l'issue, et elle se lit pareil sur cet écran-là.

La clé a dû être ajoutée à `DictusApp/Localizable.xcstrings` : celle que j'avais ajoutée est dans le bundle du clavier et vaut « Traitement... », là où la voisine de cet écran dit « Transcription en cours... ». Donc « Traitement en cours... » ici.

## Reduce Motion en cours de route (Minor)

Juste, et dans les deux sens. Je raisonnais que le passage en `.processing` resynchronise le driver en lisant la valeur courante — vrai, mais ça ne couvre qu'un réglage changé **avant** l'apparition de l'overlay. Un basculement pendant que l'overlay est déjà là était ignoré jusqu'au changement de statut suivant : Reduce Motion activé laissait le pic balayer, désactivé laissait les barres figées. Une ligne, à côté des quatre autres observateurs.

## Force unwrap dans le test (Minor)

Juste. `let sweepFloor = sweepLevels.min() ?? 0`. Le tableau ne peut pas être vide là, mais la convention du repo est qu'un `!` porte une justification écrite, et celui-ci n'avait rien à écrire.

## Delta pour le test device

**Aucune des onze étapes de la liste ci-dessus n'est invalidée.** Rien n'a touché `KeyboardWaveformView`, `RecordingOverlay`, `ProcessingWaveform` ni `DictusWidgets` — les trois animations, la Dynamic Island, l'écran verrouillé, l'absence de saut de layout et le repli reduce-motion se testent exactement comme écrit.

Trois étapes **s'ajoutent**, toutes dans DictusApp et non dans le clavier :

12. Dicte **depuis DictusApp** (pas le clavier), au moins 3 s, stop. Pendant l'attente, la légende sous la forme d'onde doit passer de « Transcription en cours... » à **« Traitement en cours... »**. C'est la remarque 2.
13. Recommence, et pendant « Traitement en cours... » **appuie sur le ✕** pour quitter l'écran. Puis relance une dictée tout de suite. Attendu : la Dynamic Island affiche bien **« Rec »**. Si elle reste collée sur l'étape précédente pendant que tu enregistres, le correctif de la remarque 1 n'a pas pris. C'est le seul chemin qui déclenche la récupération à la main — les watchdogs demandent 30 s ou 60 s de blocage réel.
14. Optionnel, pénible à produire : basculer Reduce Motion pendant qu'un overlay est affiché. Ça oblige à quitter vers Réglages, ce qui reconstruit le clavier, donc le cas ne se rejoue pas facilement à la main. La remarque 4 est traitée dans le code et couverte par lecture, pas par ce test.

## Vérifications de ce round

```
xcodebuild build -scheme DictusApp   → ** BUILD SUCCEEDED **   (4 cibles)
cd DictusCore && swift test          → 640 tests, 1 skipped, 0 failures   (636 avant)
swiftlint lint --strict              → 0 violations in 162 files
git diff -- '*.xcstrings'            → une seule clé ajoutée, aucun bruit de build
```


---

# Round 2 — après validation device sur `7517a86`

Quatre changements décidés par Pierre pendant sa session device, quatre commits : `283d691`, `04a8457`, `586f86b`, `d66113d`.

## 1. Le pic était trop rapide, 0.7 → 0.5 Hz

Le nombre qui compte n'a jamais été la vitesse seule, mais son rapport à l'animation avec laquelle elle contraste. Mesuré : la sinusoïde de transcription avance sa phase de 0.5 par seconde, donc son motif traverse la rangée en 2.00 s. À 0.7 Hz le pic traversait en 0.71 s, soit 2.8x plus vite, ce qui se lisait comme précipité et non comme un autre tempo. À 0.5 Hz une traversée prend exactement 1.00 s, deux fois la sinusoïde.

Le contraste de tempo est voulu et reste. Le plancher sous ce nombre est la plus courte étape qui mérite une animation : les étapes LLM mesurées ont duré 1 s et 3 s, et à 0.5 Hz même celle d'une seconde montre une traversée entière.

Le test qui figeait l'ancien rythme affirmait qu'un cycle tenait deux fois dans 3 s, ce qui était un fait sur 0.7 Hz, pas une raison. Il affirme maintenant le rapport à la sinusoïde, c'est-à-dire ce qui a réellement été décidé.

## 2. Le pic est dessiné sur l'écran d'enregistrement de DictusApp

J'avais délibérément partagé une seule animation entre les deux étapes sur cet écran, en écrivant pourquoi. Pierre a testé et tranché dans l'autre sens : quelqu'un qui dicte depuis DictusApp attend sur cet écran, et il lui doit la même réponse que l'overlay clavier.

**Les maths ne sont pas dupliquées** : `BrandWaveform` appelle le même `ProcessingWaveform` que le clavier, donc la forme, la crête, le plancher et le tempo n'ont qu'une seule définition.

Le vocabulaire est partagé aussi, maintenant. Les deux formes d'onde portaient un `isProcessing: Bool` que le rendu lisait pour choisir entre deux animations ; une troisième n'aurait pu arriver que comme second booléen, ce qui rend « les deux à vrai » exprimable. `WaveformAnimation` remplace les deux drapeaux, et l'énumération locale du clavier devient la partagée : mêmes noms de cas, mêmes corps de `switch`, donc le rendu du clavier est inchangé par construction.

## 3. Le repli Reduce Motion est retiré

Le pic bouge à l'identique, réglage activé ou non.

C'est une décision et pas une simplification : l'argument contraire a été posé en entier, à savoir que ce réglage existe précisément pour les personnes à qui un objet localisé qui traverse l'écran coûte quelque chose, et que retirer le repli abandonne le critère d'acceptation 7. Pierre a choisi de le retirer après test sur device, à revoir si un utilisateur le signale.

Le raisonnement est consigné dans le code à l'endroit exact où la branche se trouvait (`needsDisplayLink`), pour qu'un lecteur futur trouve une décision et non ce qui ressemble à un oubli.

## 4. L'annulation pendant une étape renvoyait l'utilisateur dans l'écran d'enregistrement

Le rebond était le symptôme. Le défaut est qu'une session déclarée terminée avait encore du travail qui écrivait dedans.

```
liveActivityTransition from=transcribing to=standby-abandoned
statusChanged from=transcribing to=idle
statusChanged from=idle to=failed          <- la tâche abandonnée, qui rapporte
```

Le teardown est correct et la vue se ferme. Puis la tâche de transcription toujours en vol lève, écrit `.failed`, et l'écran revient. Six transitions Live Activity rejetées dans la même fenêtre, la state machine refusant correctement des écritures d'une session terminée. **Les `standby->ready` sont la moitié inquiétante** : sur ce chemin la tâche avait *réussi*, et le chemin de succès écrit la transcription dans l'App Group puis poste `transcriptionReady`, ce qui fait taper le texte par le clavier. Une dictée annulée pouvait insérer du texte quelques secondes plus tard.

**Pourquoi la garde existante ne couvrait pas ça.** `dictationGeneration` (#60) était incrémenté à un seul endroit, `startDictation()`, donc il répondait à « une session PLUS RÉCENTE a-t-elle démarré » : de la supersession, pas de l'abandon, et rien ne démarre quand une dictée est abandonnée. Et la tâche ne capturait jamais le compteur, donc même une supersession n'aurait pas arrêté ces écritures. Deux trous, dont un dans le concept.

`DictationSessionGeneration` ferme le concept : la génération bouge pour les deux raisons qu'a une session de cesser d'être la courante, et ces deux raisons sont des méthodes nommées plutôt que des incréments dispersés dans un coordinateur de 1200 lignes. La tâche capture sa session et chaque écriture est conditionnée à être encore cette session, la garde du chemin de succès étant placée **avant** l'écriture App Group et non après.

`handleAudioInterruptionDuringDictation` abandonne aussi : même teardown, même course.

Testé dans DictusCore parce que DictusApp n'a pas de bundle de test, et parce que la règle est là où était le bug. Signature à vérifier sur device ensuite : aucune transition Live Activity rejetée après un abandon propre.

## Critères d'acceptation, mise à jour

| # | Critère | Statut |
| --- | --- | --- |
| 7 | Repli reduced-motion | ❌ **Abandonné par décision** (voir §3), pas rempli. Le pic bouge à l'identique avec le réglage activé. Décision prise après test device, avec l'argument accessibilité posé ; à revoir si un utilisateur le signale. |

Les six autres sont inchangés, le 2 et le 3 étant désormais aussi vrais dans DictusApp.

## Delta de test manuel

Sur les cinq étapes déjà passées par Pierre :

| # | Étape | Verdict |
| --- | --- | --- |
| 1 | Les deux animations distinctes | **À rejouer** : le pic est deux fois plus lent |
| 2 | Pas de saut de layout | **Toujours valide** |
| 3 | Dynamic Island blanc puis violet | **Toujours valide** |
| 4 | Abandon pendant le traitement puis nouvelle dictée | **À rejouer** : le comportement attendu a changé |
| 5 | Dictée courte, pas d'étape traitement | **Toujours valide** |

Étapes nouvelles ou modifiées :

1. Dicte depuis le clavier, 3 s minimum, ✓. Le pic doit traverser la rangée en **1 seconde** environ, deux fois plus lentement qu'avant, et se lire comme posé plutôt que pressé.
4. Annule pendant le traitement, avec le ✕ depuis DictusApp. Attendu : tu restes **sur l'écran d'accueil**. L'écran d'enregistrement ne doit **pas** réapparaître une demi-seconde plus tard. C'est le correctif principal de ce round.
6. Dicte **depuis DictusApp**. La forme d'onde elle-même doit passer du balayage sinusoïdal au **pic qui balaie**, en plus du texte qui passe à « Traitement en cours... ».
7. Reduce Motion activé, redicte : le pic doit **bouger normalement**. C'est le comportement voulu maintenant, plus le pic figé.
8. Après quelques annulations, exporte le log et cherche des transitions Live Activity rejetées. Attendu : **aucune** après un abandon propre. Une ligne `abandoned session dropped ...` est au contraire le signe que la garde a fait son travail.

## Vérifications de ce round

```
xcodebuild build -scheme DictusApp   → ** BUILD SUCCEEDED **   (4 cibles)
cd DictusCore && swift test          → 648 tests, 1 skipped, 0 failures   (640 avant)
swiftlint lint --strict              → 0 violations in 164 files
git status                           → aucun bruit xcstrings
```



---

# Round 3 — CodeRabbit, avant merge

Deux remarques, deux commits : `6478654` et `df8d8e5`.

## Les chemins de démarrage n'étaient pas gardés (Major)

La garde de session était posée sur la tâche stop-et-transcris. La relecture pointait les chemins de démarrage, et trois des sites cités sont atteignables avec une vraie conséquence : le correctif était donc fait aux deux tiers.

**Cold start.** `ensureEngineReady()` tourne dans la même tâche et prend plusieurs secondes à la première dictée : c'est la fenêtre la plus large de l'app pour qu'une annulation arrive en vol. Annuler là laissait le chargement lever dans `handleError`, qui écrivait `.failed` et re-présentait l'écran d'enregistrement. Exactement le défaut déjà corrigé sur le chemin de transcription, sur un chemin à fenêtre bien plus grande.

**Warm start.** Fenêtre plus courte, une seule suspension sur une permission déjà accordée, mais l'issue est pire : la continuation exécutait `startRecording()` et publiait `.recording`. Une dictée annulée pouvait donc laisser le micro capturer avec l'overlay rouvert. La garde est placée **avant** `startRecording()`, pas seulement avant l'écriture de statut.

**`onEngineWillRun`.** Se déclenche depuis l'intérieur de `polish`, qu'une annulation n'interrompt pas : une dictée abandonnée rouvrait l'overlay sur « Traitement... » et poussait la Live Activity dans une étape qu'elle avait déjà quittée. Une des transitions rejetées du log device venait précisément de là.

**Vérifiés et laissés tels quels**, avec le raisonnement consigné sur `mayReport` :

- `verifyAudioFlow()` commence par `guard status == .recording`, et une session abandonnée est `.idle` : son redémarrage moteur est inatteignable après une annulation.
- `setModelLoadState(...)` décrit le *modèle*, qui survit à toute dictée. Le garder fausserait l'état lu par la session suivante.
- `schedulePolishPrewarm()` préchauffe un modèle et ne publie rien.
- Le watchdog d'étape revérifie déjà `self.status` contre le statut pour lequel il a été armé.
- `pendingColdStartDictation` n'est rejoué depuis `didBecomeActive` que si l'App Group lit encore `.requested` ; une annulation écrit `.idle` avant, donc le démarrage différé ne ressuscite pas.

Aucune issue de suivi : rien ici ne s'est révélé être un trou distinct méritant d'être sorti de cette PR.

## Le display link de BrandWaveform tournait pour `.still` (Minor)

Corrigé. Une correction de prémisse pour le compte rendu : ce n'était **pas atteignable** aujourd'hui. Le seul site qui passe `.still` est `RecordingView`, qui passe `isActive: false` dans les mêmes états. Les écrans d'onboarding et de chargement de modèle passent `.sweep`, qui a légitimement besoin du display link, donc aucune batterie n'y était consommée.

La garde reste utile : « immobile mais actif » n'est devenu exprimable qu'en passant l'animation d'un booléen à un mode, c'est-à-dire dans cette PR.

**Non-régression des deux autres écrans** (ceux que Pierre teste en ce moment) : `isProcessing: true` devient `.sweep`, qui emprunte les mêmes branches que l'ancien drapeau — `processingPhase += link.duration / 2`, `processingEnergy` dans le Canvas, `minHeight` 4 via `isSelfDriven`, display link actif. Vérifié aussi en simulateur : la page d'accueil rend le même balayage sinusoïdal qu'avant le refactor.

## Vérifications de ce round

```
xcodebuild build -scheme DictusApp   → ** BUILD SUCCEEDED **   (4 cibles)
cd DictusCore && swift test          → 649 tests, 1 skipped, 0 failures   (648 avant)
swiftlint lint --strict              → 0 violations in 164 files
git status                           → aucun bruit xcstrings
```
