### PR TITLE
fix: advance the waveform phase by elapsed time, not by nominal frames (refs #314)

### DIFF
--- a/DictusCore/Sources/DictusCore/Design/BrandWaveform.swift
+++ b/DictusCore/Sources/DictusCore/Design/BrandWaveform.swift
@@ -18,7 +18,14 @@ final class BrandWaveformDriver: ObservableObject {
     private var energyLevels: [Float] = []
     private var isActive = false
     private var displayLink: CADisplayLink?
-    private var lastRenderTime: Date = .distantPast
+
+    /// Timestamp of the previous display-link callback, and the worst interval between
+    /// two of them since the last heartbeat. Both read `CADisplayLink.timestamp` rather
+    /// than the wall clock: it is monotonic, it is the frame's own time rather than the
+    /// moment the callback happened to run, and it is what the keyboard's driver
+    /// already used -- the two now measure the same thing the same way (#314).
+    private var lastTickTime: CFTimeInterval?
+    private var maxGapSinceHeartbeat: CFTimeInterval = 0
     private var lastHeartbeatTime: Date = .distantPast
 
     deinit {
@@ -77,7 +84,8 @@ final class BrandWaveformDriver: ObservableObject {
         let link = CADisplayLink(target: self, selector: #selector(handleDisplayLink))
         link.add(to: .main, forMode: .common)
         displayLink = link
-        lastRenderTime = Date()
+        lastTickTime = nil
+        maxGapSinceHeartbeat = 0
         lastHeartbeatTime = .distantPast
 
         PersistentLog.log(.waveformAppeared(
@@ -93,6 +101,7 @@ final class BrandWaveformDriver: ObservableObject {
 
         displayLink?.invalidate()
         displayLink = nil
+        lastTickTime = nil
 
         PersistentLog.log(.waveformDisappeared(
             refreshID: renderTick,
@@ -103,9 +112,20 @@ final class BrandWaveformDriver: ObservableObject {
     @objc
     private func handleDisplayLink(_ link: CADisplayLink) {
         let now = Date()
+        let timestamp = link.timestamp
+        let previousTimestamp = lastTickTime
+        lastTickTime = timestamp
 
-        if lastRenderTime != .distantPast {
-            let gapMs = Int(now.timeIntervalSince(lastRenderTime) * 1000)
+        // The nominal frame duration stands in on the first callback only, which is the
+        // one tick with no previous timestamp to measure from. Everywhere else it is
+        // the wrong number: it never reports the frames that were missed (#314).
+        let elapsed = previousTimestamp.map { timestamp - $0 } ?? link.duration
+
+        if let previousTimestamp {
+            let gap = timestamp - previousTimestamp
+            maxGapSinceHeartbeat = max(maxGapSinceHeartbeat, gap)
+
+            let gapMs = Int(gap * 1000)
             if gapMs > 500 {
                 PersistentLog.log(.waveformStall(
                     gapMs: gapMs,
@@ -114,15 +134,12 @@ final class BrandWaveformDriver: ObservableObject {
                 ))
             }
         }
-        lastRenderTime = now
 
         switch animation {
         case .micLevels:
             tickLevels()
-        case .sweep:
-            processingPhase += link.duration / 2.0
-        case .travellingPeak:
-            processingPhase += link.duration * ProcessingWaveform.phaseRate
+        case .sweep, .travellingPeak:
+            processingPhase += ProcessingWaveform.phaseAdvance(for: animation, elapsedSeconds: elapsed)
         case .still:
             break
         }
@@ -133,8 +150,10 @@ final class BrandWaveformDriver: ObservableObject {
             PersistentLog.log(.waveformHeartbeat(
                 renderTick: renderTick,
                 avgLevel: avg,
-                energyCount: energyLevels.count
+                energyCount: energyLevels.count,
+                maxGapMs: Int(maxGapSinceHeartbeat * 1000)
             ))
+            maxGapSinceHeartbeat = 0
             lastHeartbeatTime = now
         }
 

--- a/DictusCore/Sources/DictusCore/LogEvent.swift
+++ b/DictusCore/Sources/DictusCore/LogEvent.swift
@@ -124,7 +124,11 @@ public enum LogEvent: Sendable {
     // MARK: Waveform Diagnostics
     case waveformAppeared(refreshID: Int, isProcessing: Bool, energyCount: Int, killedState: Bool)
     case waveformDisappeared(refreshID: Int, renderTick: Int)
-    case waveformHeartbeat(renderTick: Int, avgLevel: Float, energyCount: Int)
+    /// `maxGapMs` is the worst interval between two display-link callbacks since the
+    /// previous heartbeat. It is the frame-cadence evidence #314 asks for, carried by a
+    /// line that is already emitted every ~2 s: a per-frame event would be the wrong
+    /// trade against a log that is capped at 1 MB and deduplicated (#255).
+    case waveformHeartbeat(renderTick: Int, avgLevel: Float, energyCount: Int, maxGapMs: Int)
     case waveformStall(gapMs: Int, renderTick: Int, energyCount: Int)
     case waveformRefreshIDChanged(oldID: Int, newID: Int, status: String)
     case waveformEnergyTransition(fromCount: Int, toCount: Int, status: String)
@@ -570,8 +574,8 @@ public enum LogEvent: Sendable {
             return "refreshID=\(refreshID) isProcessing=\(isProcessing) energyCount=\(energyCount) killed=\(killedState)"
         case .waveformDisappeared(let refreshID, let renderTick):
             return "refreshID=\(refreshID) renderTick=\(renderTick)"
-        case .waveformHeartbeat(let renderTick, let avgLevel, let energyCount):
-            return "renderTick=\(renderTick) avgLevel=\(String(format: "%.3f", avgLevel)) energyCount=\(energyCount)"
+        case .waveformHeartbeat(let renderTick, let avgLevel, let energyCount, let maxGapMs):
+            return "renderTick=\(renderTick) avgLevel=\(String(format: "%.3f", avgLevel)) energyCount=\(energyCount) maxGapMs=\(maxGapMs)"
         case .waveformStall(let gapMs, let renderTick, let energyCount):
             return "gapMs=\(gapMs) renderTick=\(renderTick) energyCount=\(energyCount)"
         case .waveformRefreshIDChanged(let oldID, let newID, let status):

--- a/DictusCore/Sources/DictusCore/ProcessingWaveform.swift
+++ b/DictusCore/Sources/DictusCore/ProcessingWaveform.swift
@@ -102,4 +102,67 @@ public enum ProcessingWaveform {
     /// `(barCount - 1) / 2`. Naming it stops the phase reset from looking like it
     /// forgot to initialise something.
     public static let centredPhase: Double = 0
+
+    // MARK: - Advancing the phase
+
+    /// Phase per second for the transcription sine (`.sweep`).
+    ///
+    /// WHY it lives here, next to the travelling peak's rate, when the sine is drawn
+    /// by each surface's own `processingEnergy`: the two animations share one phase
+    /// variable, and until now this number existed only as a `/ 2.0` written inline in
+    /// two display-link callbacks. A rate that is only visible at the point it is
+    /// consumed is a rate that drifts apart between surfaces.
+    ///
+    /// The sine's pattern translates by one full row per unit of phase, so 0.5 is the
+    /// 2.00 s crossing that `phaseRate` and `TranscribingStageHold` are both stated
+    /// against. The value is unchanged from the inline divisor (#314 is about the
+    /// animation running at the speed it was designed for, not about a new speed).
+    public static let sweepPhaseRate: Double = 0.5
+
+    /// The most real time a single frame is allowed to advance the phase by.
+    ///
+    /// WHY a ceiling at all: with the phase advancing by real elapsed time, a gap of
+    /// any size advances by that size -- and the gaps that are not dropped frames are
+    /// enormous. The keyboard extension is suspended and resumed, the device sleeps,
+    /// the display link is left registered across an App Group round trip. Unclamped,
+    /// the first frame after such a gap teleports the peak to an arbitrary point of its
+    /// travel, which is a worse artefact than the slowdown this fix removes.
+    ///
+    /// WHY 100 ms. It has to sit above any hitch worth catching up and below any gap
+    /// worth abandoning. Six frames at 60 Hz is far more than a stutter costs, so
+    /// ordinary jank is still absorbed in full; and it is a fifth of the 500 ms
+    /// `waveformStall` threshold, so anything the log calls a stall is always clamped.
+    /// At the peak's 0.5 Hz the ceiling caps one frame's travel at 5 % of a cycle,
+    /// which cannot read as a jump.
+    public static let maxPhaseAdvanceSeconds: Double = 0.1
+
+    /// How far the shared phase moves in `elapsedSeconds` of real time.
+    ///
+    /// WHY the drivers must not do this themselves (#314): both used to advance the
+    /// phase by `CADisplayLink.duration`, the *nominal* interval between refreshes.
+    /// That number does not grow when a callback is late and does not account for a
+    /// frame that was skipped, so under load -- App Group writes, text insertion,
+    /// polish completing on the app side -- the phase fell behind real time by exactly
+    /// the frames that were lost, permanently. The animation did not stutter, it ran
+    /// slow, which is what was reported. Elapsed time makes a dropped frame *skip*
+    /// where the nominal duration made it *slow*.
+    ///
+    /// Negative elapsed times clamp to zero. Both surfaces feed this from
+    /// `CADisplayLink.timestamp`, which is monotonic, but the same guard is what
+    /// `TranscribingStageHold` learned to want from a clock that moved backwards, and
+    /// a negative advance would run the animation in reverse for a frame.
+    public static func phaseAdvance(for animation: WaveformAnimation, elapsedSeconds: Double) -> Double {
+        let clamped = min(max(elapsedSeconds, 0), maxPhaseAdvanceSeconds)
+
+        switch animation {
+        case .sweep:
+            return clamped * sweepPhaseRate
+        case .travellingPeak:
+            return clamped * phaseRate
+        case .micLevels, .still:
+            // Neither draws from the phase: the mic levels follow live energy, and a
+            // still waveform is not moving at all.
+            return 0
+        }
+    }
 }

--- a/DictusCore/Tests/DictusCoreTests/LogEventTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/LogEventTests.swift
@@ -283,6 +283,36 @@ final class LogEventTests: XCTestCase {
         XCTAssertEqual(event.subsystem, .keyboard)
     }
 
+    // MARK: - Waveform frame cadence (#314)
+
+    /// The issue asks for frame-gap evidence at a finer grain than the 500 ms
+    /// `waveformStall` threshold: 50-100 ms is already enough to make a 60 Hz
+    /// animation feel bad, and none of it was visible in a log. The heartbeat is
+    /// where that evidence rides, because it is emitted every ~2 s and the log is
+    /// capped and deduplicated (#255) -- a per-frame event was not an option.
+    func testWaveformHeartbeatCarriesTheWorstFrameGapOfItsWindow() {
+        let event = LogEvent.waveformHeartbeat(
+            renderTick: 1200, avgLevel: 0.42, energyCount: 40, maxGapMs: 83
+        )
+        XCTAssertEqual(event.name, "waveformHeartbeat")
+        XCTAssertEqual(
+            event.message,
+            "renderTick=1200 avgLevel=0.420 energyCount=40 maxGapMs=83"
+        )
+    }
+
+    /// A window with no frame worth reporting still says so, rather than dropping the
+    /// field: a reader comparing two heartbeats needs the healthy one to be readable
+    /// as healthy, not as missing.
+    func testWaveformHeartbeatReportsASmoothWindowAsZero() {
+        let event = LogEvent.waveformHeartbeat(
+            renderTick: 60, avgLevel: 0, energyCount: 0, maxGapMs: 0
+        )
+        XCTAssertEqual(event.message, "renderTick=60 avgLevel=0.000 energyCount=0 maxGapMs=0")
+        XCTAssertEqual(event.level, .debug)
+        XCTAssertEqual(event.subsystem, .keyboard)
+    }
+
     // MARK: - Lifecycle events
 
     func testAppLaunchedIsInfoLifecycle() {

--- a/DictusCore/Tests/DictusCoreTests/ProcessingWaveformTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/ProcessingWaveformTests.swift
@@ -160,9 +160,123 @@ final class ProcessingWaveformTests: XCTestCase {
     }
 
     /// Seconds for the transcription sine's pattern to cross the row. Its phase
-    /// advances by `link.duration / 2` per frame, i.e. 0.5 per second, and the
-    /// pattern translates by one full row per unit of phase.
+    /// advances by 0.5 per second and the pattern translates by one full row per unit
+    /// of phase.
     private var transcriptionSweepCrossingSeconds: Double {
-        1 / 0.5
+        1 / ProcessingWaveform.sweepPhaseRate
+    }
+
+    // MARK: - The phase advances with real time, not with frames
+
+    private let selfDrivenAnimations: [WaveformAnimation] = [.sweep, .travellingPeak]
+
+    /// The defect #314 reports, stated as a test: the phase has to depend on how much
+    /// time passed, not on how many callbacks arrived. Both drivers used to advance it
+    /// by `CADisplayLink.duration`, so a run of frames at 120 Hz and the same wall-clock
+    /// interval at 60 Hz produced *different* totals -- and a dropped frame, which is
+    /// the same shape of discrepancy, cost travel that was never recovered.
+    func testTheSameElapsedTimeAdvancesTheSameAmountAtAnyFrameRate() {
+        for animation in selfDrivenAnimations {
+            let atHighRefreshRate = totalPhase(for: animation, ticks: 20, each: 1.0 / 120)
+            let atStandardRefreshRate = totalPhase(for: animation, ticks: 10, each: 1.0 / 60)
+
+            XCTAssertEqual(
+                atHighRefreshRate, atStandardRefreshRate, accuracy: 0.000_001,
+                "\(animation): 20 frames at 120 Hz and 10 at 60 Hz are the same sixth of a second"
+            )
+            XCTAssertGreaterThan(atHighRefreshRate, 0, "\(animation): the phase did not move at all")
+        }
+    }
+
+    /// One long frame is worth exactly the frames it replaced. This is what makes a
+    /// dropped frame skip rather than slow: the phase arrives where it would have been
+    /// had every frame been delivered.
+    func testAFrameThatSwallowedItsNeighboursAdvancesByTheirTotal() {
+        for animation in selfDrivenAnimations {
+            let fiveFrames = totalPhase(for: animation, ticks: 5, each: 1.0 / 60)
+            let oneLateFrame = ProcessingWaveform.phaseAdvance(for: animation, elapsedSeconds: 5.0 / 60)
+
+            XCTAssertEqual(fiveFrames, oneLateFrame, accuracy: 0.000_001, "\(animation)")
+        }
+    }
+
+    /// The ceiling is what separates a dropped frame from a suspended extension. A gap
+    /// large enough to be a stall must not hand the peak an arbitrary position.
+    func testAnElapsedTimeAboveTheCeilingAdvancesByTheCeiling() {
+        for animation in selfDrivenAnimations {
+            let atTheCeiling = ProcessingWaveform.phaseAdvance(
+                for: animation, elapsedSeconds: ProcessingWaveform.maxPhaseAdvanceSeconds
+            )
+
+            for elapsed in [ProcessingWaveform.maxPhaseAdvanceSeconds + 0.001, 0.5, 30, 3600] {
+                XCTAssertEqual(
+                    ProcessingWaveform.phaseAdvance(for: animation, elapsedSeconds: elapsed),
+                    atTheCeiling, accuracy: 0.000_001,
+                    "\(animation): \(elapsed) s advanced by more than the ceiling"
+                )
+            }
+        }
+    }
+
+    /// Under the ceiling nothing is clamped, or the fix would have traded a slow
+    /// animation for one that is slow only under load.
+    func testAnOrdinaryFrameIsNotClamped() {
+        let ordinaryGaps = [1.0 / 120, 1.0 / 60, 1.0 / 30, ProcessingWaveform.maxPhaseAdvanceSeconds - 0.001]
+
+        for animation in selfDrivenAnimations {
+            for elapsed in ordinaryGaps {
+                let rate = animation == .sweep ? ProcessingWaveform.sweepPhaseRate : ProcessingWaveform.phaseRate
+                XCTAssertEqual(
+                    ProcessingWaveform.phaseAdvance(for: animation, elapsedSeconds: elapsed),
+                    elapsed * rate, accuracy: 0.000_001,
+                    "\(animation): \(elapsed) s was clamped and should not have been"
+                )
+            }
+        }
+    }
+
+    /// A clock that moved backwards must not run the animation in reverse for a frame.
+    /// Both surfaces feed this from `CADisplayLink.timestamp`, which is monotonic; the
+    /// guard is the same one `TranscribingStageHold` needed for its wall clock.
+    func testANegativeElapsedTimeDoesNotMoveThePhaseBackwards() {
+        for animation in selfDrivenAnimations {
+            XCTAssertEqual(
+                ProcessingWaveform.phaseAdvance(for: animation, elapsedSeconds: -1), 0, accuracy: 0.000_001,
+                "\(animation)"
+            )
+        }
+    }
+
+    /// The mic levels follow live energy and a still waveform is not moving, so neither
+    /// reads the phase. Advancing it under them would leave the next self-driven stage
+    /// starting somewhere other than `centredPhase`.
+    func testTheAnimationsThatDoNotUseThePhaseDoNotAdvanceIt() {
+        for animation in [WaveformAnimation.micLevels, .still] {
+            XCTAssertEqual(
+                ProcessingWaveform.phaseAdvance(for: animation, elapsedSeconds: 1.0 / 60), 0,
+                "\(animation)"
+            )
+        }
+    }
+
+    /// The peak's tempo, restated through the advance function rather than the constant:
+    /// half a cycle -- one edge-to-edge crossing -- takes the second the rate promises.
+    func testASecondOfRealTimeCarriesThePeakAcrossTheRow() {
+        var phase = ProcessingWaveform.centredPhase
+        for _ in 0..<60 {
+            phase += ProcessingWaveform.phaseAdvance(for: .travellingPeak, elapsedSeconds: 1.0 / 60)
+        }
+
+        XCTAssertEqual(phase, 0.5, accuracy: 0.000_001, "half a cycle in one second")
+        XCTAssertEqual(
+            ProcessingWaveform.peakPosition(phase: phase), centre, accuracy: 0.000_001,
+            "back at the centre, having been to one edge and returned"
+        )
+    }
+
+    private func totalPhase(for animation: WaveformAnimation, ticks: Int, each elapsed: Double) -> Double {
+        (0..<ticks).reduce(0) { total, _ in
+            total + ProcessingWaveform.phaseAdvance(for: animation, elapsedSeconds: elapsed)
+        }
     }
 }

--- a/DictusKeyboard/Views/KeyboardWaveformView.swift
+++ b/DictusKeyboard/Views/KeyboardWaveformView.swift
@@ -22,6 +22,11 @@ final class KeyboardWaveformDriver: ObservableObject {
     private var activePresenterID: String?
     private var displayLink: CADisplayLink?
     private var lastTickTime: CFTimeInterval?
+    /// Worst interval between two display-link callbacks since the last heartbeat, which
+    /// is where it is reported (#314). A stutter well under the 500 ms `waveformStall`
+    /// threshold is already enough to be felt, and this is how it becomes visible in a
+    /// log without a per-frame line.
+    private var maxGapSinceHeartbeat: CFTimeInterval = 0
     private var lastHeartbeatTime: Date = .distantPast
 
     private init() {
@@ -72,6 +77,7 @@ final class KeyboardWaveformDriver: ObservableObject {
 
         if !isVisible {
             lastTickTime = nil
+            maxGapSinceHeartbeat = 0
             lastHeartbeatTime = .distantPast
         }
 
@@ -149,6 +155,7 @@ final class KeyboardWaveformDriver: ObservableObject {
         displayLink?.invalidate()
         displayLink = nil
         lastTickTime = nil
+        maxGapSinceHeartbeat = 0
 
         PersistentLog.log(.waveformDisappeared(
             refreshID: renderTick,
@@ -163,8 +170,16 @@ final class KeyboardWaveformDriver: ObservableObject {
         let previousTimestamp = lastTickTime
         lastTickTime = timestamp
 
+        // The nominal frame duration stands in on the first callback only, which is the
+        // one tick with no previous timestamp to measure from. Everywhere else it is
+        // the wrong number: it never reports the frames that were missed (#314).
+        let elapsed = previousTimestamp.map { timestamp - $0 } ?? link.duration
+
         if let previousTimestamp {
-            let gapMs = Int((timestamp - previousTimestamp) * 1000)
+            let gap = timestamp - previousTimestamp
+            maxGapSinceHeartbeat = max(maxGapSinceHeartbeat, gap)
+
+            let gapMs = Int(gap * 1000)
             if gapMs > 500 {
                 PersistentLog.log(.waveformStall(
                     gapMs: gapMs,
@@ -177,10 +192,8 @@ final class KeyboardWaveformDriver: ObservableObject {
         switch animation {
         case .micLevels:
             tickRecording()
-        case .sweep:
-            processingPhase += link.duration / 2.0
-        case .travellingPeak:
-            processingPhase += link.duration * ProcessingWaveform.phaseRate
+        case .sweep, .travellingPeak:
+            processingPhase += ProcessingWaveform.phaseAdvance(for: animation, elapsedSeconds: elapsed)
         case .still:
             break
         }
@@ -231,8 +244,10 @@ final class KeyboardWaveformDriver: ObservableObject {
         PersistentLog.log(.waveformHeartbeat(
             renderTick: renderTick,
             avgLevel: average,
-            energyCount: energyLevels.count
+            energyCount: energyLevels.count,
+            maxGapMs: Int(maxGapSinceHeartbeat * 1000)
         ))
+        maxGapSinceHeartbeat = 0
         if animation == .micLevels {
             logProbe(
                 "waveformShape",


### PR DESCRIPTION
refs #314

## What this was for

You reported that the keyboard's processing and transcription animations sometimes look slower than their normal speed. Not stuttering — slow. The cause is that both waveform drivers advance the animation's phase by `CADisplayLink.duration`, the *nominal* interval between screen refreshes. That number never grows when a callback arrives late and never accounts for a frame that was skipped, so every frame the system drops is travel the animation loses and never gets back. Under load — the keyboard extension, App Group writes, text insertion, polish finishing on the app side — the animation falls behind real time permanently, which is exactly "plus lente que sa vitesse normale".

The phase now advances by the time that actually elapsed, so a dropped frame makes the animation *skip* instead of *slow*. Both surfaces get it from one shared function instead of holding two copies of the arithmetic, which is how they came to share the same defect in the first place.

The heartbeat log line also now carries the worst frame gap of its window, so the next time this is in question there is evidence instead of an impression. It already caught something: a 116 ms gap during app launch, well under the 500 ms `waveformStall` threshold that has always been the only cadence signal in the log.

## To test by hand

Nothing below can be checked without hardware — an agent cannot judge motion, and a simulator runs on Mac silicon under no load, so it says nothing about how the phone behaves. Everything else is covered by the automated checks listed further down.

1. Build the branch onto the phone, open the keyboard in any app, dictate a normal sentence with Parakeet and polish ON. During "Transcription..." and then the processing stage, the animations should hold a steady speed. This is the whole point of the change: no passage where the motion visibly drags.
2. Repeat five or six times in a row, including while the phone is warm. The old defect was intermittent and load-dependent, so a single clean run does not settle it.
3. Do a very short dictation (two or three words) so the processing stage returns fast. The travelling peak should start at the centre of the row and move away from it smoothly. It must never *jump* to a position — a teleport would mean the clamp is set wrong.
4. Do a long dictation on Whisper medium, where the transcription sine runs several seconds. Its speed should be the same as before this branch: it crosses the row in 2 s. If it looks faster or slower than you remember, say so — the rates were deliberately left untouched here.
5. Lock the phone mid-dictation, or switch to another app and come back. When the overlay reappears the animation should resume from wherever it is, without a jump.
6. Export the debug log afterwards and grep `waveformHeartbeat`. Every line now ends with `maxGapMs=`. On a healthy run it should sit near one frame (16 ms at 60 Hz, 8 at 120 Hz). If you ever feel the animation drag again, that field is what tells us whether the phone dropped frames or something else is wrong.
7. Also grep `waveformStall`. Its threshold is unchanged at 500 ms and it should behave exactly as before — this branch did not touch it.

## What changed

- **`ProcessingWaveform.phaseAdvance(for:elapsedSeconds:)`** (DictusCore) is the single copy of the phase arithmetic. Pure, so `swift test` covers it with no simulator.
- **`ProcessingWaveform.sweepPhaseRate`** names the transcription sine's rate, which existed only as an inline `/ 2.0` inside two display-link callbacks. Same value.
- **`ProcessingWaveform.maxPhaseAdvanceSeconds = 0.1`** is the clamp ceiling. It has to sit above any hitch worth catching up and below any gap worth abandoning: six frames at 60 Hz absorbs ordinary jank in full, and a fifth of the `waveformStall` threshold means anything the log calls a stall is always clamped. At the peak's 0.5 Hz one frame can then move at most 5 % of a cycle, which cannot read as a jump.
- **Both drivers** (`KeyboardWaveformDriver`, `BrandWaveformDriver`) measure elapsed time from `CADisplayLink.timestamp` and call the shared function. The app driver previously measured its stall gap with `Date()`; it now reads the display link like the keyboard driver does, so the two measure the same thing the same way. `link.duration` survives only as the first tick's fallback — the one callback with no previous timestamp — and says so at both call sites.
- **`waveformHeartbeat`** gains `maxGapMs`, the worst callback interval since the previous heartbeat. It rides an existing ~2 s line rather than becoming a per-frame event, because the log is capped at 1 MB and deduplicated (#255).

Out of scope and untouched, as the brief requires: the #309 transcription hold and the drawn-stage feed into the drivers, the phase restart on stage change (#267), Reduce Motion, the animation rates themselves, and the mic-levels smoothing and decay factors.

## Acceptance criteria

| Criterion | Status | Evidence |
| --- | --- | --- |
| Unit test: phase advance proportional to elapsed time, both animations | ✅ | `testTheSameElapsedTimeAdvancesTheSameAmountAtAnyFrameRate` — 20 ticks at 1/120 s against 10 at 1/60 s (the same sixth of a second), for `.sweep` and `.travellingPeak`. Plus `testAFrameThatSwallowedItsNeighboursAdvancesByTheirTotal`. |
| Unit test: elapsed above the ceiling advances by the ceiling | ✅ | `testAnElapsedTimeAboveTheCeilingAdvancesByTheCeiling` (ceiling + 1 ms, 0.5 s, 30 s, 1 h) and its complement `testAnOrdinaryFrameIsNotClamped`. |
| No driver uses `link.duration` to advance the phase; first-tick fallback only, documented | ✅ | `grep -rn 'link.duration' --include='*.swift' .` returns exactly two lines, both `previousTimestamp.map { timestamp - $0 } ?? link.duration`, each under a comment naming why. |
| Heartbeat carries the max frame gap in ms | ✅ | `testWaveformHeartbeatCarriesTheWorstFrameGapOfItsWindow`, and observed live on a simulator: `waveformHeartbeat renderTick=114 avgLevel=0.450 energyCount=0 maxGapMs=116` at launch, then `maxGapMs=16` steady. The same log file holds the pre-branch lines, which have no such field. |
| `waveformStall` and its 500 ms threshold unchanged | ✅ | `git diff develop -- LogEvent.swift` touches only the `waveformHeartbeat` declaration and its payload arm; `grep -rn 'gapMs > 500'` still returns both drivers. |
| `swiftlint lint --strict` clean, `swift test` green | ✅ | `Done linting! Found 0 violations, 0 serious in 167 files.` · `Executed 702 tests, with 1 test skipped and 0 failures`. |
| Device-validation list in the PR body | ✅ | Above. |

Also run: `xcodebuild build -scheme DictusApp -destination 'platform=iOS Simulator,id=…'` → `** BUILD SUCCEEDED **` (app, keyboard, widgets, core).

## Notes for review

- The 116 ms launch gap the new field caught is a real illustration of the issue's own point: 50–100 ms gaps are enough to make a 60 Hz animation feel bad, and nothing in the log reported them. It is a simulator launch hitch, not a device measurement — the value of it is that the field works.
- The clamp ceiling at 100 ms is a judgement call, argued in the constant's doc comment. If a device session shows animation catching up in visible lurches, that number is the dial.
- `LogEvent.swift` is being edited concurrently for a polish-failure event. This branch touches two regions of it only, both `waveformHeartbeat`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Waveform animations now advance based on real elapsed display time for smoother, frame-rate-independent motion.
  * Animations recover more consistently after delayed or dropped frames.
  * Non-animated waveform styles remain stable without unnecessary phase updates.

* **Diagnostics**
  * Waveform heartbeat logs now report the maximum frame gap, improving visibility into animation stalls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->