### PR TITLE
Name why the polish engine failed, instead of one opaque bucket (refs #315)

### DIFF
--- a/DictusApp/Polish/PolishCoordinator.swift
+++ b/DictusApp/Polish/PolishCoordinator.swift
@@ -295,7 +295,8 @@ public final class PolishCoordinator {
                 preprocessMs: preprocessMs,
                 engineMs: bundle.engineMs,
                 postprocessMs: bundle.postprocessMs
-            )
+            ),
+            failureReason: bundle.failureReason
         )
         await emit(m, raw: raw, polished: bundle.engineOutput)
 
@@ -395,7 +396,8 @@ public final class PolishCoordinator {
                 preprocessMs: preprocessMs,
                 engineMs: bundle.engineMs,
                 postprocessMs: bundle.postprocessMs
-            )
+            ),
+            failureReason: bundle.failureReason
         )
         await emit(m, raw: raw, polished: bundle.engineOutput)
         return returned
@@ -413,7 +415,8 @@ public final class PolishCoordinator {
                                   detectedLanguage: String? = nil,
                                   latencyMs: Int = 0,
                                   timings: PolishTimings =
-                                      PolishTimings(preprocessMs: 0, engineMs: 0, postprocessMs: 0)
+                                      PolishTimings(preprocessMs: 0, engineMs: 0, postprocessMs: 0),
+                                  failureReason: PolishFailureReason? = nil
     ) -> PolishMetrics {
         PolishMetrics(
             engine: engineID,
@@ -426,7 +429,8 @@ public final class PolishCoordinator {
             outcome: outcome,
             sttEngine: languagePolicy.engine.rawValue,
             sttModelID: languagePolicy.modelIdentifier,
-            timings: timings
+            timings: timings,
+            failureReason: failureReason
         )
     }
 
@@ -442,6 +446,19 @@ public final class PolishCoordinator {
     /// Log one metrics event and append it to the debug ring.
     private func emit(_ m: PolishMetrics, raw: String, polished: String?) async {
         PolishMetrics.log(m)
+        // An engine failure also goes to the persistent log (#315), where it can
+        // be read against the dictation timeline around it. Keyed on the
+        // outcome, not on the reason being present, so no failure can slip
+        // through unlogged; "unclassified" would mean the engine returned no
+        // reason at all, which no engine does today.
+        if m.outcome == .engineFailed {
+            PersistentLog.log(.polishEngineFailed(
+                reason: m.failureReason?.slug ?? "unclassified",
+                engine: m.engine,
+                mode: m.mode?.rawValue ?? "-",
+                engineMs: m.timings?.engineMs ?? 0
+            ))
+        }
         await metricsRing.append(PolishDebugEntry(raw: raw, polished: polished, metrics: m))
     }
 

--- a/DictusApp/Polish/PolishDebugExporter.swift
+++ b/DictusApp/Polish/PolishDebugExporter.swift
@@ -19,6 +19,13 @@ struct PolishDebugExport: Codable {
     let device: DeviceInfo
     let settings: SettingsInfo
     let outcomes: [String: Int]
+    /// Per-reason counts over the `engineFailed` events (#315), e.g.
+    /// `{"rateLimited": 21, "other:NSError": 4}`. Same role as `outcomes` one
+    /// level down: it answers "which reason dominates" without reading 242
+    /// events. Absent keys mean zero — unlike `outcomes`, the set of reasons is
+    /// open, so seeding it with every known slug would print noise on a healthy
+    /// export.
+    let failureReasons: [String: Int]
     let events: [Event]
 
     struct DeviceInfo: Codable {
@@ -52,6 +59,8 @@ struct PolishDebugExport: Codable {
         let targetLanguage: String
         let detectedLanguage: String?
         let outcome: String
+        /// Why the engine failed (#315) — present on `engineFailed` events only.
+        let failureReason: String?
         let latencyMs: Int
         /// Latency breakdown — `latencyMs` ≈ preprocess + engine + postprocess.
         /// `engineMs` is the pure LLM cost; the other two are our regex passes.
@@ -100,8 +109,12 @@ enum PolishDebugExporter {
             "skippedShort": 0, "skippedAutoMode": 0, "cancelled": 0, "engineFailed": 0,
             "exceededContextBudget": 0
         ]
+        var failureReasons: [String: Int] = [:]
         for e in entries {
             outcomes[e.metrics.outcome.rawValue, default: 0] += 1
+            if let reason = e.metrics.failureReason {
+                failureReasons[reason.slug, default: 0] += 1
+            }
         }
 
         let events = entries.map { entry in
@@ -113,6 +126,7 @@ enum PolishDebugExporter {
                 targetLanguage: entry.metrics.targetLanguage.rawValue,
                 detectedLanguage: entry.metrics.detectedLanguage,
                 outcome: entry.metrics.outcome.rawValue,
+                failureReason: entry.metrics.failureReason?.slug,
                 latencyMs: entry.metrics.latencyMs,
                 preprocessMs: entry.metrics.timings?.preprocessMs,
                 engineMs: entry.metrics.timings?.engineMs,
@@ -131,6 +145,7 @@ enum PolishDebugExporter {
             device: device,
             settings: settings,
             outcomes: outcomes,
+            failureReasons: failureReasons,
             events: events
         )
     }

--- a/DictusApp/Polish/PolishDebugView.swift
+++ b/DictusApp/Polish/PolishDebugView.swift
@@ -154,9 +154,9 @@ private struct EntryRow: View {
                     .background(entry.metrics.outcome.tintColor.opacity(0.15))
                     .foregroundStyle(entry.metrics.outcome.tintColor)
                     .clipShape(Capsule())
-                // The reason takes the mode's slot on a failure: it is the one
-                // thing worth reading on that row (#315), and a failed event has
-                // nothing to say about which prompt it would have used.
+                // The reason takes the mode's slot on a failure (#315): the row
+                // is one line wide, and on a failed event the reason is what
+                // gets read. The mode is still on the detail sheet.
                 if let reason = entry.metrics.failureReason {
                     Text(reason.slug)
                         .font(.caption2.monospaced())

--- a/DictusApp/Polish/PolishDebugView.swift
+++ b/DictusApp/Polish/PolishDebugView.swift
@@ -154,7 +154,15 @@ private struct EntryRow: View {
                     .background(entry.metrics.outcome.tintColor.opacity(0.15))
                     .foregroundStyle(entry.metrics.outcome.tintColor)
                     .clipShape(Capsule())
-                if let mode = entry.metrics.mode {
+                // The reason takes the mode's slot on a failure: it is the one
+                // thing worth reading on that row (#315), and a failed event has
+                // nothing to say about which prompt it would have used.
+                if let reason = entry.metrics.failureReason {
+                    Text(reason.slug)
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(entry.metrics.outcome.tintColor)
+                        .lineLimit(1)
+                } else if let mode = entry.metrics.mode {
                     Text(mode.rawValue).font(.caption2).foregroundStyle(.secondary)
                 }
                 Text(entry.metrics.targetLanguage.rawValue.uppercased())
@@ -239,6 +247,9 @@ private struct EntryDetailView: View {
             HStack(spacing: 12) {
                 LabeledValue("latency", "\(entry.metrics.latencyMs) ms")
                 LabeledValue("chars", "\(entry.metrics.rawCharCount) → \(entry.metrics.polishedCharCount)")
+            }
+            if let reason = entry.metrics.failureReason {
+                LabeledValue("failure reason", reason.slug)
             }
         }
     }

--- a/DictusCore/Sources/DictusCore/LogEvent.swift
+++ b/DictusCore/Sources/DictusCore/LogEvent.swift
@@ -193,6 +193,18 @@ public enum LogEvent: Sendable {
     case appWhisperKitLoaded(modelName: String)
     case deviceCapabilitySnapshot(model: String, ramGB: Int, availableMemoryMB: Int, thermalState: String)
 
+    // MARK: Polish
+    /// Issue #315: the polish engine threw. `reason` is the slug the engine gave
+    /// its own failure (`PolishFailureReason`) — "rateLimited", "concurrentRequests",
+    /// or "other:<Type>" for an error no engine recognised.
+    ///
+    /// WHY it belongs in this log and not only in the polish debug export: the
+    /// export answers "how often, and which reason", but not "what else was the
+    /// app doing". A failure that arrives in 4 ms has to be readable against the
+    /// dictation timeline right next to it — status transitions, holds, the
+    /// insertion — and only this log has all of them on one page.
+    case polishEngineFailed(reason: String, engine: String, mode: String, engineMs: Int)
+
     // MARK: - Computed Properties
 
     /// The subsystem this event belongs to, derived from the case.
@@ -246,6 +258,11 @@ public enum LogEvent: Sendable {
         case .appLaunched, .appDidBecomeActive, .appWillResignActive,
              .appDidEnterBackground, .appWhisperKitLoaded, .deviceCapabilitySnapshot:
             return .lifecycle
+        // Polish is the stage after the STT result and before the App Group
+        // write, so it reads with the transcription stream rather than as a
+        // subsystem of its own (#315).
+        case .polishEngineFailed:
+            return .transcription
         }
     }
 
@@ -312,6 +329,12 @@ public enum LogEvent: Sendable {
              .waveformHeartbeat, .overlayTimerStarted, .overlayTimerStopped,
              .diagnosticProbe:
             return .debug
+
+        // Warning, not error: the user still gets their text (the deterministic
+        // floor), only the polish is lost — but silently, which is the failure
+        // worth finding in a log (#315).
+        case .polishEngineFailed:
+            return .warning
         }
     }
 
@@ -411,6 +434,7 @@ public enum LogEvent: Sendable {
         case .modelLoadStateChanged: return "modelLoadStateChanged"
         case .modelDownloadProgress: return "modelDownloadProgress"
         case .modelDownloadStalled: return "modelDownloadStalled"
+        case .polishEngineFailed: return "polishEngineFailed"
         }
     }
 
@@ -620,6 +644,10 @@ public enum LogEvent: Sendable {
             return "name=\(name) timeout=\(timeoutSeconds)s"
         case .deviceCapabilitySnapshot(let model, let ramGB, let availableMemoryMB, let thermalState):
             return "model=\(model) ramGB=\(ramGB) availableMB=\(availableMemoryMB) thermal=\(thermalState)"
+
+        // Polish (#315)
+        case .polishEngineFailed(let reason, let engine, let mode, let engineMs):
+            return "reason=\(reason) engine=\(engine) mode=\(mode) engineMs=\(engineMs)"
         }
     }
 

--- a/DictusCore/Sources/DictusCore/Polish/AppleFoundationModelsPolishEngine.swift
+++ b/DictusCore/Sources/DictusCore/Polish/AppleFoundationModelsPolishEngine.swift
@@ -131,6 +131,42 @@ public final class AppleFoundationModelsPolishEngine: PolishEngineProtocol, Send
         )
     }
 
+    // MARK: - Failure classification (#315)
+
+    /// Map what `session.respond(...)` threw onto a stable slug.
+    ///
+    /// This is the whole point of #315: a failure that arrives in 4 ms while
+    /// availability reads `available` has to say which of Apple's nine
+    /// `GenerationError` cases it was. Two of them can plausibly throw that
+    /// fast without the model running — `rateLimited` and `concurrentRequests` —
+    /// and they point at opposite culprits: a quota Apple applies to us, or two
+    /// of our own calls overlapping. The exported reason is what tells them
+    /// apart.
+    ///
+    /// Deliberately reads nothing out of the error but its case. The attached
+    /// `Context.debugDescription` can quote the prompt, i.e. the user's
+    /// dictation, and this value travels into a shared export.
+    public func failureReason(for error: Error) -> PolishFailureReason {
+        guard let generationError = error as? LanguageModelSession.GenerationError else {
+            return .other(error)
+        }
+        switch generationError {
+        case .exceededContextWindowSize: return .exceededContextWindowSize
+        case .assetsUnavailable: return .assetsUnavailable
+        case .guardrailViolation: return .guardrailViolation
+        case .unsupportedGuide: return .unsupportedGuide
+        case .unsupportedLanguageOrLocale: return .unsupportedLanguageOrLocale
+        case .decodingFailure: return .decodingFailure
+        case .rateLimited: return .rateLimited
+        case .concurrentRequests: return .concurrentRequests
+        case .refusal: return .refusal
+        // `GenerationError` ships with library evolution, so a future OS can add
+        // a case this build has never heard of. It lands in the catch-all with
+        // its type name rather than failing to compile against a newer SDK.
+        @unknown default: return .other(error)
+        }
+    }
+
     // MARK: - Instruction routing
 
     /// Returns the system prompt for `(mode, language)`. All four supported

--- a/DictusCore/Sources/DictusCore/Polish/PolishEngineProtocol.swift
+++ b/DictusCore/Sources/DictusCore/Polish/PolishEngineProtocol.swift
@@ -55,6 +55,22 @@ public protocol PolishEngineProtocol: Sendable {
     func contextFit(input: String,
                     targetLanguage: SupportedLanguage,
                     mode: PolishMode) -> PolishContextFit
+
+    /// Name the failure `error` — thrown by this engine's own `polish(...)` —
+    /// so an engine failure stops being one opaque bucket (#315).
+    ///
+    /// WHY the engine answers rather than the pipeline: the error is an SDK
+    /// type. Apple's `LanguageModelSession.GenerationError` lives behind
+    /// `#if canImport(FoundationModels)` AND behind an iOS/macOS 26 availability
+    /// gate, so a pipeline that classified it would have to import the framework
+    /// and carry that gate — onto the off-device harness and every test with it.
+    /// Only the engine that threw can see what it threw; the transform around it
+    /// stays backend-agnostic, exactly as `contextFit` above already arranges
+    /// for the context ceiling.
+    ///
+    /// Default implementation returns `.other(error)`: an engine that classifies
+    /// nothing still reports an identifiable reason.
+    func failureReason(for error: Error) -> PolishFailureReason
 }
 
 public extension PolishEngineProtocol {
@@ -65,4 +81,6 @@ public extension PolishEngineProtocol {
     func contextFit(input: String,
                     targetLanguage: SupportedLanguage,
                     mode: PolishMode) -> PolishContextFit { .fits }
+
+    func failureReason(for error: Error) -> PolishFailureReason { .other(error) }
 }

--- a/DictusCore/Sources/DictusCore/Polish/PolishFailureReason.swift
+++ b/DictusCore/Sources/DictusCore/Polish/PolishFailureReason.swift
@@ -1,0 +1,78 @@
+// DictusCore/Sources/DictusCore/Polish/PolishFailureReason.swift
+import Foundation
+
+/// Why a polish engine call failed (#315).
+///
+/// WHY this exists: `PolishMetrics.Outcome.engineFailed` is one opaque bucket.
+/// The field export from 1.8.0 (25) showed 25 failures out of 242 events, many
+/// returning in 4-24 ms — far too fast for the model to have run — while
+/// availability stayed `available` throughout. The error value was caught and
+/// dropped on the floor, so nothing in the metrics, the export or the log could
+/// say what those failures were. This type is the missing word.
+///
+/// WHY a string slug rather than an enum: the set is open. Nine of the values
+/// below mirror `LanguageModelSession.GenerationError`'s cases, but any error
+/// can reach the catch block, and an unforeseen one must still be identifiable
+/// rather than collapsing into "other". `other(_:)` carries the error's type
+/// name for exactly that.
+///
+/// WHY nothing but the slug: a failure reason is diagnostic data that ends up in
+/// a shared export and in the persistent log. `GenerationError.Context.debugDescription`
+/// and `localizedDescription` can quote the prompt — which is the user's
+/// dictation — so neither is ever read here. The reason stays low-cardinality by
+/// construction, which is also what makes a per-reason count meaningful.
+public struct PolishFailureReason: Sendable, Hashable, Codable, CustomStringConvertible {
+
+    /// Stable identifier, e.g. "rateLimited" or "other:URLError". Stable means
+    /// it is a wire value: it lands in the debug export and in the persistent
+    /// log, and reports written against one build get compared to the next.
+    public let slug: String
+
+    public init(slug: String) {
+        self.slug = slug
+    }
+
+    public var description: String { slug }
+
+    // MARK: - Apple Foundation Models
+
+    // The nine `LanguageModelSession.GenerationError` cases, one slug each. The
+    // names match Apple's case names deliberately: the reason in an export can
+    // be searched straight against Apple's documentation.
+
+    public static let exceededContextWindowSize = PolishFailureReason(slug: "exceededContextWindowSize")
+    public static let assetsUnavailable = PolishFailureReason(slug: "assetsUnavailable")
+    public static let guardrailViolation = PolishFailureReason(slug: "guardrailViolation")
+    public static let unsupportedGuide = PolishFailureReason(slug: "unsupportedGuide")
+    public static let unsupportedLanguageOrLocale = PolishFailureReason(slug: "unsupportedLanguageOrLocale")
+    public static let decodingFailure = PolishFailureReason(slug: "decodingFailure")
+    public static let rateLimited = PolishFailureReason(slug: "rateLimited")
+    public static let concurrentRequests = PolishFailureReason(slug: "concurrentRequests")
+    public static let refusal = PolishFailureReason(slug: "refusal")
+
+    // MARK: - Catch-all
+
+    /// The reason for an error no engine recognised, carrying the error's Swift
+    /// type name (`other:URLError`). An engine that never classifies anything —
+    /// every backend but Apple FM today — reports every failure this way, which
+    /// is still enough to tell two unforeseen failures apart in an export.
+    public static func other(_ error: Error) -> PolishFailureReason {
+        PolishFailureReason(slug: "other:\(String(describing: type(of: error)))")
+    }
+
+    // MARK: - Codable
+
+    // Encoded as a bare string, not as `{"slug": "..."}`. `PolishMetrics` is
+    // persisted one JSON object per line in the 7-day debug ring and read back
+    // by a human as often as by the decoder; a nested object for a single
+    // string would earn nothing.
+
+    public init(from decoder: Decoder) throws {
+        slug = try decoder.singleValueContainer().decode(String.self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(slug)
+    }
+}

--- a/DictusCore/Sources/DictusCore/Polish/PolishMetrics.swift
+++ b/DictusCore/Sources/DictusCore/Polish/PolishMetrics.swift
@@ -77,6 +77,16 @@ public struct PolishMetrics: Sendable, Codable {
     /// with events persisted before the latency-investigation branch.
     public let timings: PolishTimings?
 
+    /// Why the engine failed, when it did (#315). Set on `.engineFailed` and
+    /// only there.
+    ///
+    /// Optional for the same reason `timings` is: the debug ring holds seven
+    /// days of events written by whatever build was installed at the time, and
+    /// those events must keep decoding after this field lands. A missing key
+    /// decodes to `nil` — an event from before the reason existed, not an
+    /// unclassified failure.
+    public let failureReason: PolishFailureReason?
+
     public init(engine: String,
                 mode: PolishMode?,
                 targetLanguage: SupportedLanguage,
@@ -87,7 +97,8 @@ public struct PolishMetrics: Sendable, Codable {
                 outcome: Outcome,
                 sttEngine: String? = nil,
                 sttModelID: String? = nil,
-                timings: PolishTimings? = nil) {
+                timings: PolishTimings? = nil,
+                failureReason: PolishFailureReason? = nil) {
         self.engine = engine
         self.mode = mode
         self.targetLanguage = targetLanguage
@@ -99,6 +110,7 @@ public struct PolishMetrics: Sendable, Codable {
         self.sttEngine = sttEngine
         self.sttModelID = sttModelID
         self.timings = timings
+        self.failureReason = failureReason
     }
 
     /// Emit one line for a pre-call context refusal (#270). The metrics event
@@ -121,8 +133,12 @@ public struct PolishMetrics: Sendable, Codable {
         if #available(iOS 14.0, macOS 11.0, *) {
             let t = m.timings
             let breakdown = t.map { " timings=pre:\($0.preprocessMs)/engine:\($0.engineMs)/post:\($0.postprocessMs)" } ?? ""
+            // Appended only on a failure (#315): the reason is nil on the ~80% of
+            // events that succeed, and a `reason=-` on every one of them would
+            // pay for nothing.
+            let reason = m.failureReason.map { " reason=\($0.slug)" } ?? ""
             PolishLog.logger.info(
-                "📊 polish outcome=\(m.outcome.rawValue, privacy: .public) engine=\(m.engine, privacy: .public) mode=\(m.mode?.rawValue ?? "-", privacy: .public) target=\(m.targetLanguage.rawValue, privacy: .public) detected=\(m.detectedLanguage ?? "-", privacy: .public) stt=\(m.sttEngine ?? "-", privacy: .public)/\(m.sttModelID ?? "-", privacy: .public) chars=\(m.rawCharCount, privacy: .public)→\(m.polishedCharCount, privacy: .public) latencyMs=\(m.latencyMs, privacy: .public)\(breakdown, privacy: .public)"
+                "📊 polish outcome=\(m.outcome.rawValue, privacy: .public) engine=\(m.engine, privacy: .public) mode=\(m.mode?.rawValue ?? "-", privacy: .public) target=\(m.targetLanguage.rawValue, privacy: .public) detected=\(m.detectedLanguage ?? "-", privacy: .public) stt=\(m.sttEngine ?? "-", privacy: .public)/\(m.sttModelID ?? "-", privacy: .public) chars=\(m.rawCharCount, privacy: .public)→\(m.polishedCharCount, privacy: .public) latencyMs=\(m.latencyMs, privacy: .public)\(breakdown, privacy: .public)\(reason, privacy: .public)"
             )
         }
     }

--- a/DictusCore/Sources/DictusCore/Polish/PolishPipeline.swift
+++ b/DictusCore/Sources/DictusCore/Polish/PolishPipeline.swift
@@ -21,12 +21,22 @@ public enum PolishPipeline {
         public let engineMs: Int
         /// Marker decode + NBSP + guardrail, measured after the engine returned.
         public let postprocessMs: Int
+        /// The engine's own name for what it threw (#315). Set on
+        /// `.engineFailed` and only there: every other outcome either never
+        /// reached the engine or came back from it normally. `nil` elsewhere,
+        /// so a caller can key on the reason's presence.
+        public let failureReason: PolishFailureReason?
 
-        public init(engineOutput: String?, outcome: PolishMetrics.Outcome, engineMs: Int, postprocessMs: Int) {
+        public init(engineOutput: String?,
+                    outcome: PolishMetrics.Outcome,
+                    engineMs: Int,
+                    postprocessMs: Int,
+                    failureReason: PolishFailureReason? = nil) {
             self.engineOutput = engineOutput
             self.outcome = outcome
             self.engineMs = engineMs
             self.postprocessMs = postprocessMs
+            self.failureReason = failureReason
         }
     }
 
@@ -101,7 +111,13 @@ public enum PolishPipeline {
             return Result(engineOutput: nil, outcome: .cancelled, engineMs: engineMs, postprocessMs: 0)
         } catch {
             let engineMs = Int(Date().timeIntervalSince(engineStart) * 1000)
-            return Result(engineOutput: nil, outcome: .engineFailed, engineMs: engineMs, postprocessMs: 0)
+            // Ask the engine that threw what it threw (#315). Only the failing
+            // backend can read its own SDK's error type; the transform records
+            // the answer without ever knowing which backend it is talking to.
+            // Nothing else in this `do` block throws, so the error is always the
+            // engine's.
+            return Result(engineOutput: nil, outcome: .engineFailed, engineMs: engineMs, postprocessMs: 0,
+                          failureReason: engine.failureReason(for: error))
         }
     }
 

--- a/DictusCore/Sources/polish-harness/main.swift
+++ b/DictusCore/Sources/polish-harness/main.swift
@@ -107,6 +107,25 @@ struct RunOutcome {
     /// Raw NLLanguage code of the input ("fr", "it", "zh-Hans", …).
     let detected: String?
     let mode: PolishMode?
+    /// Set when the engine threw (#315) — the same slug the app exports, so a
+    /// failure seen here reads against the field data without a translation.
+    let failureReason: PolishFailureReason?
+
+    init(final: String,
+         engineOutput: String?,
+         outcome: PolishMetrics.Outcome,
+         engineMs: Int,
+         detected: String?,
+         mode: PolishMode?,
+         failureReason: PolishFailureReason? = nil) {
+        self.final = final
+        self.engineOutput = engineOutput
+        self.outcome = outcome
+        self.engineMs = engineMs
+        self.detected = detected
+        self.mode = mode
+        self.failureReason = failureReason
+    }
 }
 
 @available(macOS 26.0, *)
@@ -124,7 +143,7 @@ func runOnce(_ fx: Fixture, engine: AppleFoundationModelsPolishEngine) async -> 
     let mode = PolishPipeline.mode(sttEngine: fx.speechEngine, detected: detected, target: target)
     let r = await PolishPipeline.transform(preprocessed: preprocessed, engine: engine, target: target, mode: mode)
     let final = PolishPipeline.resolvedOutput(r, preprocessed: preprocessed, target: target, mode: mode)
-    return RunOutcome(final: final, engineOutput: r.engineOutput, outcome: r.outcome, engineMs: r.engineMs, detected: detected.rawValue, mode: mode)
+    return RunOutcome(final: final, engineOutput: r.engineOutput, outcome: r.outcome, engineMs: r.engineMs, detected: detected.rawValue, mode: mode, failureReason: r.failureReason)
 }
 
 /// Auto-detect path (#239), mirroring `PolishCoordinator.polishAutoDetected`:
@@ -141,7 +160,7 @@ func runOnceAuto(_ fx: Fixture, engine: AppleFoundationModelsPolishEngine) async
     let preprocessed = PolishPipeline.autoPreprocess(fx.raw, detectedCode: detectedCode)
     let r = await PolishPipeline.transform(preprocessed: preprocessed, engine: engine, target: .english, mode: .auto)
     let final = PolishPipeline.resolvedOutput(r, preprocessed: preprocessed, target: .english, mode: .auto)
-    return RunOutcome(final: final, engineOutput: r.engineOutput, outcome: r.outcome, engineMs: r.engineMs, detected: detectedCode, mode: .auto)
+    return RunOutcome(final: final, engineOutput: r.engineOutput, outcome: r.outcome, engineMs: r.engineMs, detected: detectedCode, mode: .auto, failureReason: r.failureReason)
 }
 
 @available(macOS 26.0, *)
@@ -155,7 +174,8 @@ func runHarness() async {
             for run in 1...max(1, runs) {
                 let o = await runOnce(fx, engine: engine)
                 let tag = runs > 1 ? " #\(run)" : ""
-                let route = "\(o.outcome.rawValue), \(o.engineMs)ms, detected=\(o.detected ?? "-")→\(o.mode?.rawValue ?? "-")"
+                let why = o.failureReason.map { ", reason=\($0.slug)" } ?? ""
+                let route = "\(o.outcome.rawValue), \(o.engineMs)ms, detected=\(o.detected ?? "-")→\(o.mode?.rawValue ?? "-")\(why)"
                 print("  polished\(tag): \(o.final)")
                 print("            (\(route))")
                 // When the guardrail rejects, `final` is the raw fallback — surface

--- a/DictusCore/Tests/DictusCoreTests/Polish/PolishFailureReasonTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/Polish/PolishFailureReasonTests.swift
@@ -1,0 +1,263 @@
+// DictusCore/Tests/DictusCoreTests/Polish/PolishFailureReasonTests.swift
+import XCTest
+@testable import DictusCore
+
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+/// Coverage of the engine-failure reason (#315): the mapping itself, the path it
+/// travels from a throwing engine to a persisted metric, and the two things this
+/// work must NOT have changed — what the user receives on a failure, and the
+/// decodability of events written before the field existed.
+final class PolishFailureReasonTests: XCTestCase {
+
+    // MARK: - Slug mapping
+
+    /// The slugs are a wire format: they land in the debug export, in the
+    /// persistent log, and in reports written against one build and read against
+    /// the next. Renaming one silently would make two exports incomparable, so
+    /// every value is pinned literally here.
+    func testSlugsAreStableStrings() {
+        XCTAssertEqual(PolishFailureReason.exceededContextWindowSize.slug, "exceededContextWindowSize")
+        XCTAssertEqual(PolishFailureReason.assetsUnavailable.slug, "assetsUnavailable")
+        XCTAssertEqual(PolishFailureReason.guardrailViolation.slug, "guardrailViolation")
+        XCTAssertEqual(PolishFailureReason.unsupportedGuide.slug, "unsupportedGuide")
+        XCTAssertEqual(PolishFailureReason.unsupportedLanguageOrLocale.slug, "unsupportedLanguageOrLocale")
+        XCTAssertEqual(PolishFailureReason.decodingFailure.slug, "decodingFailure")
+        XCTAssertEqual(PolishFailureReason.rateLimited.slug, "rateLimited")
+        XCTAssertEqual(PolishFailureReason.concurrentRequests.slug, "concurrentRequests")
+        XCTAssertEqual(PolishFailureReason.refusal.slug, "refusal")
+    }
+
+    func testCatchAllCarriesTheErrorTypeName() {
+        XCTAssertEqual(PolishFailureReason.other(UnrecognisedFailure()).slug, "other:UnrecognisedFailure")
+    }
+
+    /// An engine that classifies nothing — every backend but Apple FM today —
+    /// still reports an identifiable reason through the protocol's default
+    /// implementation.
+    func testDefaultEngineImplementationFallsBackToTheCatchAll() {
+        let engine = PassthroughPolishEngine()
+        XCTAssertEqual(engine.failureReason(for: UnrecognisedFailure()), .other(UnrecognisedFailure()))
+        XCTAssertEqual(engine.failureReason(for: UnrecognisedFailure()).slug, "other:UnrecognisedFailure")
+    }
+
+    #if canImport(FoundationModels)
+    /// The acceptance criterion of #315: each of Apple's nine `GenerationError`
+    /// cases must map to its own slug. Distinctness is what makes the per-reason
+    /// count in the export meaningful — the whole investigation turns on telling
+    /// `rateLimited` (Apple capping us) from `concurrentRequests` (our own two
+    /// calls overlapping).
+    func testEveryGenerationErrorCaseMapsToItsOwnSlug() throws {
+        guard #available(iOS 26.0, macOS 26.0, *) else {
+            throw XCTSkip("LanguageModelSession.GenerationError requires the iOS/macOS 26 SDK")
+        }
+        let engine = AppleFoundationModelsPolishEngine()
+        let context = LanguageModelSession.GenerationError.Context(debugDescription: "test")
+        let expected: [(LanguageModelSession.GenerationError, PolishFailureReason)] = [
+            (.exceededContextWindowSize(context), .exceededContextWindowSize),
+            (.assetsUnavailable(context), .assetsUnavailable),
+            (.guardrailViolation(context), .guardrailViolation),
+            (.unsupportedGuide(context), .unsupportedGuide),
+            (.unsupportedLanguageOrLocale(context), .unsupportedLanguageOrLocale),
+            (.decodingFailure(context), .decodingFailure),
+            (.rateLimited(context), .rateLimited),
+            (.concurrentRequests(context), .concurrentRequests),
+            (.refusal(LanguageModelSession.GenerationError.Refusal(transcriptEntries: []), context), .refusal)
+        ]
+        for (error, reason) in expected {
+            XCTAssertEqual(engine.failureReason(for: error), reason)
+        }
+        XCTAssertEqual(Set(expected.map { engine.failureReason(for: $0.0) }).count, expected.count,
+                       "two GenerationError cases collapsed into one slug — the export could not tell them apart")
+    }
+
+    /// An error Apple FM did not throw itself still has to be identifiable.
+    func testAppleEngineMapsAnUnrecognisedErrorToTheCatchAll() throws {
+        guard #available(iOS 26.0, macOS 26.0, *) else {
+            throw XCTSkip("AppleFoundationModelsPolishEngine requires the iOS/macOS 26 SDK")
+        }
+        let engine = AppleFoundationModelsPolishEngine()
+        XCTAssertEqual(engine.failureReason(for: UnrecognisedFailure()).slug, "other:UnrecognisedFailure")
+    }
+
+    /// The reason must never quote the error's message: `Context.debugDescription`
+    /// can carry the prompt, which is the user's dictation, and the reason
+    /// travels into a shared export.
+    func testSlugDoesNotLeakTheErrorContext() throws {
+        guard #available(iOS 26.0, macOS 26.0, *) else {
+            throw XCTSkip("LanguageModelSession.GenerationError requires the iOS/macOS 26 SDK")
+        }
+        let secret = "rendez-vous chez le docteur mardi à quinze heures"
+        let error = LanguageModelSession.GenerationError.rateLimited(
+            .init(debugDescription: secret)
+        )
+        let slug = AppleFoundationModelsPolishEngine().failureReason(for: error).slug
+        XCTAssertEqual(slug, "rateLimited")
+        XCTAssertFalse(slug.contains("docteur"))
+    }
+    #endif
+
+    // MARK: - The path from engine to metric
+
+    /// The engine throws, the pipeline records the reason the engine gave, and
+    /// the metric built from that result carries it unchanged.
+    func testReasonSurvivesFromTheEngineIntoTheMetric() async {
+        let result = await PolishPipeline.transform(
+            preprocessed: "une dictée parfaitement ordinaire qu'il faudrait polir",
+            engine: ClassifyingStubEngine(reason: .rateLimited),
+            target: .french,
+            mode: .natural
+        )
+        XCTAssertEqual(result.outcome, .engineFailed)
+        XCTAssertEqual(result.failureReason, .rateLimited)
+
+        let metric = PolishMetrics(
+            engine: "classifying-stub", mode: .natural, targetLanguage: .french,
+            detectedLanguage: "fr", rawCharCount: 54, polishedCharCount: 54,
+            latencyMs: 20, outcome: result.outcome, failureReason: result.failureReason
+        )
+        XCTAssertEqual(metric.failureReason, .rateLimited)
+    }
+
+    /// The metric is persisted as one JSON object per line in the 7-day debug
+    /// ring, so "carried into the metric" only counts if it survives the round
+    /// trip to disk — as a bare string, which is what the export and any reader
+    /// of the .jsonl expects.
+    func testReasonSurvivesTheMetricJSONRoundTrip() throws {
+        let metric = PolishMetrics(
+            engine: "apple-fm", mode: .natural, targetLanguage: .french,
+            detectedLanguage: "fr", rawCharCount: 354, polishedCharCount: 354,
+            latencyMs: 20, outcome: .engineFailed,
+            timings: PolishTimings(preprocessMs: 16, engineMs: 4, postprocessMs: 0),
+            failureReason: .concurrentRequests
+        )
+        let data = try JSONEncoder().encode(metric)
+        let json = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertTrue(json.contains("\"failureReason\":\"concurrentRequests\""),
+                      "the reason must encode as a bare string, not a nested object: \(json)")
+        let decoded = try JSONDecoder().decode(PolishMetrics.self, from: data)
+        XCTAssertEqual(decoded.failureReason, .concurrentRequests)
+    }
+
+    /// Backward compatibility, the reason the field is optional: the ring holds
+    /// seven days of events written by whatever build was installed at the time.
+    /// This payload is shaped exactly like one written by 1.8.0 (25) — the build
+    /// the field report came from — and it must still decode.
+    func testEventEncodedWithoutAReasonStillDecodes() throws {
+        let shipped = """
+        {"engine":"apple-fm","mode":"natural","targetLanguage":"fr","detectedLanguage":"fr",\
+        "rawCharCount":354,"polishedCharCount":354,"latencyMs":20,"outcome":"engineFailed",\
+        "sttEngine":"PK","sttModelID":"parakeet-tdt-0.6b-v3",\
+        "timings":{"preprocessMs":16,"engineMs":4,"postprocessMs":0}}
+        """
+        let decoded = try JSONDecoder().decode(PolishMetrics.self, from: XCTUnwrap(shipped.data(using: .utf8)))
+        XCTAssertEqual(decoded.outcome, .engineFailed)
+        XCTAssertNil(decoded.failureReason, "a missing key means 'written before the reason existed', not a failed decode")
+        XCTAssertEqual(decoded.timings?.engineMs, 4)
+    }
+
+    // MARK: - What must NOT have changed
+
+    /// #315 instruments the failure; it does not touch what the user receives.
+    /// On an engine failure that is still the deterministic floor — the pre-pass
+    /// output with target typography — never the literal raw. (#185)
+    func testFailureStillReturnsTheDeterministicFloor() async {
+        // The pre-pass has already turned the spoken "virgule" into a comma; the
+        // floor must keep that work and apply French NBSP on top.
+        let preprocessed = "Ok, petit test ?"
+        let result = await PolishPipeline.transform(
+            preprocessed: preprocessed,
+            engine: ClassifyingStubEngine(reason: .rateLimited),
+            target: .french,
+            mode: .natural
+        )
+        XCTAssertEqual(result.outcome, .engineFailed)
+        XCTAssertNil(result.engineOutput)
+        let out = PolishPipeline.resolvedOutput(
+            result, preprocessed: preprocessed, target: .french, mode: .natural
+        )
+        XCTAssertEqual(out, "Ok, petit test\u{00A0}?")
+    }
+
+    /// A cancellation is not an engine failure and must carry no reason — the
+    /// pipeline catches it first, and #315 must not have blurred the two.
+    func testCancellationCarriesNoReason() async {
+        let task = Task {
+            await PolishPipeline.transform(
+                preprocessed: "une dictée que l'on va interrompre avant la fin",
+                engine: SlowStubEngine(),
+                target: .french,
+                mode: .natural
+            )
+        }
+        task.cancel()
+        let result = await task.value
+        XCTAssertEqual(result.outcome, .cancelled)
+        XCTAssertNil(result.failureReason)
+    }
+
+    /// Nothing reached the engine on a context overflow (#270), so there is
+    /// nothing for it to have failed at.
+    func testContextOverflowCarriesNoReason() async {
+        let result = await PolishPipeline.transform(
+            preprocessed: String(repeating: "a", count: 20_000),
+            engine: NarrowStubEngine(),
+            target: .french,
+            mode: .natural
+        )
+        XCTAssertEqual(result.outcome, .exceededContextBudget)
+        XCTAssertNil(result.failureReason)
+    }
+}
+
+// MARK: - Stubs
+
+/// An error no engine knows about — the catch-all's input.
+private struct UnrecognisedFailure: Error {}
+
+/// An engine that always throws and classifies its own failure, standing in for
+/// Apple FM (which cannot run in a test process, let alone be made to rate-limit
+/// on command).
+private struct ClassifyingStubEngine: PolishEngineProtocol {
+    let identifier = "classifying-stub"
+    let reason: PolishFailureReason
+
+    struct Failure: Error {}
+
+    func polish(raw: String, targetLanguage: SupportedLanguage, mode: PolishMode) async throws -> String {
+        throw Failure()
+    }
+
+    func failureReason(for error: Error) -> PolishFailureReason { reason }
+}
+
+/// Slow enough that a caller can cancel the surrounding task before it returns.
+private struct SlowStubEngine: PolishEngineProtocol {
+    let identifier = "slow-stub"
+
+    func polish(raw: String, targetLanguage: SupportedLanguage, mode: PolishMode) async throws -> String {
+        try await Task.sleep(nanoseconds: 500_000_000)
+        try Task.checkCancellation()
+        return raw
+    }
+}
+
+/// A ceiling so low that any real dictation is refused before the engine runs.
+private struct NarrowStubEngine: PolishEngineProtocol {
+    let identifier = "narrow-stub"
+
+    func polish(raw: String, targetLanguage: SupportedLanguage, mode: PolishMode) async throws -> String {
+        XCTFail("the engine must not be called on a context overflow")
+        return raw
+    }
+
+    func contextFit(input: String,
+                    targetLanguage: SupportedLanguage,
+                    mode: PolishMode) -> PolishContextFit {
+        PolishContextBudget(contextWindowTokens: 200, scaffoldingTokens: 0,
+                            outputReserveRatio: 1.1, safetyMargin: 1.2)
+            .fit(instructions: "", input: input)
+    }
+}


### PR DESCRIPTION
## What this was for

When polish fails, the next failure has to say **why**. Today it does not: the pipeline
catches whatever the engine threw, maps everything to one `engineFailed` bucket and drops
the error value. The 1.8.0 (25) export showed 25 failures out of 242 events with
`appleFMState = available` throughout, many returning in 4–24 ms — far too fast for the
model to have run — and nothing anywhere could say what they were.

This PR does not fix the failures. Fixing them follows from what the reason turns out to
be, and that is deliberately a different issue: `rateLimited` means Apple is capping us
(and #268 stops being about old devices), `concurrentRequests` means two of our own calls
overlap and the bug is ours. **The deliverable that closes #315 is a comment on the issue
saying which reason dominates**, from a real device run — see below.

## To test by hand

Apple Foundation Models does not run in the simulator, so the real failure path could not
be triggered here. This is the run that produces the data:

1. On device, install this branch (Settings → the app must be the build from
   `fix/315-polish-engine-failure-reason`).
2. Settings → make sure **Polish is on**, and that Apple Intelligence is enabled.
3. Dictate roughly a dozen times in a few minutes, each one of normal length (10–30 s of
   speech — under 2 s skips the model entirely and produces no engine call). Expect: the
   text is inserted every time, polished or not. Nothing user-visible changes in this PR.
4. Settings → long-press the **Version** row for 3 seconds → **Polish debug**.
5. Expect: failed rows are the red `failed` pills. On each one, the slot that used to show
   the mode now shows a reason — `rateLimited`, `concurrentRequests`,
   `exceededContextWindowSize`, … or `other:<Type>`. Tap a row: the detail sheet shows the
   same value under **failure reason**.
6. Top-right menu → **Export JSON…** → share it to yourself.
7. In the JSON, expect a new top-level `failureReasons` block next to `outcomes`, e.g.
   `"failureReasons": { "rateLimited": 21, "concurrentRequests": 4 }`, and a
   `"failureReason"` field on every event whose `outcome` is `engineFailed`. Successful
   events do not carry the field. If there were no failures at all, `failureReasons` is
   `{}` — dictate more, or in a longer burst, since the failures cluster after a run of
   successful calls.
8. Optional, and worth it if a failure looks odd: export the normal debug log too. Each
   engine failure now writes one `polishEngineFailed reason=… engine=… mode=… engineMs=…`
   line, so it can be read against the dictation timeline around it.
9. **Then comment on #315 with which reason dominates.** That number is what unblocks the
   decision the issue describes.

## What changed, and why

**The one choice the brief left open — where classification lives — went to the engine.**
`PolishEngineProtocol` gains `failureReason(for:) -> PolishFailureReason`, with a default
implementation returning the catch-all; `AppleFoundationModelsPolishEngine` overrides it
and switches over `LanguageModelSession.GenerationError`. The alternative (engines throw,
the pipeline classifies) was rejected because `GenerationError` sits behind **both**
`#if canImport(FoundationModels)` and an iOS/macOS 26 availability gate: a pipeline that
classified it would have to import the framework and carry that gate, and propagate it to
the off-device harness and every test — the hard dependency the brief forbids. The
protocol already asks the engine backend-shaped questions (`contextFit`,
`announcesProcessingStage`), so this is the existing seam, not a new one.

- **`PolishFailureReason`** (new, DictusCore) — a stable low-cardinality slug. Nine named
  values mirroring Apple's nine `GenerationError` cases, plus `other(_:)` carrying the
  error's Swift type name so an unforeseen failure stays identifiable. Encoded as a bare
  string. It reads **nothing** out of the error but its case: the attached
  `Context.debugDescription` can quote the prompt, which is the user's dictation, and this
  value travels into a shared export.
- **`PolishPipeline.Result.failureReason`** — set on `.engineFailed` and only there.
  Cancellation is still caught first and carries no reason; a context overflow (#270)
  never reached the engine, so it carries none either.
- **`PolishMetrics.failureReason`** — new, **optional**, added last with a default. The
  7-day debug ring holds events written by whatever build was installed at the time, and
  those must keep decoding; a missing key means "written before the reason existed", not a
  failed decode. `engineFailed` keeps its `rawValue`. A test pins this with a payload
  shaped exactly like a 1.8.0 (25) event.
- **Debug export** — `failureReason` per failed event, `failureReasons` per-reason counts
  in the summary. Not seeded with every known slug, unlike `outcomes`: the reason set is
  open, and a healthy export should print `{}` rather than nine zeroes.
- **`PersistentLog`** — one `polishEngineFailed` line per engine failure, subsystem
  `transcription`, level `warning` (the user still gets their text; the loss is silent,
  which is what makes it worth finding). `Subsystem` deliberately stays at six cases.
- **`polish-harness`** — prints the reason on a non-success run, so an off-device failure
  reads against the field data without a translation.
- **Unchanged on purpose:** what the user receives on a failure is still the deterministic
  floor (#185), pinned by a test. No retry, no recovery, no user-visible message — all
  explicitly out of scope until the data exists.

`LogEvent.swift` is touched by insertion only (28 added, 0 removed, new MARK section at
the end of the enum, one dedicated clause appended per switch) — another branch is editing
its waveform region concurrently.

## Acceptance criteria

| Criterion | Status | Evidence |
|---|---|---|
| Every `GenerationError` case → distinct stable slug; unrecognised → catch-all with type name | ✅ | `testEveryGenerationErrorCaseMapsToItsOwnSlug` (builds all nine — Apple's `Context`/`Refusal` inits are public — asserts each mapping *and* that the nine slugs are distinct), `testCatchAllCarriesTheErrorTypeName`, `testAppleEngineMapsAnUnrecognisedErrorToTheCatchAll`, `testSlugsAreStableStrings`. All ran (not skipped) on macOS 26. |
| Reason optional on the metric; an event encoded without it still decodes | ✅ | `testEventEncodedWithoutAReasonStillDecodes` — decodes a literal 1.8.0-shaped JSON payload, asserts `failureReason == nil` and that the rest still decodes. |
| DictusCore test drives the pipeline with a throwing stub, reason survives into result and metric | ✅ | `testReasonSurvivesFromTheEngineIntoTheMetric`, `testReasonSurvivesTheMetricJSONRoundTrip` (also pins the bare-string encoding). |
| Text handed back on failure is still the deterministic floor | ✅ | `testFailureStillReturnsTheDeterministicFloor` — French NBSP floor, unchanged. |
| Debug export shows the reason per failed event + per-reason count in the summary | ⚠️ code + build only | The exporter is `@MainActor` DictusApp code over UIKit and the App Group, so it is not reachable from the DictusCore suite and cannot be exercised off-device. Verified by the app build and by reading the diff; the JSON is confirmed by step 7 of the manual run above. |
| `swiftlint lint --strict` clean, `swift test` green | ✅ | `Found 0 violations, 0 serious in 168 files.` — `Executed 705 tests, with 1 test skipped and 0 failures`. The single skip is the pre-existing `UserDictionaryTests` one, untouched here. |
| PR body includes the device-reproduction recipe | ✅ | Above. |

Build: `xcodebuild build -scheme DictusApp -destination 'platform=iOS Simulator,id=…'` →
`** BUILD SUCCEEDED **` (DictusApp + DictusKeyboard.appex + DictusWidgets.appex).

## What I am not comfortable with

**The real classification path has never executed.** Apple FM does not run in the
simulator, so no `GenerationError` was ever produced by an actual model call. The mapping
is proven against errors constructed in a test, and the transport is proven with a stub
engine — but "Apple FM throws, and the slug that lands in the export is the right one" is
established by the device run in step 7, not by anything in this PR.

`type(of:)` on a bridged `NSError` yields the slug `other:NSError`, which is weak. The
brief asked for the type name and the nine named cases are what the field data needs, so
I did not add the domain/code — but if the export comes back dominated by `other:NSError`,
that is the follow-up.

refs #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kzb4mjnKsLvy2WJ19dyDYM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed failure reasons for polishing engine errors.
  * Failure diagnostics now appear in metrics, logs, debug exports, and troubleshooting views.
  * Added stable classifications for common failures, including rate limits, refusals, unsupported languages, and context limits.
  * Debug output now includes aggregated failure counts and per-event reason details.

* **Bug Fixes**
  * Preserved compatibility with older diagnostic records without failure reasons.
  * Cancellations and pre-engine failures remain distinguishable from engine failures.
  * Failure details now remain consistent across targeted and automatic language detection runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->