### PR TITLE
feat: QWERTZ keyboard layout for German (refs #151)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -62,7 +62,9 @@ A polish backend conforming to `PolishEngineProtocol` (in DictusCore). One imple
 ## Keyboard
 
 ### Layout type
-The physical key arrangement: `LayoutType.azerty` (French) or `LayoutType.qwerty` (English, Spanish, German). Each `SupportedLanguage` declares its `defaultLayout`. Layout is global today (one active at a time), not per-language; per-language layout selection is tracked in issue #52.
+The physical key arrangement: `LayoutType.azerty` (French), `LayoutType.qwerty` (English, Spanish) or `LayoutType.qwertz` (German, #151). Each `SupportedLanguage` declares its `defaultLayout`, which seeds the layout when that language is *selected* and never rewrites a layout already stored. Layout is global today (one active at a time), not per-language; per-language layout selection is tracked in issue #52, and decoupling layout from dictionary language in #272.
+
+QWERTZ carries dedicated ä/ö/ü keys, which makes its first two rows 11 units wide against 10 for every other row in every layout. The renderer normalizes each row against its own unit total, so those rows draw narrower keys. Row data lives in `DictusCore/KeyboardLayoutData.swift`; `DictusKeyboard/KeyboardLayouts.swift` builds the keys from it.
 
 ### Long-press accents (`AccentedCharacters.mappings`)
 Pop-up accent variants shown when a key is long-pressed. Currently merged across languages (French + Spanish ñ + acute variants), keyed by base letter. To be migrated into `LanguageProfile.longPressAccents` so each language declares its own popups.

--- a/DictusApp/Views/SettingsView.swift
+++ b/DictusApp/Views/SettingsView.swift
@@ -166,7 +166,7 @@ struct SettingsView: View {
                 }
                 .onChange(of: language) { _, newLang in
                     // Auto-switch keyboard layout to the language's default.
-                    // French -> AZERTY, English/Spanish -> QWERTY.
+                    // French -> AZERTY, English/Spanish -> QWERTY, German -> QWERTZ.
                     if let lang = SupportedLanguage(rawValue: newLang) {
                         keyboardLayout = lang.defaultLayout.rawValue
                     }
@@ -175,8 +175,12 @@ struct SettingsView: View {
                 DefaultLayerPicker()
 
                 Picker("Layout", selection: $keyboardLayout) {
-                    Text("AZERTY").tag("azerty")
-                    Text("QWERTY").tag("qwerty")
+                    // Iterate over LayoutType so adding a layout (QWERTZ in #151,
+                    // any future one) only requires the enum case — the entries used
+                    // to be hardcoded here and in the keyboard panel separately.
+                    ForEach(LayoutType.allCases, id: \.rawValue) { layout in
+                        Text(layout.displayName).tag(layout.rawValue)
+                    }
                 }
 
                 Toggle("Haptic feedback", isOn: $hapticsEnabled)

--- a/DictusCore/Sources/DictusCore/KeyboardLayoutData.swift
+++ b/DictusCore/Sources/DictusCore/KeyboardLayoutData.swift
@@ -8,9 +8,27 @@ import Foundation
 /// Both the main app (settings UI) and the keyboard extension need to read/write the
 /// layout preference. Putting the enum and its persistence logic in the shared framework
 /// prevents each target from defining its own incompatible version.
-public enum LayoutType: String, Codable, Sendable {
+/// WHY the raw values are frozen:
+/// The raw string is what sits in App Group UserDefaults on every installed device.
+/// Renaming a case renames the persisted value, and every keyboard already holding
+/// the old string would silently fall back to AZERTY on the next launch.
+public enum LayoutType: String, Codable, Sendable, CaseIterable {
     case azerty
     case qwerty
+    case qwertz
+
+    /// Label shown wherever a layout is named in the UI (Settings picker, keyboard panel).
+    ///
+    /// WHY not `rawValue.uppercased()`: the Settings picker and the keyboard panel used to
+    /// spell their labels independently, so a new layout meant editing both. Naming them
+    /// once here means adding a case is the whole change (#151).
+    public var displayName: String {
+        switch self {
+        case .azerty: return "AZERTY"
+        case .qwerty: return "QWERTY"
+        case .qwertz: return "QWERTZ"
+        }
+    }
 
     /// Reads the active layout from App Group UserDefaults, defaulting to AZERTY.
     /// AZERTY is the default because Dictus targets French-speaking users.
@@ -40,5 +58,56 @@ public enum QWERTYLayout {
         ["A", "S", "D", "F", "G", "H", "J", "K", "L"],
         ["Z", "X", "C", "V", "B", "N", "M"],
         ["globe", "123", "mic", "space", "return"]
+    ]
+}
+
+/// QWERTZ letter layout as raw string arrays — the German layout (#151).
+///
+/// Rows, in order: `Q W E R T Z U I O P Ü` / `A S D F G H J K L Ö Ä` / `Y X C V B N M`.
+/// That is the layout iOS ships as its *default* German keyboard and the one the
+/// AOSP-derived open-source keyboards build: ü closes the top row, ö and ä close the
+/// home row. Apple's second German entry (labelled "QWERTZ" in iOS settings) hides the
+/// umlauts behind a long-press to keep the remaining keys wider; Dictus does not ship
+/// that variant — if it is ever wanted it is a separate layout, not a change to this one.
+///
+/// There is no dedicated ß on either platform. It stays a long-press on `s`
+/// (`AccentedCharacters.mappings`).
+///
+/// WHY the rows live here and not only in `KeyboardLayouts` (DictusKeyboard):
+/// the keyboard extension has no test target — `swift test` builds this package alone —
+/// so row data declared only in the extension cannot be pinned by a test. The keyboard
+/// builds its `KeyDefinition`s from these arrays, which keeps the test measuring what
+/// actually renders instead of a copy.
+public enum QWERTZLayout {
+    /// Unit width of the shift and delete keys flanking row 3 — the same 1.5 the other
+    /// layouts use. Declared here, and read by the keyboard, so `rowUnitWidths` below is
+    /// derived from the value the renderer uses rather than restating it.
+    public static let flankKeyUnitWidth: Double = 1.5
+
+    /// The three letter rows, uppercase (the shifted page). Matches the `QWERTYLayout`
+    /// convention: layout data stores uppercase, the keyboard lowercases for the normal page.
+    /// Row 3 holds letters only — shift and delete are added by the keyboard target.
+    public static let lettersRows: [[String]] = [
+        ["Q", "W", "E", "R", "T", "Z", "U", "I", "O", "P", "\u{00DC}"],   // …P Ü
+        ["A", "S", "D", "F", "G", "H", "J", "K", "L", "\u{00D6}", "\u{00C4}"],   // …L Ö Ä
+        ["Y", "X", "C", "V", "B", "N", "M"]
+    ]
+
+    /// The same three rows lowercased — the normal (unshifted) page.
+    public static var lowercasedLettersRows: [[String]] {
+        lettersRows.map { row in row.map { $0.lowercased() } }
+    }
+
+    /// Total unit width of each letter row as rendered.
+    ///
+    /// Rows 1 and 2 total **11** where every other row in every layout totals 10. That
+    /// asymmetry is the specification, not an oversight: the renderer normalizes each row
+    /// against its own unit total (`KeyboardView.sizeForItemAt`), so the umlaut rows simply
+    /// render slightly narrower keys — exactly what iOS and Android do. Padding them back
+    /// to 10 with spacers would push the umlauts off the edge of the row.
+    public static let rowUnitWidths: [Double] = [
+        Double(lettersRows[0].count),                                  // 11 input keys
+        Double(lettersRows[1].count),                                  // 11 input keys
+        flankKeyUnitWidth * 2 + Double(lettersRows[2].count)           // shift + 7 + delete = 10
     ]
 }

--- a/DictusCore/Sources/DictusCore/Languages/German.swift
+++ b/DictusCore/Sources/DictusCore/Languages/German.swift
@@ -6,14 +6,14 @@ import Foundation
 
 /// German (`de`).
 ///
-/// Layout: QWERTY on launch (QWERTZ deferred to follow-up issue #151).
+/// Layout: QWERTZ (#151) — dedicated ä/ö/ü keys, ß by long-press on `s`.
 /// Overrides: empty per ADR 0001 (populated post-launch from native-speaker feedback on issue #109).
 /// Contractions: empty — German `geht's`/`gibt's` style elisions are rare and not curated.
 public let germanProfile = LanguageProfile(
     code: "de",
     displayName: "Deutsch",
     shortCode: "DE",
-    defaultLayout: .qwerty,
+    defaultLayout: .qwertz,
     spaceName: "Leertaste",
     returnName: "Eingabe",
     overrides: [:],
@@ -28,12 +28,15 @@ public let germanProfile = LanguageProfile(
     ],
     contractionPrefixes: [],
     collapseRules: [
-        // German Umlautersatz: standard ASCII transliterations Germans use on
-        // keyboards without umlaut keys (URLs, filenames, emails — and our
-        // QWERTY layout). Each rule converts the 2-char ASCII sequence to its
-        // single-char umlaut counterpart. Same 5x-dominance protection as
-        // single-char accent expansion guards against false positives like
-        // `bauer` (farmer) → `baür` (not a word, no false correction).
+        // German Umlautersatz: standard ASCII transliterations Germans use where
+        // umlauts are unavailable or unwanted — URLs, filenames, email addresses —
+        // and out of habit anywhere else. They stay after #151 gave the layout real
+        // ä/ö/ü keys: the keys removed the *need* to transliterate, not the habit,
+        // and a user who still types `koennen` expects `können`. Each rule converts
+        // the 2-char ASCII sequence to its single-char umlaut counterpart. The same
+        // 5x-dominance protection as single-char accent expansion guards against
+        // false positives like `bauer` (farmer) → `baür` (not a word, no false
+        // correction).
         //
         // Without these rules, `tuer` → `tier` (animal, edit-distance 1) via
         // the trie's spell-check fallback instead of `Tür` (door).

--- a/DictusCore/Sources/DictusCore/SupportedLanguage.swift
+++ b/DictusCore/Sources/DictusCore/SupportedLanguage.swift
@@ -29,12 +29,16 @@ public enum SupportedLanguage: String, CaseIterable, Codable, Sendable {
     public var shortCode: String { rawValue.uppercased() }
 
     /// Default keyboard layout for this language.
-    /// French defaults to AZERTY; English, Spanish, and German default to QWERTY.
-    /// (German QWERTZ is deferred to follow-up issue #151.)
+    /// French defaults to AZERTY; English and Spanish to QWERTY; German to QWERTZ (#151).
+    ///
+    /// This is the layout a user gets when they *select* the language. It does not
+    /// rewrite a layout already stored: a German user who installed before #151 keeps
+    /// QWERTY until they select German again. Nobody's keyboard changes shape on update.
     public var defaultLayout: LayoutType {
         switch self {
         case .french: return .azerty
-        case .english, .spanish, .german: return .qwerty
+        case .english, .spanish: return .qwerty
+        case .german: return .qwertz
         }
     }
 

--- a/DictusCore/Tests/DictusCoreTests/Languages/GermanLanguageTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/Languages/GermanLanguageTests.swift
@@ -13,8 +13,8 @@ final class GermanLanguageTests: XCTestCase {
         XCTAssertEqual(p.code, "de")
         XCTAssertEqual(p.displayName, "Deutsch")
         XCTAssertEqual(p.shortCode, "DE")
-        XCTAssertEqual(p.defaultLayout, .qwerty,
-                       "QWERTY on launch — QWERTZ deferred to issue #151.")
+        XCTAssertEqual(p.defaultLayout, .qwertz,
+                       "German selects QWERTZ — the layout iOS ships as its default German keyboard.")
         XCTAssertEqual(p.spaceName, "Leertaste")
         XCTAssertEqual(p.returnName, "Eingabe")
     }

--- a/DictusCore/Tests/DictusCoreTests/LayoutTypeTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/LayoutTypeTests.swift
@@ -1,0 +1,67 @@
+// DictusCore/Tests/DictusCoreTests/LayoutTypeTests.swift
+// The layout enum is persisted by raw value in App Group defaults and read by
+// both targets, so the raw values and the fallback are pinned here (#151).
+import XCTest
+@testable import DictusCore
+
+final class LayoutTypeTests: XCTestCase {
+
+    private var defaults: UserDefaults? {
+        UserDefaults(suiteName: AppGroup.identifier)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        defaults?.removeObject(forKey: SharedKeys.keyboardLayout)
+    }
+
+    // MARK: - Persisted raw values
+
+    /// Renaming any of these renames what is already stored on installed devices,
+    /// which would silently reset those users to AZERTY.
+    func testRawValuesAreStable() {
+        XCTAssertEqual(LayoutType.azerty.rawValue, "azerty")
+        XCTAssertEqual(LayoutType.qwerty.rawValue, "qwerty")
+        XCTAssertEqual(LayoutType.qwertz.rawValue, "qwertz")
+    }
+
+    func testAllCasesCoversTheThreeLayouts() {
+        XCTAssertEqual(LayoutType.allCases, [.azerty, .qwerty, .qwertz])
+    }
+
+    // MARK: - Round-trip through App Group defaults
+
+    func testEveryLayoutRoundTripsThroughAppGroupDefaults() {
+        for layout in LayoutType.allCases {
+            defaults?.set(layout.rawValue, forKey: SharedKeys.keyboardLayout)
+            XCTAssertEqual(LayoutType.active, layout, "\(layout.rawValue) did not round-trip")
+        }
+    }
+
+    func testQwertzIsResolvedFromTheStoredRawValue() {
+        defaults?.set("qwertz", forKey: SharedKeys.keyboardLayout)
+        XCTAssertEqual(LayoutType.active, .qwertz)
+    }
+
+    // MARK: - Fallback
+
+    func testUnknownStoredValueFallsBackToAzerty() {
+        defaults?.set("dvorak", forKey: SharedKeys.keyboardLayout)
+        XCTAssertEqual(LayoutType.active, .azerty,
+                       "An unrecognised stored layout must keep falling back to AZERTY.")
+    }
+
+    func testMissingStoredValueFallsBackToAzerty() {
+        defaults?.removeObject(forKey: SharedKeys.keyboardLayout)
+        XCTAssertEqual(LayoutType.active, .azerty)
+    }
+
+    // MARK: - Display names
+
+    /// Settings and the keyboard panel both read this, so the label is pinned once.
+    func testDisplayNames() {
+        XCTAssertEqual(LayoutType.azerty.displayName, "AZERTY")
+        XCTAssertEqual(LayoutType.qwerty.displayName, "QWERTY")
+        XCTAssertEqual(LayoutType.qwertz.displayName, "QWERTZ")
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/QWERTZLayoutTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/QWERTZLayoutTests.swift
@@ -1,0 +1,91 @@
+// DictusCore/Tests/DictusCoreTests/QWERTZLayoutTests.swift
+// Pins the German QWERTZ rows (#151). The keyboard target builds its KeyDefinitions
+// from this data, so these assertions cover what actually renders.
+import XCTest
+@testable import DictusCore
+
+final class QWERTZLayoutTests: XCTestCase {
+
+    // MARK: - Key sequences (shifted page)
+
+    func testShiftedRowsAreTheGermanSequenceInOrder() {
+        XCTAssertEqual(QWERTZLayout.lettersRows[0],
+                       ["Q", "W", "E", "R", "T", "Z", "U", "I", "O", "P", "\u{00DC}"])
+        XCTAssertEqual(QWERTZLayout.lettersRows[1],
+                       ["A", "S", "D", "F", "G", "H", "J", "K", "L", "\u{00D6}", "\u{00C4}"])
+        XCTAssertEqual(QWERTZLayout.lettersRows[2],
+                       ["Y", "X", "C", "V", "B", "N", "M"])
+    }
+
+    // MARK: - Key sequences (normal page)
+
+    func testNormalRowsAreTheSameSequenceLowercased() {
+        XCTAssertEqual(QWERTZLayout.lowercasedLettersRows[0],
+                       ["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "\u{00FC}"])
+        XCTAssertEqual(QWERTZLayout.lowercasedLettersRows[1],
+                       ["a", "s", "d", "f", "g", "h", "j", "k", "l", "\u{00F6}", "\u{00E4}"])
+        XCTAssertEqual(QWERTZLayout.lowercasedLettersRows[2],
+                       ["y", "x", "c", "v", "b", "n", "m"])
+    }
+
+    func testThreeLetterRows() {
+        XCTAssertEqual(QWERTZLayout.lettersRows.count, 3)
+        XCTAssertEqual(QWERTZLayout.lowercasedLettersRows.count, 3)
+    }
+
+    // MARK: - Y/Z swap (what makes it QWERTZ)
+
+    func testZSitsInTheTopRowAndYInTheBottomRow() {
+        XCTAssertEqual(QWERTZLayout.lettersRows[0][5], "Z")
+        XCTAssertEqual(QWERTZLayout.lettersRows[2][0], "Y")
+    }
+
+    // MARK: - Row unit widths (the 11/11/10 asymmetry IS the spec)
+
+    /// Rows 1 and 2 carry 11 units where every other row totals 10. The renderer
+    /// normalizes each row against its own total, so those rows render narrower keys.
+    /// Padding them back to 10 would push ü/ä off the edge — hence a test, not a comment.
+    func testRowsOneAndTwoTotalElevenUnitsAndRowThreeTotalsTen() {
+        XCTAssertEqual(QWERTZLayout.rowUnitWidths, [11, 11, 10])
+    }
+
+    func testRowsOneAndTwoCarryElevenKeys() {
+        XCTAssertEqual(QWERTZLayout.lettersRows[0].count, 11)
+        XCTAssertEqual(QWERTZLayout.lettersRows[1].count, 11)
+    }
+
+    func testRowThreeCarriesSevenLetterKeys() {
+        // Shift and delete are added by the keyboard target at 1.5 units each.
+        XCTAssertEqual(QWERTZLayout.lettersRows[2].count, 7)
+        XCTAssertEqual(QWERTZLayout.flankKeyUnitWidth, 1.5)
+    }
+
+    // MARK: - Umlauts and eszett
+
+    func testUmlautsCloseTheirRows() {
+        XCTAssertEqual(QWERTZLayout.lettersRows[0].last, "\u{00DC}")            // Ü
+        XCTAssertEqual(QWERTZLayout.lettersRows[1].suffix(2),
+                       ["\u{00D6}", "\u{00C4}"])                                // Ö Ä
+    }
+
+    /// Neither iOS nor the AOSP-derived keyboards give ß a key; it is a long-press
+    /// on `s`, wired through `AccentedCharacters.mappings`.
+    func testNoDedicatedEszettKey() {
+        let allKeys = QWERTZLayout.lettersRows.flatMap { $0 }
+            + QWERTZLayout.lowercasedLettersRows.flatMap { $0 }
+        XCTAssertFalse(allKeys.contains("\u{00DF}"), "ß must not have a key of its own.")
+    }
+
+    func testEszettIsReachableByLongPressOnS() {
+        XCTAssertEqual(AccentedCharacters.mappings["s"], ["\u{00DF}"])
+    }
+
+    // MARK: - Data conventions
+
+    func testLettersRowsAreStoredUppercase() {
+        // Same convention as QWERTYLayout: uppercase data, lowercased for the normal page.
+        for key in QWERTZLayout.lettersRows.flatMap({ $0 }) {
+            XCTAssertEqual(key, key.uppercased(), "Key '\(key)' should be uppercase in layout data")
+        }
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/SupportedLanguageActivationTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/SupportedLanguageActivationTests.swift
@@ -28,7 +28,7 @@ final class SupportedLanguageActivationTests: XCTestCase {
         SupportedLanguage.activate(.german)
         SupportedLanguage.activate(.german)
         XCTAssertEqual(SupportedLanguage.active, .german)
-        XCTAssertEqual(LayoutType.active, .qwerty)
+        XCTAssertEqual(LayoutType.active, .qwertz)
     }
 
     // MARK: - Layout write (the #272 coupling)
@@ -45,6 +45,24 @@ final class SupportedLanguageActivationTests: XCTestCase {
         SupportedLanguage.activate(.english)
         XCTAssertEqual(defaults?.string(forKey: SharedKeys.keyboardLayout), "qwerty")
         XCTAssertEqual(LayoutType.active, .qwerty)
+    }
+
+    func testActivateGermanWritesQwertz() {
+        SupportedLanguage.activate(.english)
+        SupportedLanguage.activate(.german)
+        XCTAssertEqual(defaults?.string(forKey: SharedKeys.keyboardLayout), "qwertz")
+        XCTAssertEqual(LayoutType.active, .qwertz)
+    }
+
+    /// No migration rewrites a stored layout (#151): a German user who installed
+    /// before QWERTZ existed keeps QWERTY until they select German again. The layout
+    /// is read from what is stored, never re-derived from the active language.
+    func testStoredLayoutSurvivesALanguageItNoLongerMatches() {
+        defaults?.set(SupportedLanguage.german.rawValue, forKey: SharedKeys.language)
+        defaults?.set(LayoutType.qwerty.rawValue, forKey: SharedKeys.keyboardLayout)
+        XCTAssertEqual(SupportedLanguage.active, .german)
+        XCTAssertEqual(LayoutType.active, .qwerty,
+                       "Nobody's keyboard may change shape without them selecting the language again.")
     }
 
     /// Every supported language must leave the pair consistent — a new language

--- a/DictusKeyboard/KeyboardLayouts.swift
+++ b/DictusKeyboard/KeyboardLayouts.swift
@@ -1,6 +1,6 @@
 // DictusKeyboard/KeyboardLayouts.swift
-// AZERTY and QWERTY layout definitions in giellakbd-ios KeyboardDefinition format.
-// Supports French, English, and Spanish with language-aware labels.
+// AZERTY, QWERTY and QWERTZ layout definitions in giellakbd-ios KeyboardDefinition format.
+// Supports French, English, Spanish and German with language-aware labels.
 
 import UIKit
 import DictusCore
@@ -59,6 +59,29 @@ enum KeyboardLayouts {
         )
     }
 
+    /// QWERTZ layout (default for German).
+    ///
+    /// Rows 1 and 2 carry 11 keys where the other two layouts carry 10: ü closes the top
+    /// row, ö and ä close the home row. That is the layout iOS ships as its default German
+    /// keyboard and the one the AOSP-derived keyboards build. The row data itself lives in
+    /// `DictusCore.QWERTZLayout` so it can be covered by tests — the keyboard target has no
+    /// test bundle.
+    static func qwertz(lang: SupportedLanguage = .active, needsGlobe: Bool) -> KeyboardDefinition {
+        return KeyboardDefinition(
+            name: lang.displayName + (lang == .german ? "" : " (QWERTZ)"),
+            locale: lang.rawValue,
+            spaceName: lang.spaceName,
+            returnName: lang.returnName,
+            longPress: longPressData,
+            layout: KeyboardDefinition.Layout(
+                normal: qwertzNormal(lang: lang, needsGlobe: needsGlobe),
+                shifted: qwertzShifted(lang: lang, needsGlobe: needsGlobe),
+                symbols1: numbersPage(lang: lang, needsGlobe: needsGlobe),
+                symbols2: symbolsPage(lang: lang, needsGlobe: needsGlobe)
+            )
+        )
+    }
+
     /// Returns the layout matching the user's App Group preferences.
     ///
     /// - Parameter needsGlobe: pass `UIInputViewController.needsInputModeSwitchKey`. When true
@@ -70,6 +93,7 @@ enum KeyboardLayouts {
         switch LayoutType.active {
         case .azerty: return azerty(lang: lang, needsGlobe: needsGlobe)
         case .qwerty: return qwerty(lang: lang, needsGlobe: needsGlobe)
+        case .qwertz: return qwertz(lang: lang, needsGlobe: needsGlobe)
         }
     }
 
@@ -147,6 +171,45 @@ enum KeyboardLayouts {
                 key("Z"), key("X"), key("C"), key("V"), key("B"), key("N"), key("M"),
                 KeyDefinition(type: .backspace, size: CGSize(width: 1.5, height: 1))
             ],
+            bottomRow(lang: lang, needsGlobe: needsGlobe)
+        ]
+    }
+
+    // MARK: - QWERTZ Letter Pages
+
+    private static func qwertzNormal(lang: SupportedLanguage, needsGlobe: Bool) -> [[KeyDefinition]] {
+        qwertzPage(rows: QWERTZLayout.lowercasedLettersRows, lang: lang, needsGlobe: needsGlobe)
+    }
+
+    private static func qwertzShifted(lang: SupportedLanguage, needsGlobe: Bool) -> [[KeyDefinition]] {
+        qwertzPage(rows: QWERTZLayout.lettersRows, lang: lang, needsGlobe: needsGlobe)
+    }
+
+    /// Builds a QWERTZ letter page from the three letter rows of `QWERTZLayout`.
+    ///
+    /// WHY one builder for both cases, unlike AZERTY and QWERTY: those two spell their
+    /// normal and shifted rows out twice because the rows differ in more than case (the
+    /// AZERTY accent key, the QWERTY spacers). QWERTZ has neither, so the pages differ
+    /// only by which of the two arrays is passed in.
+    ///
+    /// Rows 1 and 2 total 11 units against 10 everywhere else. That is deliberate: the
+    /// renderer normalizes each row against its own unit total (`KeyboardView`), so the
+    /// umlaut rows render slightly narrower keys — what iOS and Android both do. Do NOT
+    /// pad them to 10 with spacers; that would push ü/ä off the edge of the row.
+    private static func qwertzPage(rows: [[String]],
+                                   lang: SupportedLanguage,
+                                   needsGlobe: Bool) -> [[KeyDefinition]] {
+        let flankSize = CGSize(width: QWERTZLayout.flankKeyUnitWidth, height: 1)
+        return [
+            // Row 1: 11 keys = 11 units (…o p ü)
+            rows[0].map { key($0) },
+            // Row 2: 11 keys = 11 units (…k l ö ä)
+            rows[1].map { key($0) },
+            // Row 3: shift + 7 letters + delete = 10 units
+            [KeyDefinition(type: .shift, size: flankSize)]
+                + rows[2].map { key($0) }
+                + [KeyDefinition(type: .backspace, size: flankSize)],
+            // Row 4: unified bottom row (123 + emoji + space + return)
             bottomRow(lang: lang, needsGlobe: needsGlobe)
         ]
     }

--- a/DictusKeyboard/TextPrediction/AOSPTrieEngine.swift
+++ b/DictusKeyboard/TextPrediction/AOSPTrieEngine.swift
@@ -61,6 +61,9 @@ final class AOSPTrieEngine {
 
             // Set proximity map based on active keyboard layout.
             // AZERTY is default because Dictus targets French-speaking users.
+            // QWERTZ takes the QWERTY map: the two differ only by the y/z swap, and
+            // the bridge ships no third map. Worth revisiting only if German typo
+            // reports point at y/z (#151).
             if LayoutType.active == .azerty {
                 self.bridge.setProximityMapAZERTY()
             } else {

--- a/DictusKeyboard/TextPrediction/TextPredictionEngine.swift
+++ b/DictusKeyboard/TextPrediction/TextPredictionEngine.swift
@@ -538,6 +538,8 @@ class TextPredictionEngine {
     /// 3 keys from space, causing false splits like "calvier" → "cal hier".
     /// On QWERTY: bottom row is Z-X-C-V-B-N-M — M is rightmost (next to space),
     /// N and B are close enough to count.
+    /// QWERTZ shares the QWERTY set: its bottom row is Y-X-C-V-B-N-M, so the three
+    /// keys adjacent to the spacebar are the same ones (#151).
     private static let azertySpacebarNeighbors: Set<Character> = ["n", "b", ","]
     private static let qwertySpacebarNeighbors: Set<Character> = ["n", "b", "m"]
 

--- a/DictusKeyboard/Views/EmojiPickerView.swift
+++ b/DictusKeyboard/Views/EmojiPickerView.swift
@@ -382,6 +382,10 @@ private struct MiniSearchKeyboard: View, Equatable {
                 ["a", "s", "d", "f", "g", "h", "j", "k", "l"],
                 ["z", "x", "c", "v", "b", "n", "m"]
             ]
+        case .qwertz:
+            // Read from the shared layout data rather than re-typed here, so the
+            // search keyboard cannot drift from the real one (#151).
+            return QWERTZLayout.lowercasedLettersRows
         }
     }
 

--- a/DictusKeyboard/Views/KeyboardPanelView.swift
+++ b/DictusKeyboard/Views/KeyboardPanelView.swift
@@ -107,7 +107,7 @@ struct KeyboardPanelView: View {
 
                 Spacer(minLength: 8)
 
-                Text(entry.defaultLayout.rawValue.uppercased())
+                Text(entry.defaultLayout.displayName)
                     .font(.system(size: 13, weight: .medium))
                     .foregroundColor(.secondary)
             }


### PR DESCRIPTION
## What this was for

German shipped on QWERTY. A German typist got the layout with Y and Z in the English places and no umlaut keys, reaching ä/ö/ü by long-pressing a/o/u. iOS ships QWERTZ as its *default* German keyboard, with ä, ö and ü as real keys, so QWERTY-only was a visible gap for anyone who knows the system keyboard.

This adds QWERTZ as a third layout, in the shape the brief locked on 2026-08-06 — the variant with dedicated umlaut keys, which is what iOS's default German entry and the AOSP-derived keyboards both ship — and makes it what German selects.

## To test by hand

Everything below needs a real device: the Dictus keyboard **cannot be enabled in a simulator** (`docs/agents/simulator.md` §7, established by experiment there). Nothing about the rendered keyboard was verified on screen.

1. Install the build, open Dictus → Settings → **Layout**. Expect three entries: AZERTY, QWERTY, QWERTZ.
2. Still in Settings, set **Keyboard language** to Deutsch. Expect the Layout row to switch to QWERTZ by itself.
3. Open any text field, switch to the Dictus keyboard. Expect row 1 `q w e r t z u i o p ü`, row 2 `a s d f g h j k l ö ä`, row 3 `y x c v b n m` between shift and delete.
4. Type on the edge keys of the two 11-key rows — `q`, `ü`, `a`, `ä`. **This is the one thing only you can judge:** those rows carry 11 keys where every other row carries 10, so their keys are narrower. If `ü` or `ä` is uncomfortable to hit with a thumb, say so — the fallback is Apple's other German layout (umlauts behind a long-press, wider keys), and that is a new layout rather than a change to this one.
5. Press shift. Expect the same three rows uppercased, umlauts included: `Q W E R T Z U I O P Ü` / `A S D F G H J K L Ö Ä` / `Y X C V B N M`.
6. Long-press `s`. Expect ß in the popup. There is no dedicated ß key, on purpose — neither iOS nor Android gives it one.
7. Long-press `a`, `o`, `u`. The popups still offer ä/ö/ü even though the keys now exist. Redundant, not wrong; per-language long-press popups are #157.
8. Press `123`, then `#+=`, then `ABC`. Expect the numbers and symbols pages unchanged, and nothing resizing on the bottom row.
9. Open the keyboard's hamburger panel. Expect **QWERTZ** next to Deutsch in the language list.
10. Open the emoji picker and tap the search field. Its mini keyboard follows QWERTZ too (11 keys on the first two rows, at 34 pt — worth a look).
11. Switch the language back to Français, then to Deutsch again. Expect AZERTY, then QWERTZ.
12. **If you have a device already running Dictus in German**: install this build over it and confirm the keyboard is still QWERTY until you re-select Deutsch. That is deliberate, see below.

## Migration: nobody's keyboard changes shape on update

`defaultLayout` is what selecting a language *writes*; it does not rewrite a layout already stored. An existing German user therefore keeps QWERTY until they select German again. No migration was added, on purpose — a keyboard silently changing shape under someone's thumbs on an app update is worse than a stale default. Pinned by `testStoredLayoutSurvivesALanguageItNoLongerMatches`.

## What changed

- **`LayoutType`** (DictusCore) gains `qwertz`, plus `CaseIterable` and `displayName`. Raw values are now pinned by a test: the raw string is what sits in App Group defaults on installed devices, so renaming a case would reset those users to AZERTY.
- **`QWERTZLayout`** (DictusCore) holds the three letter rows and the row unit widths. It lives in Core, not only in the keyboard, because the keyboard extension has no test target — `swift test` builds the DictusCore package alone. Row data declared only in the extension cannot be pinned by anything, which is exactly how `DictusKeyboard/Models/KeyboardLayout.swift` became dead code that tests would have "covered". `KeyboardLayouts` builds its `KeyDefinition`s from these arrays, so the tests measure what renders.
- **`KeyboardLayouts.qwertz(lang:needsGlobe:)`** (DictusKeyboard) with its normal/shifted pages and a branch in `current(needsGlobe:)`. Numbers, symbols, bottom row and globe handling are the shared ones, untouched.
- **Rows 1 and 2 total 11 units** against 10 for every other row. Deliberate and documented in three places, because it looks like a bug: the vendored renderer normalizes each row against its own unit total (`KeyboardView.calculateRows` / `sizeForItemAt`), so those rows just draw narrower keys — what iOS and Android do. Padding them to 10 with spacers would push ü/ä off the row.
- **German** selects QWERTZ (`SupportedLanguage.defaultLayout` + `germanProfile`). The test that pinned `.qwerty` while citing this issue is updated, not deleted.
- **`collapseRules` (`ae → ä`) stay.** Their comment justified them by "our QWERTY layout", which stops being true. Rewritten: real keys removed the *need* to transliterate, not the habit, and people still type `koennen` in URLs, filenames and out of reflex.
- **Settings layout picker** is driven by `LayoutType.allCases` + `displayName` instead of two hardcoded rows. The keyboard panel badge reads the same `displayName` instead of uppercasing the raw value, so the two can't spell a layout differently.
- **Emoji search mini-keyboard** gets its QWERTZ case from `QWERTZLayout`, so it cannot drift from the real keyboard.
- **Prediction is unchanged.** QWERTZ takes the QWERTY proximity map (the two differ only by the y/z swap; the C++ bridge ships no third map) and the QWERTY spacebar-neighbour set (both bottom rows end X-C-V-B-N-M). Both sites now say so instead of relying on an `else`.
- `CONTEXT.md` glossary updated.

Not touched: `DictusKeyboard/Models/KeyboardLayout.swift` and `Models/KeyDefinition.swift`. Verified they are declared in the pbxproj but listed in **no** Sources build phase, so the new enum case does not break their exhaustive switch — they are not compiled at all.

## Acceptance criteria

| Criterion | Status | Evidence |
|---|---|---|
| `qwertz` raw value round-trips through App Group defaults; unknown value still falls back | ✅ | `LayoutTypeTests` — 7 tests incl. `testUnknownStoredValueFallsBackToAzerty` |
| Resolving the active layout returns the QWERTZ definition, with and without the globe | ⚠️ **partial** | See below |
| Test pins the exact key sequence of the three letter rows, normal and shifted, in order | ✅ | `QWERTZLayoutTests.testShiftedRowsAreTheGermanSequenceInOrder`, `testNormalRowsAreTheSameSequenceLowercased` |
| Test pins rows 1–2 at 11 units, the rest at 10 | ✅ | `QWERTZLayoutTests.testRowsOneAndTwoTotalElevenUnitsAndRowThreeTotalsTen` (`rowUnitWidths == [11, 11, 10]`, derived from the row data and the 1.5-unit flanking keys, not restated) |
| No dedicated ß; ß stays a long-press on `s` | ✅ | `testNoDedicatedEszettKey`, `testEszettIsReachableByLongPressOnS` |
| German `defaultLayout` is `.qwertz`, test updated and no longer deferring to #151 | ✅ | `GermanLanguageTests.test_germanProfile_displayFields`, `SupportedLanguageActivationTests.testActivateGermanWritesQwertz` |
| Settings picker lists all three, driven by the enum | ✅ | `SettingsView.swift` `ForEach(LayoutType.allCases)`; **not** verified on screen (see below) |
| `swiftlint lint --strict` clean, `swift test` green | ✅ | `Found 0 violations, 0 serious in 167 files` · `Executed 713 tests, with 1 test skipped and 0 failures` |
| PR body carries a device check list | ✅ | Above |

**The partial one.** `KeyboardLayouts.current(needsGlobe:)` lives in DictusKeyboard, which has no test target — the Xcode project has three native targets, all app or app-extension, and `swift test` builds the DictusCore package on macOS where `KeyboardLayouts.swift` (UIKit + vendored types) cannot compile. So that criterion is covered in three pieces instead of one test: `LayoutType.active == .qwertz` from the stored raw value is tested; the `current(needsGlobe:)` branch is a compiler-enforced exhaustive switch (adding the case forced the branch to exist); and `needsGlobe` only reaches the *shared* `bottomRow(lang:needsGlobe:)`, the same code path all three layouts use. What is genuinely unverified is that the definition renders — step 3 of the manual list, and step 3 on an iPad for the globe variant.

## Verification run

```
xcodebuild -resolvePackageDependencies …                → exit 0
./scripts/patch-fluidaudio-swift5.sh build/DerivedData  → Patched: …/FluidAudio/Package.swift
xcodebuild build … -destination 'platform=iOS Simulator,id=1720B34A-…'  → ** BUILD SUCCEEDED **
cd DictusCore && swift test   → Executed 713 tests, 1 skipped, 0 failures
swiftlint lint --strict       → Found 0 violations, 0 serious in 167 files
```

Installed and launched on the simulator: the app runs and stays alive (onboarding renders). That is a smoke test and nothing more — no keyboard, and `selectedTab` is `@State`, so Settings is not reachable without a tap either. `simctl` has no touch injection.

refs #151


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added German QWERTZ keyboard layout support, including correct key ordering, umlauts, and ß long-press input.
  * German now defaults to QWERTZ when newly activated.
  * Layout selection now includes all supported keyboard layouts and displays readable names.
  * QWERTZ is supported in the main keyboard and emoji search keyboard.

* **Bug Fixes**
  * Preserved previously selected layouts when switching languages without reactivation.
  * Improved layout fallback handling for missing or unknown saved values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->