### PR TITLE
Offer ẞ instead of SS on shift + long-press S (refs #322)

### DIFF
--- a/DictusCore/Sources/DictusCore/KeyCaseTransform.swift
+++ b/DictusCore/Sources/DictusCore/KeyCaseTransform.swift
@@ -1,0 +1,56 @@
+// DictusCore/Sources/DictusCore/KeyCaseTransform.swift
+// Case transformation for keyboard keys, where Unicode's one-to-many uppercase
+// mappings would otherwise turn one key into two characters.
+import Foundation
+
+/// Uppercasing for keyboard keys and long-press candidates.
+///
+/// WHY not `String.uppercased()` at the call sites:
+/// `uppercased()` implements Unicode's *full* case mapping, in which a few characters
+/// uppercase to more than one character — `"\u{00DF}".uppercased() == "SS"`. A key is
+/// one character by construction: the long-press popup renders the string as a single
+/// key and the bridge inserts it verbatim, so `SS` drew one key that typed two letters
+/// (#322). This namespace keeps the transformation one character in, one character out.
+///
+/// The mapping is a property of the character, not of the keyboard showing it, so it
+/// stays layout- and language-agnostic: no caller passes a language in.
+public enum KeyCaseTransform {
+
+    /// Single-character uppercase forms for the characters whose Unicode uppercase
+    /// mapping is one-to-many.
+    ///
+    /// ß → ẞ (U+1E9E LATIN CAPITAL LETTER SHARP S): Unicode has carried the capital
+    /// sharp s since 5.1 and German orthography has permitted it since the 2017 spelling
+    /// reform, and it is what iOS itself offers on shift plus long-press `s`. Unicode
+    /// still maps ß to `SS` for compatibility with the historical rule, which is why the
+    /// intended capital has to be spelled out here.
+    private static let singleCharacterUppercase: [Character: Character] = [
+        "\u{00DF}": "\u{1E9E}"   // ß → ẞ
+    ]
+
+    /// The uppercase form of a key, never longer than the key it came from.
+    ///
+    /// One-to-one mappings (é → É, ä → Ä, ñ → Ñ …) go straight through `uppercased()`,
+    /// which is what every accent candidate but ß uses. A character whose uppercase would
+    /// be longer takes its declared single-character capital, and is otherwise left as it
+    /// is: a lowercase glyph on a shifted page is a cosmetic surprise, whereas two
+    /// characters out of one key is wrong text.
+    ///
+    /// WHY counting `Character`s rather than unicode scalars: a grapheme cluster is what
+    /// renders as one key and inserts as one glyph. `ǰ` uppercases to `J` plus a combining
+    /// caron — two scalars, one grapheme — and passing that through is correct.
+    public static func uppercased(_ key: String) -> String {
+        var result = ""
+        for character in key {
+            let uppercasedCharacter = character.uppercased()
+            if uppercasedCharacter.count == 1 {
+                result += uppercasedCharacter
+            } else if let single = singleCharacterUppercase[character] {
+                result.append(single)
+            } else {
+                result.append(character)
+            }
+        }
+        return result
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/KeyCaseTransformTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/KeyCaseTransformTests.swift
@@ -1,0 +1,101 @@
+// DictusCore/Tests/DictusCoreTests/KeyCaseTransformTests.swift
+import XCTest
+@testable import DictusCore
+
+/// The transformation the shifted/capslock long-press popup applies to its candidates
+/// (`KeyboardView.longpressKeys(for:)`). The keyboard target has no test bundle, which is
+/// why the transformation lives in DictusCore — these tests measure what the popup renders
+/// and, since the selected candidate is inserted verbatim, what gets typed.
+final class KeyCaseTransformTests: XCTestCase {
+
+    // MARK: - The ß case (#322)
+
+    /// The bug: `"ß".uppercased()` is `"SS"`, so the popup drew one key that typed two letters.
+    func testSharpSUppercasesToCapitalSharpS() {
+        XCTAssertEqual(KeyCaseTransform.uppercased("\u{00DF}"), "\u{1E9E}")
+        XCTAssertNotEqual(KeyCaseTransform.uppercased("\u{00DF}"), "SS")
+    }
+
+    /// One key in, one key out — what the popup renders and what the bridge inserts.
+    func testSharpSUppercaseIsASingleCharacter() {
+        XCTAssertEqual(KeyCaseTransform.uppercased("\u{00DF}").count, 1)
+    }
+
+    /// The capital sharp s is already uppercase and must survive the transformation.
+    func testCapitalSharpSIsUnchanged() {
+        XCTAssertEqual(KeyCaseTransform.uppercased("\u{1E9E}"), "\u{1E9E}")
+    }
+
+    /// The unshifted path is untouched: the popup shows the mapping as declared.
+    /// `AccentedCharacterTests` and `QWERTZLayoutTests` pin the mapping itself; this
+    /// restates it here so the unshifted half of #322 is visible in one place.
+    func testUnshiftedSharpSComesStraightFromTheMapping() {
+        XCTAssertEqual(AccentedCharacters.accents(for: "s"), ["\u{00DF}"])
+    }
+
+    // MARK: - The general rule
+
+    /// Every long-press candidate the keyboard can show, whatever the layout or language:
+    /// its uppercase form is exactly one character. This is the invariant the popup depends
+    /// on, and the one `uppercased()` alone breaks for ß.
+    func testEveryAccentCandidateUppercasesToASingleCharacter() {
+        for (baseKey, candidates) in AccentedCharacters.mappings {
+            for candidate in candidates {
+                let uppercased = KeyCaseTransform.uppercased(candidate)
+                XCTAssertEqual(uppercased.count, 1,
+                               "long-press \(baseKey): '\(candidate)' uppercased to '\(uppercased)'")
+            }
+        }
+    }
+
+    /// A one-to-many uppercase with no declared single-character capital keeps its character
+    /// rather than growing: `ŉ` (U+0149) would otherwise become `ʼN`, two characters.
+    /// Cosmetically wrong beats textually wrong.
+    func testOneToManyWithoutASingleCharacterCapitalIsLeftAlone() {
+        XCTAssertEqual(KeyCaseTransform.uppercased("\u{0149}"), "\u{0149}")
+    }
+
+    // MARK: - Unchanged for every other candidate
+
+    /// French accents, the reason the transformation exists in the first place.
+    func testFrenchAccentsUppercaseAsBefore() {
+        XCTAssertEqual(KeyCaseTransform.uppercased("\u{00E9}"), "\u{00C9}")   // é → É
+        XCTAssertEqual(KeyCaseTransform.uppercased("\u{00E8}"), "\u{00C8}")   // è → È
+        XCTAssertEqual(KeyCaseTransform.uppercased("\u{00EA}"), "\u{00CA}")   // ê → Ê
+        XCTAssertEqual(KeyCaseTransform.uppercased("\u{00EB}"), "\u{00CB}")   // ë → Ë
+        XCTAssertEqual(KeyCaseTransform.uppercased("\u{00E0}"), "\u{00C0}")   // à → À
+        XCTAssertEqual(KeyCaseTransform.uppercased("\u{00F4}"), "\u{00D4}")   // ô → Ô
+        XCTAssertEqual(KeyCaseTransform.uppercased("\u{00E7}"), "\u{00C7}")   // ç → Ç
+    }
+
+    /// Spanish acute and n-tilde (#82/#83), and the German umlauts (#109/#151).
+    func testSpanishAndGermanCandidatesUppercaseAsBefore() {
+        XCTAssertEqual(KeyCaseTransform.uppercased("\u{00F1}"), "\u{00D1}")   // ñ → Ñ
+        XCTAssertEqual(KeyCaseTransform.uppercased("\u{00E1}"), "\u{00C1}")   // á → Á
+        XCTAssertEqual(KeyCaseTransform.uppercased("\u{00E4}"), "\u{00C4}")   // ä → Ä
+        XCTAssertEqual(KeyCaseTransform.uppercased("\u{00F6}"), "\u{00D6}")   // ö → Ö
+        XCTAssertEqual(KeyCaseTransform.uppercased("\u{00FC}"), "\u{00DC}")   // ü → Ü
+    }
+
+    /// Anything with a one-to-one mapping still matches plain `uppercased()`, so no accent
+    /// candidate changed behaviour except ß.
+    func testMatchesPlainUppercasedForEveryOneToOneCandidate() {
+        for candidates in AccentedCharacters.mappings.values {
+            for candidate in candidates where candidate.uppercased().count == 1 {
+                XCTAssertEqual(KeyCaseTransform.uppercased(candidate), candidate.uppercased())
+            }
+        }
+    }
+
+    /// Characters with no case (the AZERTY adaptive key's apostrophe, digits, the emoji key
+    /// glyph) pass through untouched — the popup transform runs over whatever the page holds.
+    func testCaselessCharactersAreUnchanged() {
+        XCTAssertEqual(KeyCaseTransform.uppercased("'"), "'")
+        XCTAssertEqual(KeyCaseTransform.uppercased("1"), "1")
+        XCTAssertEqual(KeyCaseTransform.uppercased("\u{1F600}"), "\u{1F600}")
+    }
+
+    func testEmptyStringIsUnchanged() {
+        XCTAssertEqual(KeyCaseTransform.uppercased(""), "")
+    }
+}

--- a/DictusKeyboard/Vendored/Views/KeyboardView.swift
+++ b/DictusKeyboard/Vendored/Views/KeyboardView.swift
@@ -857,10 +857,14 @@ final internal class GiellaKeyboardView: UIView,
 
         // Apply case transformation for shifted/capslock pages
         // so that long-pressing "E" shows uppercase accents (E, E, E, E)
+        // KeyCaseTransform rather than uppercased(): Unicode's full case mapping turns
+        // ß into the two characters "SS", which this popup drew as one key and inserted
+        // as two letters (#322). The candidate is inserted verbatim by the bridge, so the
+        // transformation has to be one character in, one character out.
         if page == .shifted || page == .capslock {
             keys = keys.map { keyDef in
                 if case let .input(char, alt) = keyDef.type {
-                    return KeyDefinition(type: .input(key: char.uppercased(), alternate: alt))
+                    return KeyDefinition(type: .input(key: KeyCaseTransform.uppercased(char), alternate: alt))
                 }
                 return keyDef
             }


### PR DESCRIPTION
`refs #322`

## What this was for

With Shift active, long-pressing `S` on the German keyboard offered **`SS`** instead of **`ẞ`**, so tapping it typed two characters where the user expected one. `"ß".uppercased()` returns `"SS"` in Swift — Unicode's full case mapping still encodes the historical German rule — and the long-press popup runs every candidate through `uppercased()` on shifted/caps-locked pages so that long-pressing `E` offers `É È Ê Ë`. iOS itself offers `ẞ` (U+1E9E) in exactly this position.

It also read as a stale-data bug before it read as a wrong one: shift dropping after a few characters made the popup "fix itself".

## To test by hand

The keyboard extension's long-press popup cannot be exercised in a simulator, so all of this is device-only.

1. Build and install on the device, open any text field with the Dictus keyboard, and switch the language to **German** (hamburger panel → German).
2. With Shift **off**, long-press `s`. → The popup offers `s` and `ß`. Nothing changed here.
3. Release on `ß`. → One character `ß` is inserted.
4. Tap **Shift** once (the arrow fills), then long-press `S`. → The popup offers `S` and a single **`ẞ`** — one key, one glyph. It must not read `SS`.
5. Release on `ẞ`. → **One** character `ẞ` is inserted. Check with backspace: a single backspace clears it.
6. Double-tap Shift to engage caps lock, long-press `S` again. → Same single `ẞ`; selecting it inserts one character and caps lock stays on.
7. Switch to **French** (AZERTY), tap Shift, long-press `E`. → `É È Ê Ë` as before. Same check on `A` (`À Â Ä Á`) and `C` (`Ç`).
8. Switch to **Spanish**, tap Shift, long-press `N`. → `Ñ`, unchanged.
9. Confirm the `ẞ` glyph renders as a capital sharp s and not as a `.notdef` box on the device's iOS version.

## What changed

- **New** `DictusCore/Sources/DictusCore/KeyCaseTransform.swift` — `KeyCaseTransform.uppercased(_:)`. One character in, one character out: a candidate whose `uppercased()` is one character goes straight through (every accent but ß), ß takes its declared capital `ẞ` (U+1E9E), and any other one-to-many mapping keeps its character rather than growing to two. No language parameter — the mapping is a property of the character, so the transformation stays layout- and language-agnostic, as the issue requires.
- **New** `DictusCore/Tests/DictusCoreTests/KeyCaseTransformTests.swift` — 11 tests.
- **Edited** `DictusKeyboard/Vendored/Views/KeyboardView.swift` (`longpressKeys(for:)`) — the shifted/capslock branch calls `KeyCaseTransform.uppercased(char)` instead of `char.uppercased()`, with a comment naming #322.

Why the helper sits in DictusCore and not in the vendored view: the keyboard target has no test bundle (`swift test` builds the DictusCore package alone), which is the same reason `QWERTZLayout` lives there. It is a new file rather than an addition to `AccentedCharacters.swift` so it does not collide with #272.

### Why one fix reaches both the popup and the inserted text

`longpressKeys(for:)` → `LongPressOverlayController(longpressValues:)` → `LongpressKeyCell` (the `page` argument picks the *font* only, it never rewrites the string) → `longpress(didSelectKey:)` → `DictusKeyboardBridge.didTriggerKey` → `handleInputKey` → `insertText(character)` verbatim. The rendered label and the inserted text are the same string.

`KeyboardView.swift:863` was the only site in the repo that case-transforms long-press candidates (`grep -rni "uppercas|capitalized"` over `DictusKeyboard`, `DictusCore/Sources`, `DictusApp`). `FrenchAdaptiveKey.label` also calls `uppercased()`, but only over é/à/ù/î/ô — all one-to-one — and that file belongs to #272, so it is untouched.

## Acceptance criteria

| Criterion | Status | Evidence |
|---|---|---|
| Shift + long-press `S` offers a single `ẞ` and inserts a single `ẞ` | Transformation verified by test; on-screen popup and insertion **device-only** | `testSharpSUppercasesToCapitalSharpS`, `testSharpSUppercaseIsASingleCharacter` pass. The consumer chain above shows label == inserted string, but no automated test drives the popup — the keyboard target has no test bundle and a simulator cannot activate a keyboard extension. Steps 4-6 above. |
| Unshifted long-press `S` still offers `ß` | Verified | Code path untouched (the transform only runs when `page == .shifted \|\| .capslock`). `testUnshiftedSharpSComesStraightFromTheMapping` passes, and the pre-existing `AccentedCharacterTests` / `QWERTZLayoutTests` assertions on `mappings["s"] == ["ß"]` still pass. Step 2-3 above. |
| Uppercase candidates for French and Spanish accents unchanged | Verified by test | `testFrenchAccentsUppercaseAsBefore`, `testSpanishAndGermanCandidatesUppercaseAsBefore`, and `testMatchesPlainUppercasedForEveryOneToOneCandidate` — which enumerates every entry of `AccentedCharacters.mappings` and asserts the new transform equals plain `uppercased()` for each one-to-one candidate. Steps 7-8 for the eye. |
| A test covers the transformation directly, ß as the case in point | Verified by test | `testEveryAccentCandidateUppercasesToASingleCharacter` walks the whole mapping and asserts a one-character result; `testOneToManyWithoutASingleCharacterCapitalIsLeftAlone` pins the fallback with `ŉ` (U+0149, whose uppercase is `ʼN`). |
| `swiftlint lint --strict` clean | Verified | `Found 0 violations, 0 serious in 169 files.` (`DictusKeyboard/Vendored` is excluded from lint by `.swiftlint.yml`; `DictusCore/Tests` is not in `included`.) |
| `cd DictusCore && swift test` green | Verified | `Executed 745 tests, with 1 test skipped and 0 failures (0 unexpected)`. |
| PR body carries the device steps | Done | Above. |

Build: `xcodebuild build -scheme DictusApp -destination 'generic/platform=iOS Simulator'` → `** BUILD SUCCEEDED **` (builds all three targets).

## Notes

- Nothing in the issue turned out to be wrong or incomplete.
- Out of scope and untouched, as the issue states: a dedicated `ß` key, the `ß`↔`ss` autocorrect scoring (`German.swift` `collapseRules` already carries `ss → ß`), and every other long-press candidate list.
- One judgement call worth naming: when a character's uppercase is longer than one character and no single-character capital is declared, the transform returns the character **unchanged** rather than the multi-character form. A lowercase glyph on a shifted page is a cosmetic surprise; two characters out of one key is wrong text. Only ß is reachable from today's candidate lists; the rule exists so the next such character cannot reintroduce this bug.
- `ẞ` renders correctly in the fonts iOS ships (it is what Apple's own German keyboard offers here), but that is asserted, not measured — hence step 9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McjofNoZAc33EtyW8Gvoaw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent uppercase handling for keyboard keys, including accented characters and special cases such as sharp s.

* **Bug Fixes**
  * Long-press accent keys on shifted and caps-lock layouts now remain one character per key.
  * Prevented uppercase transformations from unexpectedly producing multiple characters.

* **Tests**
  * Added coverage for accented, caseless, empty, and one-to-many uppercase mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->