### PR TITLE
German autocorrect can see ä, ö and ü: accent relation and proximity geometry move to DictusCore

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,5 +66,10 @@ The physical key arrangement: `LayoutType.azerty` (French), `LayoutType.qwerty` 
 
 QWERTZ carries dedicated ä/ö/ü keys, which makes its first two rows 11 units wide against 10 for every other row in every layout. The renderer normalizes each row against its own unit total, so those rows draw narrower keys. Row data lives in `DictusCore/KeyboardLayoutData.swift`; `DictusKeyboard/KeyboardLayouts.swift` builds the keys from it.
 
+### Substitution-cost tables (`KeyboardProximity`, `AccentRelation`)
+The two tables the C++ trie scorer consults when it substitutes one character for another while walking correction candidates: **keyboard proximity** (how far apart two keys are on the active layout) and the **accent relation** (which accented letters are variants of which base letter, and at what cost). Both are declared in `DictusCore/Sources/DictusCore/TextCorrection/`, computed once per dictionary load, and installed into the scorer across the ObjC bridge; the scorer holds the lookup and the traversal, no rules of its own. **Distinct from `LanguageProfile.accentMap`**, which drives the Swift-side generative accent expansion — the accent relation is a *cost*, consulted during edit-distance scoring, not a list of variants to try. Declared in DictusCore because the keyboard target has no test bundle (#321, same reasoning as the QWERTZ rows in #151).
+
+`ß` is deliberately outside the accent relation: its relation to `ss` changes length, which one-to-one substitution cannot express. That relation lives in `LanguageProfile.collapseRules` instead.
+
 ### Long-press accents (`AccentedCharacters.mappings`)
 Pop-up accent variants shown when a key is long-pressed. Currently merged across languages (French + Spanish ñ + acute variants), keyed by base letter. To be migrated into `LanguageProfile.longPressAccents` so each language declares its own popups.

--- a/DictusCore/Sources/DictusCore/TextCorrection/AccentRelation.swift
+++ b/DictusCore/Sources/DictusCore/TextCorrection/AccentRelation.swift
@@ -1,0 +1,154 @@
+// DictusCore/Sources/DictusCore/TextCorrection/AccentRelation.swift
+// The accent-cost table the keyboard's C++ scorer reads: which accented letters
+// relate to which base letter, and what substituting one for the other costs.
+import Foundation
+
+/// Which accented characters count as a near-miss for which base letter, and how cheap
+/// that substitution is when the trie scorer walks candidates.
+///
+/// WHY this lives in DictusCore and not in the C++ scorer that consumes it:
+/// the table is data, and the keyboard target has no test bundle — `swift test` builds
+/// this package alone. Declared here it is pinned by tests; consumed from here the C++
+/// has one source of truth instead of a copy (the same reasoning that put the QWERTZ
+/// rows in `KeyboardLayoutData`, #151). The cost table is built once per dictionary
+/// load and handed across the bridge, so nothing about this moves the scorer's hot loop.
+///
+/// WHY it matters: without an entry, two spellings of the same word are *unrelated*
+/// characters to the scorer. German shipped that way — `über` and `uber` scored as far
+/// apart as `über` and `xber` (#321).
+public enum AccentRelation {
+
+    /// Cost of substituting a base letter for one of its accented forms, or the reverse
+    /// (`e` ↔ `é`, `u` ↔ `ü`). Cheap: the two spellings are the same word to a typist.
+    public static let baseToAccentCost: Float = 0.15
+
+    /// Cost of substituting one accent for another of the same base (`é` ↔ `è`).
+    /// Slightly dearer than base ↔ accent: the user typed *an* accent, just not that one.
+    public static let accentToAccentCost: Float = 0.2
+
+    /// Accented character → the base letter it is a variant of.
+    ///
+    /// French and Spanish entries are frozen as they shipped: changing one silently moves
+    /// every correction in those languages. The three umlauts were added for German (#321).
+    ///
+    /// WHY `ß` (U+00DF) is deliberately absent — the decision this table is asked to
+    /// record: `ß` is not an accent of `s`, it is a ligature whose written equivalent is
+    /// `ss`. That is a one-to-two relation and this table expresses one-to-one
+    /// substitution only. Mapping `ß` → `s` here would make the relation *look* handled
+    /// while `heisst` → `heißt` still needs a deletion the accent path cannot supply, and
+    /// it would make `s` → `ß` cheap everywhere in a language whose most frequent
+    /// consonant is `s` — a silent over-correction risk for a case it would not fix.
+    /// The `ss` → `ß` relation is modelled where a length change *can* be expressed:
+    /// `germanProfile.collapseRules` (see `expandAccents`).
+    public static let baseLetters: [Character: Character] = [
+        // French / Spanish — frozen.
+        "\u{00E9}": "e",        // é
+        "\u{00E8}": "e",        // è
+        "\u{00EA}": "e",        // ê
+        "\u{00EB}": "e",        // ë
+        "\u{00E0}": "a",        // à
+        "\u{00E2}": "a",        // â
+        "\u{00F9}": "u",        // ù
+        "\u{00FB}": "u",        // û
+        "\u{00F4}": "o",        // ô
+        "\u{00EE}": "i",        // î
+        "\u{00EF}": "i",        // ï
+        "\u{00E7}": "c",        // ç
+        // German umlauts (#321).
+        "\u{00E4}": "a",        // ä
+        "\u{00F6}": "o",        // ö
+        "\u{00FC}": "u"         // ü
+    ]
+
+    /// The base letter `character` is an accented form of, or `nil` if it is not one.
+    public static func baseLetter(of character: Character) -> Character? {
+        baseLetters[character]
+    }
+
+    /// Substitution cost between two characters when they are accent-related,
+    /// or `nil` when they are not — the caller then falls back to keyboard proximity.
+    ///
+    /// The three cases, in the order the scorer applies them:
+    ///   1. base ↔ one of its accents (`u` ↔ `ü`) → `baseToAccentCost`
+    ///   2. two accents of the same base (`é` ↔ `è`) → `accentToAccentCost`
+    ///   3. anything else → `nil`
+    public static func cost(from: Character, to: Character) -> Float? {
+        if from == to { return 0 }
+
+        let baseFrom = baseLetter(of: from)
+        let baseTo = baseLetter(of: to)
+
+        // Base letter to one of its accent variants, either direction.
+        if baseFrom == nil, isBaseLetter(from), baseTo == from { return baseToAccentCost }
+        if baseTo == nil, isBaseLetter(to), baseFrom == to { return baseToAccentCost }
+
+        // Two accents sharing a base.
+        if let baseFrom, let baseTo, baseFrom == baseTo { return accentToAccentCost }
+
+        return nil
+    }
+
+    /// Every accent-related ordered pair, flattened for the C++ scorer.
+    ///
+    /// WHY enumerate pairs rather than ship the base map and let C++ re-derive them:
+    /// re-deriving means the three-case precedence above exists twice, in two languages,
+    /// and drifts. Enumerated here, the C++ side is a pure lookup with no rules of its own.
+    /// The set is ~60 pairs — built once per dictionary load.
+    public static var costPairs: AccentCostPairs {
+        // Every character the table can relate: the accented forms and their bases.
+        let related = Set(baseLetters.keys).union(baseLetters.values)
+        let ordered = related.sorted { (scalarValue($0) ?? 0) < (scalarValue($1) ?? 0) }
+
+        var from: [UInt16] = []
+        var to: [UInt16] = []
+        var costs: [Float] = []
+        for a in ordered {
+            for b in ordered where a != b {
+                guard let cost = cost(from: a, to: b),
+                      let scalarA = scalarValue(a),
+                      let scalarB = scalarValue(b) else { continue }
+                from.append(scalarA)
+                to.append(scalarB)
+                costs.append(cost)
+            }
+        }
+        return AccentCostPairs(from: from, to: to, costs: costs)
+    }
+
+    /// True for the unaccented ASCII lowercase letters a base letter can be.
+    private static func isBaseLetter(_ character: Character) -> Bool {
+        character.isASCII && character.isLowercase
+    }
+
+    /// The single UTF-16 code unit of `character`, or `nil` if it is not one code unit.
+    /// Every character in this table is in the Latin-1 supplement, so `nil` never happens
+    /// in practice — but returning it keeps the packing free of force unwraps.
+    static func scalarValue(_ character: Character) -> UInt16? {
+        let scalars = character.unicodeScalars
+        guard scalars.count == 1, let scalar = scalars.first, scalar.value <= 0xFFFF else {
+            return nil
+        }
+        return UInt16(scalar.value)
+    }
+}
+
+/// Accent-related character pairs and their substitution costs, as three parallel arrays.
+///
+/// WHY parallel arrays of plain scalars: they cross into C++ as raw byte buffers, which
+/// keeps the bridge free of per-entry object boxing and of any struct-layout agreement
+/// between the two languages.
+public struct AccentCostPairs: Sendable, Equatable {
+    /// Substituted-from characters, as UTF-16 code units.
+    public let from: [UInt16]
+    /// Substituted-to characters, as UTF-16 code units.
+    public let to: [UInt16]
+    /// Cost of each pair, in the same order.
+    public let costs: [Float]
+
+    /// Number of pairs. The three arrays always agree on it.
+    public var count: Int { costs.count }
+
+    public var fromData: Data { from.withUnsafeBufferPointer { Data(buffer: $0) } }
+    public var toData: Data { to.withUnsafeBufferPointer { Data(buffer: $0) } }
+    public var costsData: Data { costs.withUnsafeBufferPointer { Data(buffer: $0) } }
+}

--- a/DictusCore/Sources/DictusCore/TextCorrection/AccentRelation.swift
+++ b/DictusCore/Sources/DictusCore/TextCorrection/AccentRelation.swift
@@ -97,7 +97,9 @@ public enum AccentRelation {
     public static var costPairs: AccentCostPairs {
         // Every character the table can relate: the accented forms and their bases.
         let related = Set(baseLetters.keys).union(baseLetters.values)
-        let ordered = related.sorted { (scalarValue($0) ?? 0) < (scalarValue($1) ?? 0) }
+        let ordered = related.sorted {
+            ($0.singleUTF16CodeUnit ?? 0) < ($1.singleUTF16CodeUnit ?? 0)
+        }
 
         var from: [UInt16] = []
         var to: [UInt16] = []
@@ -105,10 +107,10 @@ public enum AccentRelation {
         for a in ordered {
             for b in ordered where a != b {
                 guard let cost = cost(from: a, to: b),
-                      let scalarA = scalarValue(a),
-                      let scalarB = scalarValue(b) else { continue }
-                from.append(scalarA)
-                to.append(scalarB)
+                      let codeUnitA = a.singleUTF16CodeUnit,
+                      let codeUnitB = b.singleUTF16CodeUnit else { continue }
+                from.append(codeUnitA)
+                to.append(codeUnitB)
                 costs.append(cost)
             }
         }
@@ -119,12 +121,19 @@ public enum AccentRelation {
     private static func isBaseLetter(_ character: Character) -> Bool {
         character.isASCII && character.isLowercase
     }
+}
 
-    /// The single UTF-16 code unit of `character`, or `nil` if it is not one code unit.
-    /// Every character in this table is in the Latin-1 supplement, so `nil` never happens
-    /// in practice — but returning it keeps the packing free of force unwraps.
-    static func scalarValue(_ character: Character) -> UInt16? {
-        let scalars = character.unicodeScalars
+extension Character {
+    /// The single UTF-16 code unit of this character, or `nil` if it is not exactly one.
+    ///
+    /// Shared by both substitution-cost tables (`AccentRelation`, `KeyboardProximity`):
+    /// the scorer indexes characters as UTF-16 code units, so the buffers handed to it
+    /// must refuse anything wider. Every character either table holds is a Latin letter
+    /// or a Latin-1 supplement accent, so `nil` never occurs in practice — returning it
+    /// rather than force-unwrapping is what keeps that true if a layout ever adds a key
+    /// outside the Basic Multilingual Plane.
+    var singleUTF16CodeUnit: UInt16? {
+        let scalars = unicodeScalars
         guard scalars.count == 1, let scalar = scalars.first, scalar.value <= 0xFFFF else {
             return nil
         }

--- a/DictusCore/Sources/DictusCore/TextCorrection/KeyboardProximity.swift
+++ b/DictusCore/Sources/DictusCore/TextCorrection/KeyboardProximity.swift
@@ -1,0 +1,167 @@
+// DictusCore/Sources/DictusCore/TextCorrection/KeyboardProximity.swift
+// Key geometry per layout, and the pairwise proximity costs the keyboard's C++ scorer
+// reads to score a typo as a near miss rather than as an unrelated character.
+import Foundation
+
+/// Where each key sits on a layout, and how much it costs the trie scorer to substitute
+/// one key for another.
+///
+/// WHY this lives in DictusCore and not in the C++ that consumes it:
+/// the geometry is data and the formula runs **once per dictionary load**, not per
+/// keystroke — so moving both here costs nothing at runtime and buys the only executable
+/// coverage this repo has (`swift test` builds this package alone; the keyboard target has
+/// no test bundle). The scorer's hot loop stays in C++ and reads the finished table.
+///
+/// WHY it had to move for German (#321): the C++ stored `float[26][26]` indexed by
+/// `c - 'a'`. There was no slot for ü, ö or ä — QWERTZ's three extra keys were not
+/// mis-scored, they were unrepresentable, and QWERTZ borrowed the QWERTY table where
+/// y and z sit in each other's places.
+public enum KeyboardProximity {
+
+    /// Divisor turning a key-unit euclidean distance into a cost in [0, 1]: keys 2.5 key
+    /// widths apart or more score 1.0, the same as unrelated. Frozen — it scales every
+    /// proximity cost in every layout.
+    public static let distanceNormalizer: Double = 2.5
+
+    /// A key and its centre, in key-width units. `x` counts from the left edge of the row
+    /// block, `y` is the row index (0 = top letter row).
+    public struct KeyPosition: Sendable, Equatable {
+        public let character: Character
+        public let x: Double
+        public let y: Double
+    }
+
+    /// The key centres of `layout`, in row order then left-to-right.
+    public static func keyPositions(for layout: LayoutType) -> [KeyPosition] {
+        rows(for: layout).enumerated().flatMap { rowIndex, row -> [KeyPosition] in
+            let width = keyWidth(forKeyCount: row.keys.count)
+            return row.keys.enumerated().map { keyIndex, character in
+                // Centre of the key: its left edge plus half a key, shifted so that a
+                // plain 10-key row places its keys at x = 0…9 (the coordinates the
+                // AZERTY and QWERTY tables have always used).
+                KeyPosition(
+                    character: character,
+                    x: row.xOffset + (Double(keyIndex) + 0.5) * width - 0.5,
+                    y: Double(rowIndex)
+                )
+            }
+        }
+    }
+
+    /// Pairwise proximity costs for `layout`, ready to install in the scorer.
+    public static func costTable(for layout: LayoutType) -> ProximityCostTable {
+        let positions = keyPositions(for: layout)
+        let characters = positions.compactMap { $0.character.singleUTF16CodeUnit }
+        // compactMap above would silently shorten the table if a key were not one code
+        // unit; the geometry below indexes positions, so bail to a neutral table instead.
+        guard characters.count == positions.count else {
+            return ProximityCostTable(characters: [], distances: [])
+        }
+
+        var distances = [Float](repeating: 1.0, count: positions.count * positions.count)
+        for (i, from) in positions.enumerated() {
+            for (j, to) in positions.enumerated() {
+                distances[i * positions.count + j] = i == j ? 0 : cost(from: from, to: to)
+            }
+        }
+        return ProximityCostTable(characters: characters, distances: distances)
+    }
+
+    /// Cost between two key centres: euclidean distance in key widths, normalized and
+    /// clamped to 1.0.
+    static func cost(from: KeyPosition, to: KeyPosition) -> Float {
+        let dx = from.x - to.x
+        let dy = from.y - to.y
+        return Float(min(1.0, (dx * dx + dy * dy).squareRoot() / distanceNormalizer))
+    }
+
+    // MARK: - Layout geometry
+
+    /// One letter row as the proximity model sees it. Modifier and bottom-row keys are
+    /// absent: the scorer only ever asks about letters.
+    private struct KeyRow {
+        let keys: [Character]
+        /// Units the row's first key edge sits right of the row block's left edge.
+        let xOffset: Double
+    }
+
+    /// Width of one key in a row of `count` keys, in the shared 10-unit row space.
+    ///
+    /// Rows of 10 keys or fewer keep unit-wide keys, which is what the AZERTY and QWERTY
+    /// coordinates have always assumed. QWERTZ's 11-key rows render in the same width as
+    /// every other row (`QWERTZLayout.rowUnitWidths` — the renderer normalizes each row
+    /// against its own unit total), so their keys are 10/11 of a unit and every key on
+    /// those rows sits slightly left of where its QWERTY counterpart would: the geometry
+    /// shift #321 asks to model.
+    private static func keyWidth(forKeyCount count: Int) -> Double {
+        10.0 / Double(max(10, count))
+    }
+
+    private static func rows(for layout: LayoutType) -> [KeyRow] {
+        switch layout {
+        case .azerty:
+            // AZERTY row data lives in the keyboard target (`KeyboardLayouts.azerty`), not
+            // in DictusCore, so unlike the other two this sequence is declared here.
+            // Moving it is a layout refactor and out of scope for #321.
+            return [
+                KeyRow(keys: Array("azertyuiop"), xOffset: 0),
+                KeyRow(keys: Array("qsdfghjklm"), xOffset: 0.25),
+                KeyRow(keys: Array("wxcvbn"), xOffset: 0.75)
+            ]
+        case .qwerty:
+            // Sequence read from the layout data the keyboard renders, so the proximity
+            // model cannot drift from the keys that actually exist.
+            let letterRows = QWERTYLayout.lettersRows.prefix(3).map(letters)
+            let offsets: [Double] = [0, 0.25, 0.75]
+            return zip(letterRows, offsets).map { KeyRow(keys: $0, xOffset: $1) }
+        case .qwertz:
+            // Rows 0 and 1 carry 11 keys and start flush with the row block: ü closes the
+            // top row, ö and ä the home row. Row 2 keeps the same 0.75 offset the other
+            // layouts use, so the three stay comparable — no layout models the shift and
+            // delete keys flanking that row.
+            let letterRows = QWERTZLayout.lowercasedLettersRows.map(letters)
+            let offsets: [Double] = [0, 0, 0.75]
+            return zip(letterRows, offsets).map { KeyRow(keys: $0, xOffset: $1) }
+        }
+    }
+
+    /// The single-letter key labels of a layout row, lowercased. Drops anything that is
+    /// not one letter (`"globe"`, `"123"`), which the scorer never asks about.
+    private static func letters(_ row: [String]) -> [Character] {
+        row.compactMap { label in
+            let lowered = label.lowercased()
+            guard lowered.count == 1, let character = lowered.first, character.isLetter else {
+                return nil
+            }
+            return character
+        }
+    }
+}
+
+/// Pairwise proximity costs for one layout, as the flat buffers the scorer installs.
+///
+/// WHY a finished table rather than the key positions: the C++ then holds no formula of
+/// its own, so the numbers a test pins here are exactly the numbers the scorer scores with.
+public struct ProximityCostTable: Sendable, Equatable {
+    /// The layout's keys, as UTF-16 code units, in table row/column order.
+    public let characters: [UInt16]
+    /// `characters.count * characters.count` costs, row-major.
+    public let distances: [Float]
+
+    /// Number of keys the table covers.
+    public var count: Int { characters.count }
+
+    /// Cost of substituting `from` for `to` on this layout.
+    /// Returns 1.0 — "unrelated" — when either key is absent from the layout, which is
+    /// what a long-press-only character (ü on QWERTY) correctly gets: it has no position.
+    public func cost(from: Character, to: Character) -> Float {
+        guard let fromUnit = from.singleUTF16CodeUnit,
+              let toUnit = to.singleUTF16CodeUnit,
+              let row = characters.firstIndex(of: fromUnit),
+              let column = characters.firstIndex(of: toUnit) else { return 1.0 }
+        return distances[row * count + column]
+    }
+
+    public var charactersData: Data { characters.withUnsafeBufferPointer { Data(buffer: $0) } }
+    public var distancesData: Data { distances.withUnsafeBufferPointer { Data(buffer: $0) } }
+}

--- a/DictusCore/Tests/DictusCoreTests/AccentRelationTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/AccentRelationTests.swift
@@ -1,0 +1,160 @@
+// DictusCore/Tests/DictusCoreTests/AccentRelationTests.swift
+// Pins the accent-cost table the keyboard's C++ scorer consumes (#321). The C++ side is
+// a pure lookup into the pairs enumerated here, so these assertions cover the relation
+// itself — what is related to what, at what cost — for every language Dictus ships.
+import XCTest
+@testable import DictusCore
+
+final class AccentRelationTests: XCTestCase {
+
+    // MARK: - German umlauts (the gap #321 closes)
+
+    func testUmlautsRelateToTheirBaseLetters() {
+        XCTAssertEqual(AccentRelation.baseLetter(of: "\u{00E4}"), "a")   // ä
+        XCTAssertEqual(AccentRelation.baseLetter(of: "\u{00F6}"), "o")   // ö
+        XCTAssertEqual(AccentRelation.baseLetter(of: "\u{00FC}"), "u")   // ü
+    }
+
+    func testUmlautSubstitutionIsCheapInBothDirections() {
+        // `uber` for `über` and `über` for `uber` must both score as a near substitution.
+        for (accented, base) in [("\u{00E4}", "a"), ("\u{00F6}", "o"), ("\u{00FC}", "u")] {
+            guard let accentedChar = accented.first, let baseChar = base.first else {
+                return XCTFail("bad fixture")
+            }
+            XCTAssertEqual(AccentRelation.cost(from: baseChar, to: accentedChar),
+                           AccentRelation.baseToAccentCost, "\(base) → \(accented)")
+            XCTAssertEqual(AccentRelation.cost(from: accentedChar, to: baseChar),
+                           AccentRelation.baseToAccentCost, "\(accented) → \(base)")
+        }
+    }
+
+    func testUmlautRelatesToTheOtherAccentsOfItsBase() {
+        // ä and à share `a`, ü and ù share `u` — accent-to-accent, not unrelated.
+        XCTAssertEqual(AccentRelation.cost(from: "\u{00E4}", to: "\u{00E0}"),
+                       AccentRelation.accentToAccentCost)          // ä ↔ à
+        XCTAssertEqual(AccentRelation.cost(from: "\u{00FC}", to: "\u{00F9}"),
+                       AccentRelation.accentToAccentCost)          // ü ↔ ù
+        XCTAssertEqual(AccentRelation.cost(from: "\u{00F6}", to: "\u{00F4}"),
+                       AccentRelation.accentToAccentCost)          // ö ↔ ô
+    }
+
+    // MARK: - The ß decision (#321): deliberately out of this table
+
+    /// `ß` relates to `ss`, a one-to-two relation this one-to-one table cannot express.
+    /// It is handled by `germanProfile.collapseRules` instead. If this test fails, someone
+    /// added ß to the accent map — read the reasoning on `AccentRelation.baseLetters` first.
+    func testEszettIsNotAnAccentOfS() {
+        XCTAssertNil(AccentRelation.baseLetter(of: "\u{00DF}"))
+        XCTAssertNil(AccentRelation.cost(from: "\u{00DF}", to: "s"))
+        XCTAssertNil(AccentRelation.cost(from: "s", to: "\u{00DF}"))
+    }
+
+    func testEszettIsCoveredByTheGermanCollapseRules() {
+        // Where the ss ↔ ß relation actually lives, so excluding it above loses nothing.
+        XCTAssertTrue(germanProfile.collapseRules.contains { $0.from == "ss" && $0.to == "\u{00DF}" })
+    }
+
+    // MARK: - French and Spanish: frozen (#321 criterion — no regression)
+
+    /// Every relation that shipped before the umlauts were added, spelled out. A change
+    /// here moves every correction in French or Spanish, silently.
+    func testFrenchAndSpanishRelationsAreUnchanged() {
+        let frozen: [Character: Character] = [
+            "\u{00E9}": "e", "\u{00E8}": "e", "\u{00EA}": "e", "\u{00EB}": "e",
+            "\u{00E0}": "a", "\u{00E2}": "a",
+            "\u{00F9}": "u", "\u{00FB}": "u",
+            "\u{00F4}": "o",
+            "\u{00EE}": "i", "\u{00EF}": "i",
+            "\u{00E7}": "c"
+        ]
+        for (accented, base) in frozen {
+            XCTAssertEqual(AccentRelation.baseLetter(of: accented), base,
+                           "\(accented) must stay a variant of \(base)")
+        }
+    }
+
+    func testTheTableHoldsExactlyTheFrozenSetPlusThreeUmlauts() {
+        // Guards against a fourth entry sneaking in unremarked — including the Spanish
+        // acutes (á í ó ú ñ), which are absent today and out of scope for #321.
+        XCTAssertEqual(AccentRelation.baseLetters.count, 15)
+        XCTAssertNil(AccentRelation.baseLetter(of: "\u{00E1}"))     // á — still absent
+        XCTAssertNil(AccentRelation.baseLetter(of: "\u{00F1}"))     // ñ — still absent
+    }
+
+    func testFrenchCostsAreUnchanged() {
+        XCTAssertEqual(AccentRelation.cost(from: "e", to: "\u{00E9}"), 0.15)   // e → é
+        XCTAssertEqual(AccentRelation.cost(from: "\u{00E9}", to: "e"), 0.15)   // é → e
+        XCTAssertEqual(AccentRelation.cost(from: "\u{00E9}", to: "\u{00E8}"), 0.2)  // é → è
+        XCTAssertEqual(AccentRelation.cost(from: "\u{00E7}", to: "c"), 0.15)   // ç → c
+    }
+
+    func testCostConstantsAreUnchanged() {
+        XCTAssertEqual(AccentRelation.baseToAccentCost, 0.15)
+        XCTAssertEqual(AccentRelation.accentToAccentCost, 0.2)
+    }
+
+    // MARK: - Unrelated characters
+
+    func testUnrelatedCharactersHaveNoAccentCost() {
+        XCTAssertNil(AccentRelation.cost(from: "a", to: "b"))
+        XCTAssertNil(AccentRelation.cost(from: "\u{00FC}", to: "p"))       // ü vs p: proximity's job
+        XCTAssertNil(AccentRelation.cost(from: "\u{00E9}", to: "\u{00E0}"))  // é vs à: different bases
+        XCTAssertNil(AccentRelation.cost(from: "z", to: "\u{00E9}"))       // z has no accents
+    }
+
+    func testIdenticalCharactersCostNothing() {
+        XCTAssertEqual(AccentRelation.cost(from: "\u{00FC}", to: "\u{00FC}"), 0)
+        XCTAssertEqual(AccentRelation.cost(from: "a", to: "a"), 0)
+    }
+
+    // MARK: - The flattened pairs handed to C++
+
+    func testCostPairsAgreeWithCostForEveryPair() {
+        let pairs = AccentRelation.costPairs
+        XCTAssertEqual(pairs.from.count, pairs.count)
+        XCTAssertEqual(pairs.to.count, pairs.count)
+        for index in 0..<pairs.count {
+            guard let from = Unicode.Scalar(pairs.from[index]),
+                  let to = Unicode.Scalar(pairs.to[index]) else {
+                return XCTFail("pair \(index) is not a scalar")
+            }
+            XCTAssertEqual(AccentRelation.cost(from: Character(from), to: Character(to)),
+                           pairs.costs[index],
+                           "pair \(index): \(Character(from)) → \(Character(to))")
+        }
+    }
+
+    func testCostPairsContainNoUnrelatedPairAndNoIdentityPair() {
+        let pairs = AccentRelation.costPairs
+        for index in 0..<pairs.count {
+            XCTAssertNotEqual(pairs.from[index], pairs.to[index], "identity pair at \(index)")
+            XCTAssertGreaterThan(pairs.costs[index], 0)
+        }
+    }
+
+    func testCostPairsCoverBothDirectionsOfEveryRelation() {
+        let pairs = AccentRelation.costPairs
+        let seen = Set(zip(pairs.from, pairs.to).map { [$0, $1] })
+        for (accented, base) in AccentRelation.baseLetters {
+            guard let accentedScalar = AccentRelation.scalarValue(accented),
+                  let baseScalar = AccentRelation.scalarValue(base) else {
+                return XCTFail("unmappable entry \(accented)")
+            }
+            XCTAssertTrue(seen.contains([accentedScalar, baseScalar]), "\(accented) → \(base)")
+            XCTAssertTrue(seen.contains([baseScalar, accentedScalar]), "\(base) → \(accented)")
+        }
+    }
+
+    /// The enumeration is deterministic: the buffers handed to C++ must not depend on
+    /// dictionary iteration order, or two runs would install different tables.
+    func testCostPairsAreStableAcrossCalls() {
+        XCTAssertEqual(AccentRelation.costPairs, AccentRelation.costPairs)
+    }
+
+    func testCostPairsPackIntoBuffersOfMatchingSize() {
+        let pairs = AccentRelation.costPairs
+        XCTAssertEqual(pairs.fromData.count, pairs.count * 2)      // UInt16
+        XCTAssertEqual(pairs.toData.count, pairs.count * 2)
+        XCTAssertEqual(pairs.costsData.count, pairs.count * 4)     // Float
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/AccentRelationTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/AccentRelationTests.swift
@@ -136,12 +136,12 @@ final class AccentRelationTests: XCTestCase {
         let pairs = AccentRelation.costPairs
         let seen = Set(zip(pairs.from, pairs.to).map { [$0, $1] })
         for (accented, base) in AccentRelation.baseLetters {
-            guard let accentedScalar = AccentRelation.scalarValue(accented),
-                  let baseScalar = AccentRelation.scalarValue(base) else {
+            guard let accentedUnit = accented.singleUTF16CodeUnit,
+                  let baseUnit = base.singleUTF16CodeUnit else {
                 return XCTFail("unmappable entry \(accented)")
             }
-            XCTAssertTrue(seen.contains([accentedScalar, baseScalar]), "\(accented) → \(base)")
-            XCTAssertTrue(seen.contains([baseScalar, accentedScalar]), "\(base) → \(accented)")
+            XCTAssertTrue(seen.contains([accentedUnit, baseUnit]), "\(accented) → \(base)")
+            XCTAssertTrue(seen.contains([baseUnit, accentedUnit]), "\(base) → \(accented)")
         }
     }
 

--- a/DictusCore/Tests/DictusCoreTests/KeyboardProximityTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/KeyboardProximityTests.swift
@@ -1,0 +1,244 @@
+// DictusCore/Tests/DictusCoreTests/KeyboardProximityTests.swift
+// Pins the proximity model the keyboard's C++ scorer installs (#321).
+//
+// Two jobs. First, QWERTZ's three umlaut keys must have positions at all and score as
+// near misses against their physical neighbours. Second — the expensive half — AZERTY and
+// QWERTY pairwise costs must not move: the geometry used to be hardcoded in C++ and is
+// now computed here, so the expected values below are hand-derived from the formula
+// (`min(1, hypot / 2.5)` over the historical coordinates), not copied from an
+// implementation run. A silent shift in those numbers changes every French correction.
+import XCTest
+@testable import DictusCore
+
+final class KeyboardProximityTests: XCTestCase {
+
+    /// Distances are floats and the geometry involves 10/11; compare at 1e-5.
+    private let tolerance: Float = 0.00001
+
+    // MARK: - Coverage: every letter key of every layout has a position
+
+    func testAzertyCoversTwentySixLetters() {
+        let characters = KeyboardProximity.keyPositions(for: .azerty).map(\.character)
+        XCTAssertEqual(characters.count, 26)
+        XCTAssertEqual(Set(characters).count, 26, "no letter twice")
+        XCTAssertEqual(String(characters), "azertyuiopqsdfghjklmwxcvbn")
+    }
+
+    func testQwertyCoversTwentySixLetters() {
+        let characters = KeyboardProximity.keyPositions(for: .qwerty).map(\.character)
+        XCTAssertEqual(characters.count, 26)
+        XCTAssertEqual(Set(characters).count, 26, "no letter twice")
+        XCTAssertEqual(String(characters), "qwertyuiopasdfghjklzxcvbnm")
+    }
+
+    func testQwertzCoversTwentySixLettersPlusTheThreeUmlauts() {
+        let characters = KeyboardProximity.keyPositions(for: .qwertz).map(\.character)
+        XCTAssertEqual(characters.count, 29)
+        XCTAssertEqual(String(characters),
+                       "qwertzuiop\u{00FC}asdfghjkl\u{00F6}\u{00E4}yxcvbnm")
+    }
+
+    /// The model reads its key sequence from the rows the keyboard renders, so the two
+    /// cannot drift apart (the trap #151 called out: a copy in the extension is untestable).
+    func testQwertzSequenceMatchesTheRenderedRows() {
+        let fromLayoutData = QWERTZLayout.lowercasedLettersRows.flatMap { $0 }
+        let fromModel = KeyboardProximity.keyPositions(for: .qwertz).map { String($0.character) }
+        XCTAssertEqual(fromModel, fromLayoutData)
+    }
+
+    func testQwertySequenceMatchesTheRenderedRows() {
+        let fromLayoutData = QWERTYLayout.lettersRows.prefix(3).flatMap { $0 }.map { $0.lowercased() }
+        let fromModel = KeyboardProximity.keyPositions(for: .qwerty).map { String($0.character) }
+        XCTAssertEqual(fromModel, fromLayoutData)
+    }
+
+    // MARK: - AZERTY: unchanged (#321 criterion — a regression here is silent)
+
+    func testAzertyKeyCentresAreUnchanged() {
+        assertPosition(.azerty, "a", x: 0, y: 0)
+        assertPosition(.azerty, "z", x: 1, y: 0)
+        assertPosition(.azerty, "p", x: 9, y: 0)
+        assertPosition(.azerty, "q", x: 0.25, y: 1)
+        assertPosition(.azerty, "m", x: 9.25, y: 1)
+        assertPosition(.azerty, "w", x: 0.75, y: 2)
+        assertPosition(.azerty, "n", x: 5.75, y: 2)
+    }
+
+    func testAzertyPairwiseCostsAreUnchanged() {
+        let table = KeyboardProximity.costTable(for: .azerty)
+        // Adjacent on the same row: one key width / 2.5.
+        assertCost(table, "a", "z", 1.0 / 2.5)
+        assertCost(table, "e", "r", 1.0 / 2.5)
+        // Row 0 to row 1, staggered by 0.25.
+        assertCost(table, "a", "q", (0.25 * 0.25 + 1).squareRoot() / 2.5)
+        assertCost(table, "z", "s", (0.25 * 0.25 + 1).squareRoot() / 2.5)
+        // Row 1 to row 2, staggered by 0.5.
+        assertCost(table, "q", "w", (0.5 * 0.5 + 1).squareRoot() / 2.5)
+        // Far apart: clamped.
+        assertCost(table, "a", "p", 1.0)
+        assertCost(table, "a", "n", 1.0)
+        // Same key.
+        assertCost(table, "a", "a", 0)
+    }
+
+    // MARK: - QWERTY: unchanged (#321 criterion)
+
+    func testQwertyKeyCentresAreUnchanged() {
+        assertPosition(.qwerty, "q", x: 0, y: 0)
+        assertPosition(.qwerty, "p", x: 9, y: 0)
+        assertPosition(.qwerty, "a", x: 0.25, y: 1)
+        assertPosition(.qwerty, "l", x: 8.25, y: 1)
+        assertPosition(.qwerty, "z", x: 0.75, y: 2)
+        assertPosition(.qwerty, "m", x: 6.75, y: 2)
+    }
+
+    func testQwertyPairwiseCostsAreUnchanged() {
+        let table = KeyboardProximity.costTable(for: .qwerty)
+        assertCost(table, "q", "w", 1.0 / 2.5)
+        assertCost(table, "a", "s", 1.0 / 2.5)
+        assertCost(table, "q", "a", (0.25 * 0.25 + 1).squareRoot() / 2.5)
+        assertCost(table, "a", "z", (0.5 * 0.5 + 1).squareRoot() / 2.5)
+        assertCost(table, "q", "p", 1.0)
+        assertCost(table, "q", "q", 0)
+    }
+
+    /// The two layouts share 26 keys but not their arrangement — this guards against a
+    /// refactor that accidentally builds one from the other.
+    func testAzertyAndQwertyDisagreeWhereTheLayoutsDiffer() {
+        let azerty = KeyboardProximity.costTable(for: .azerty)
+        let qwerty = KeyboardProximity.costTable(for: .qwerty)
+        // `a` and `q` swap rows between the two, so `a`–`e` is a near miss on AZERTY
+        // (adjacent but one) and unrelated on QWERTY.
+        XCTAssertLessThan(azerty.cost(from: "a", to: "e"), qwerty.cost(from: "a", to: "e"))
+    }
+
+    // MARK: - QWERTZ: the three umlaut keys (#321)
+
+    func testQwertzUmlautKeysHavePositions() {
+        // Rows 0 and 1 carry 11 keys in a 10-unit row: keys are 10/11 wide.
+        let width = 10.0 / 11.0
+        assertPosition(.qwertz, "q", x: 0.5 * width - 0.5, y: 0)
+        assertPosition(.qwertz, "p", x: 9.5 * width - 0.5, y: 0)
+        assertPosition(.qwertz, "\u{00FC}", x: 10.5 * width - 0.5, y: 0)      // ü
+        assertPosition(.qwertz, "l", x: 8.5 * width - 0.5, y: 1)
+        assertPosition(.qwertz, "\u{00F6}", x: 9.5 * width - 0.5, y: 1)       // ö
+        assertPosition(.qwertz, "\u{00E4}", x: 10.5 * width - 0.5, y: 1)      // ä
+    }
+
+    /// The acceptance criterion, stated as the scorer sees it.
+    func testUmlautToItsNeighbourIsMateriallyCheaperThanToAFarKey() {
+        let table = KeyboardProximity.costTable(for: .qwertz)
+        let neighbour = table.cost(from: "\u{00FC}", to: "p")      // ü and p are adjacent
+        let farKey = table.cost(from: "\u{00FC}", to: "q")         // opposite end of the row
+
+        XCTAssertEqual(farKey, 1.0, "ü to q must be unrelated")
+        XCTAssertLessThan(neighbour, 0.4)
+        XCTAssertLessThan(neighbour, farKey / 2, "not materially cheaper")
+    }
+
+    func testQwertzUmlautNeighbourCosts() {
+        let table = KeyboardProximity.costTable(for: .qwertz)
+        let width = 10.0 / 11.0
+        let sameRowStep = Float(width / 2.5)
+
+        // The three mistypes on the manual test list, each between physical neighbours.
+        assertCost(table, "\u{00FC}", "p", Double(sameRowStep))                      // ü / p
+        assertCost(table, "\u{00F6}", "l", Double(sameRowStep))                      // ö / l
+        assertCost(table, "\u{00E4}", "\u{00F6}", Double(sameRowStep))               // ä / ö
+        // ü and ä both close their row, so ä sits directly under ü: one row, no column shift.
+        assertCost(table, "\u{00FC}", "\u{00E4}", 1.0 / 2.5)
+        // ö is one key left on the row below ü: one row and one key away.
+        assertCost(table, "\u{00FC}", "\u{00F6}", (width * width + 1).squareRoot() / 2.5)
+    }
+
+    /// Symmetry matters: the scorer asks in whichever direction the trie walk hits.
+    func testCostsAreSymmetric() {
+        for layout in LayoutType.allCases {
+            let positions = KeyboardProximity.keyPositions(for: layout)
+            let table = KeyboardProximity.costTable(for: layout)
+            for from in positions {
+                for to in positions {
+                    XCTAssertEqual(table.cost(from: from.character, to: to.character),
+                                   table.cost(from: to.character, to: from.character),
+                                   accuracy: tolerance,
+                                   "\(layout) \(from.character)/\(to.character)")
+                }
+            }
+        }
+    }
+
+    // MARK: - Keys the layout does not have
+
+    /// A German on QWERTY reaches ü by long-press, so it has no position and no proximity
+    /// relation — the accent path (`AccentRelation`) is what carries that case.
+    func testUmlautsAreAbsentFromLayoutsThatHaveNoUmlautKey() {
+        for layout in [LayoutType.azerty, .qwerty] {
+            let table = KeyboardProximity.costTable(for: layout)
+            XCTAssertEqual(table.cost(from: "\u{00FC}", to: "u"), 1.0, "\(layout)")
+            XCTAssertEqual(table.cost(from: "\u{00F6}", to: "o"), 1.0, "\(layout)")
+            XCTAssertEqual(table.cost(from: "\u{00E4}", to: "a"), 1.0, "\(layout)")
+        }
+    }
+
+    func testNonLetterCharactersAreUnrelated() {
+        let table = KeyboardProximity.costTable(for: .qwertz)
+        XCTAssertEqual(table.cost(from: "1", to: "q"), 1.0)
+        XCTAssertEqual(table.cost(from: "-", to: "p"), 1.0)
+        XCTAssertEqual(table.cost(from: "\u{00DF}", to: "s"), 1.0)   // ß has no key (#151)
+    }
+
+    // MARK: - The buffers handed to C++
+
+    func testTableBuffersAreSquareAndCorrectlySized() {
+        for layout in LayoutType.allCases {
+            let table = KeyboardProximity.costTable(for: layout)
+            XCTAssertEqual(table.distances.count, table.count * table.count, "\(layout)")
+            XCTAssertEqual(table.charactersData.count, table.count * 2, "\(layout)")       // UInt16
+            XCTAssertEqual(table.distancesData.count, table.count * table.count * 4, "\(layout)")
+        }
+    }
+
+    func testEveryCostIsInRange() {
+        for layout in LayoutType.allCases {
+            for distance in KeyboardProximity.costTable(for: layout).distances {
+                XCTAssertGreaterThanOrEqual(distance, 0, "\(layout)")
+                XCTAssertLessThanOrEqual(distance, 1, "\(layout)")
+            }
+        }
+    }
+
+    func testDiagonalIsZero() {
+        for layout in LayoutType.allCases {
+            let table = KeyboardProximity.costTable(for: layout)
+            for index in 0..<table.count {
+                XCTAssertEqual(table.distances[index * table.count + index], 0, "\(layout)")
+            }
+        }
+    }
+
+    func testNormalizerIsUnchanged() {
+        XCTAssertEqual(KeyboardProximity.distanceNormalizer, 2.5)
+    }
+
+    // MARK: - Helpers
+
+    private func assertPosition(
+        _ layout: LayoutType, _ character: Character, x: Double, y: Double,
+        line: UInt = #line
+    ) {
+        guard let position = KeyboardProximity.keyPositions(for: layout)
+            .first(where: { $0.character == character }) else {
+            return XCTFail("\(layout) has no key '\(character)'", line: line)
+        }
+        XCTAssertEqual(position.x, x, accuracy: 0.00001, "x of '\(character)'", line: line)
+        XCTAssertEqual(position.y, y, accuracy: 0.00001, "y of '\(character)'", line: line)
+    }
+
+    private func assertCost(
+        _ table: ProximityCostTable, _ from: Character, _ to: Character, _ expected: Double,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(table.cost(from: from, to: to), Float(expected), accuracy: tolerance,
+                       "cost '\(from)' → '\(to)'", line: line)
+    }
+}

--- a/DictusKeyboard/TextPrediction/AOSPTrieEngine.swift
+++ b/DictusKeyboard/TextPrediction/AOSPTrieEngine.swift
@@ -59,16 +59,7 @@ final class AOSPTrieEngine {
 
             let success = self.bridge.loadDictionary(atPath: path)
 
-            // Set proximity map based on active keyboard layout.
-            // AZERTY is default because Dictus targets French-speaking users.
-            // QWERTZ takes the QWERTY map: the two differ only by the y/z swap, and
-            // the bridge ships no third map. Worth revisiting only if German typo
-            // reports point at y/z (#151).
-            if LayoutType.active == .azerty {
-                self.bridge.setProximityMapAZERTY()
-            } else {
-                self.bridge.setProximityMapQWERTY()
-            }
+            self.installSubstitutionCosts(layout: LayoutType.active)
 
             // Load n-gram data on the same queue, right after the spell dict.
             // WHY here: n-grams are only useful after the dictionary is loaded,
@@ -86,6 +77,32 @@ final class AOSPTrieEngine {
                 }
                 self.isLoading = false
             }
+        }
+    }
+
+    /// Installs the two substitution-cost tables the C++ scorer scores typos with: keyboard
+    /// proximity for the active layout, and the accent relation.
+    ///
+    /// WHY both tables come from DictusCore rather than being built in the C++:
+    /// they are data, evaluated once here per dictionary load and never in the scoring
+    /// loop, and DictusCore is the only target in this repo with a test bundle. Before
+    /// #321 the geometry was hardcoded as `float[26][26]` indexed by `c - 'a'`, which left
+    /// QWERTZ's ü/ö/ä keys with nowhere to sit and sent QWERTZ to the QWERTY table, where
+    /// y and z are in each other's places.
+    private func installSubstitutionCosts(layout: LayoutType) {
+        let proximity = KeyboardProximity.costTable(for: layout)
+        if !bridge.setProximityTable(characters: proximity.charactersData,
+                                     distances: proximity.distancesData) {
+            print("[AOSPTrieEngine] Rejected \(layout.displayName) proximity table "
+                  + "(\(proximity.count) keys) — typo scoring falls back to plain edit distance")
+        }
+
+        let accents = AccentRelation.costPairs
+        if !bridge.setAccentCosts(from: accents.fromData,
+                                  to: accents.toData,
+                                  costs: accents.costsData) {
+            print("[AOSPTrieEngine] Rejected accent cost table (\(accents.count) pairs) — "
+                  + "accented spellings score as unrelated characters")
         }
     }
 

--- a/DictusKeyboard/Vendored/AOSPTrie/bridge/AOSPTrieBridge.h
+++ b/DictusKeyboard/Vendored/AOSPTrie/bridge/AOSPTrieBridge.h
@@ -37,9 +37,24 @@ NS_ASSUME_NONNULL_BEGIN
 /// Word count from the loaded dictionary header.
 - (NSUInteger)wordCount;
 
-/// Set keyboard layout for proximity scoring.
-- (void)setProximityMapAZERTY;
-- (void)setProximityMapQWERTY;
+/// Install the proximity cost table for the active keyboard layout.
+///
+/// The table is computed by DictusCore's `KeyboardProximity`, which owns the key geometry
+/// of every layout: the keyboard target has no test bundle, so a table declared here could
+/// not be pinned by anything (#321). Pass `ProximityCostTable.charactersData` (UTF-16 code
+/// units, one per key) and `.distancesData` (count x count floats, row-major).
+/// Returns NO if the two buffers disagree on size; the previous table then stays installed.
+- (BOOL)setProximityTableWithCharacters:(NSData *)characters distances:(NSData *)distances
+    NS_SWIFT_NAME(setProximityTable(characters:distances:));
+
+/// Install the accent substitution costs.
+///
+/// Computed by DictusCore's `AccentRelation`, for the same reason. Pass
+/// `AccentCostPairs.fromData` / `.toData` (UTF-16 code units) and `.costsData` (floats),
+/// three parallel buffers of equal length.
+/// Returns NO if the buffers disagree on size; the previous table then stays installed.
+- (BOOL)setAccentCostsFrom:(NSData *)from to:(NSData *)to costs:(NSData *)costs
+    NS_SWIFT_NAME(setAccentCosts(from:to:costs:));
 
 // --- N-gram prediction methods ---
 

--- a/DictusKeyboard/Vendored/AOSPTrie/bridge/AOSPTrieBridge.mm
+++ b/DictusKeyboard/Vendored/AOSPTrie/bridge/AOSPTrieBridge.mm
@@ -21,6 +21,7 @@
     dictus::Trie _trie;
     dictus::Scorer _scorer;
     dictus::ProximityMap _proximityMap;
+    dictus::AccentCostTable _accentCosts;
     BOOL _loaded;
     dictus::NgramEngine* _ngramEngine;
 }
@@ -30,6 +31,12 @@
     if (self) {
         _loaded = NO;
         _ngramEngine = new dictus::NgramEngine();
+        // Both tables are members with a stable address, so the scorer is wired to them
+        // once here. Until DictusCore installs their contents they are neutral: every
+        // substitution costs 1.0 and no accent pair is related, which degrades to plain
+        // edit distance rather than to wrong scores.
+        _scorer.setProximityMap(&_proximityMap);
+        _scorer.setAccentCostTable(&_accentCosts);
     }
     return self;
 }
@@ -45,7 +52,6 @@
 
     bool success = _trie.loadMmap([path UTF8String]);
     if (success) {
-        _scorer.setProximityMap(&_proximityMap);
         _loaded = YES;
     }
     return success ? YES : NO;
@@ -147,18 +153,23 @@ static int convertString(NSString *str, uint16_t *buffer, int bufferSize) {
     return (NSUInteger)_trie.wordCount();
 }
 
-- (void)setProximityMapAZERTY {
-    _proximityMap.buildAZERTY();
-    if (_loaded) {
-        _scorer.setProximityMap(&_proximityMap);
-    }
+- (BOOL)setProximityTableWithCharacters:(NSData *)characters distances:(NSData *)distances {
+    NSUInteger count = characters.length / sizeof(uint16_t);
+    if (count == 0 || distances.length != count * count * sizeof(float)) return NO;
+
+    return _proximityMap.setTable(static_cast<const uint16_t *>(characters.bytes),
+                                  (int)count,
+                                  static_cast<const float *>(distances.bytes)) ? YES : NO;
 }
 
-- (void)setProximityMapQWERTY {
-    _proximityMap.buildQWERTY();
-    if (_loaded) {
-        _scorer.setProximityMap(&_proximityMap);
-    }
+- (BOOL)setAccentCostsFrom:(NSData *)from to:(NSData *)to costs:(NSData *)costs {
+    NSUInteger count = from.length / sizeof(uint16_t);
+    if (count == 0 || to.length != from.length || costs.length != count * sizeof(float)) return NO;
+
+    return _accentCosts.setPairs(static_cast<const uint16_t *>(from.bytes),
+                                 static_cast<const uint16_t *>(to.bytes),
+                                 static_cast<const float *>(costs.bytes),
+                                 (int)count) ? YES : NO;
 }
 
 // --- N-gram prediction methods ---

--- a/DictusKeyboard/Vendored/AOSPTrie/include/dictus_proximity.h
+++ b/DictusKeyboard/Vendored/AOSPTrie/include/dictus_proximity.h
@@ -6,27 +6,59 @@
 
 namespace dictus {
 
-/// Keyboard proximity map for weighted edit distance scoring.
-/// Precomputes pairwise distances between a-z keys based on physical layout.
+/// Number of characters a substitution cost can be defined between.
+/// See substitutionSlot() for the ranges.
+static constexpr int SUBSTITUTION_SLOT_COUNT = 58;
+
+/// Compact table slot for a character, or -1 when there is none.
+///
+/// Covers a-z plus the lowercase half of the Latin-1 supplement (U+00E0..U+00FF), which
+/// is where every accented key of every layout Dictus ships lives: é è ê ë à â ä ç î ï
+/// ô ö ù û ü. Uppercase is folded first. Anything else -- digits, punctuation, ß
+/// (U+00DF, deliberately outside the accent relation), letters beyond Latin-1 -- returns
+/// -1 and its callers treat it as unrelated.
+///
+/// WHY a slot map rather than the c - 'a' indexing this replaced: that indexing made the
+/// tables 26 ASCII letters *by construction*, so QWERTZ's ü/ö/ä keys were not mis-scored,
+/// they were unrepresentable (#321).
+inline int substitutionSlot(uint16_t c) {
+    if (c >= 'A' && c <= 'Z') c = static_cast<uint16_t>(c - 'A' + 'a');
+    // Latin-1 uppercase to lowercase. U+00D7 is the multiplication sign, not a letter.
+    if (c >= 0x00C0 && c <= 0x00DE && c != 0x00D7) c = static_cast<uint16_t>(c + 0x20);
+
+    if (c >= 'a' && c <= 'z') return static_cast<int>(c - 'a');
+    if (c >= 0x00E0 && c <= 0x00FF) return 26 + static_cast<int>(c - 0x00E0);
+    return -1;
+}
+
+/// Keyboard proximity costs for weighted edit distance scoring.
+///
+/// The table is computed in DictusCore (`KeyboardProximity`) and installed here. WHY the
+/// split: the key geometry and the distance formula are data, evaluated once per
+/// dictionary load, and DictusCore is the only place in this repo that can run a test
+/// against them -- the keyboard target has no test bundle. What stays here is the lookup
+/// the scorer's inner loop performs.
 class ProximityMap {
 public:
     ProximityMap();
 
-    /// Build AZERTY layout proximity distances.
-    void buildAZERTY();
-
-    /// Build QWERTY layout proximity distances.
-    void buildQWERTY();
+    /// Install a precomputed cost table.
+    /// characters: `count` UTF-16 code units, one per table row and column.
+    /// distances: `count * count` costs in [0.0, 1.0], row-major.
+    /// Returns false and leaves the table untouched if the arguments are inconsistent.
+    /// Characters with no slot are skipped: they keep costing 1.0.
+    bool setTable(const uint16_t* characters, int count, const float* distances);
 
     /// Get proximity cost between two characters.
     /// Returns value in [0.0, 1.0]. Lower = closer on keyboard.
-    /// For non-letter characters, returns 1.0.
+    /// Returns 1.0 for anything the active layout has no key for.
     float cost(uint16_t a, uint16_t b) const;
 
 private:
-    float distances_[26][26];
+    /// Reset to neutral: 0.0 against itself, 1.0 against everything else.
+    void reset();
 
-    void computeDistances(const float positions[][2], int count, const int charMap[]);
+    float distances_[SUBSTITUTION_SLOT_COUNT][SUBSTITUTION_SLOT_COUNT];
 };
 
 } // namespace dictus

--- a/DictusKeyboard/Vendored/AOSPTrie/include/dictus_proximity.h
+++ b/DictusKeyboard/Vendored/AOSPTrie/include/dictus_proximity.h
@@ -14,17 +14,22 @@ static constexpr int SUBSTITUTION_SLOT_COUNT = 58;
 ///
 /// Covers a-z plus the lowercase half of the Latin-1 supplement (U+00E0..U+00FF), which
 /// is where every accented key of every layout Dictus ships lives: é è ê ë à â ä ç î ï
-/// ô ö ù û ü. Uppercase is folded first. Anything else -- digits, punctuation, ß
-/// (U+00DF, deliberately outside the accent relation), letters beyond Latin-1 -- returns
-/// -1 and its callers treat it as unrelated.
+/// ô ö ù û ü. Anything else -- digits, punctuation, ß (U+00DF, deliberately outside the
+/// accent relation), letters beyond Latin-1 -- returns -1 and its callers treat it as
+/// unrelated.
 ///
 /// WHY a slot map rather than the c - 'a' indexing this replaced: that indexing made the
 /// tables 26 ASCII letters *by construction*, so QWERTZ's ü/ö/ä keys were not mis-scored,
 /// they were unrepresentable (#321).
+///
+/// WHY A-Z folds but À-Þ does not: A-Z folding is what the proximity map has always done.
+/// Accented uppercase had no slot to fold *into* before this change, so folding it now
+/// would newly relate `É` to `e` -- a behaviour change in French smuggled in by a German
+/// fix. The scorer is fed lowercased input anyway (`AOSPTrieEngine.spellCheck`), so this
+/// costs nothing today; if a capitalized dictionary entry ever makes it worth doing, it is
+/// its own change with its own evidence.
 inline int substitutionSlot(uint16_t c) {
     if (c >= 'A' && c <= 'Z') c = static_cast<uint16_t>(c - 'A' + 'a');
-    // Latin-1 uppercase to lowercase. U+00D7 is the multiplication sign, not a letter.
-    if (c >= 0x00C0 && c <= 0x00DE && c != 0x00D7) c = static_cast<uint16_t>(c + 0x20);
 
     if (c >= 'a' && c <= 'z') return static_cast<int>(c - 'a');
     if (c >= 0x00E0 && c <= 0x00FF) return 26 + static_cast<int>(c - 0x00E0);

--- a/DictusKeyboard/Vendored/AOSPTrie/include/dictus_scorer.h
+++ b/DictusKeyboard/Vendored/AOSPTrie/include/dictus_scorer.h
@@ -5,16 +5,50 @@
 #include <cstdint>
 #include <vector>
 
+#include "dictus_proximity.h"
+
 namespace dictus {
 
 class Trie;
-class ProximityMap;
 
 /// A spell correction candidate with score.
 struct Candidate {
     char word[128];     // UTF-8, null-terminated (avoids std::string allocation)
     float score;
     uint16_t frequency;
+};
+
+/// Accent substitution costs: what it costs to type `e` where `é` belonged, or `u` where
+/// `ü` did, instead of treating the two spellings as unrelated characters.
+///
+/// The relation and its costs are declared in DictusCore (`AccentRelation`) and installed
+/// here as flat pairs. WHY the split: the table is data, built once per dictionary load,
+/// and DictusCore is the only place in this repo a test can execute. WHY *pairs* rather
+/// than the accented-to-base map this replaced: re-deriving the pairs here would put the
+/// precedence rules (base-to-accent 0.15, accent-to-accent 0.20) in two languages, free
+/// to drift. This class holds no rules of its own.
+///
+/// ß (U+00DF) is deliberately absent, which is why it has no slot in substitutionSlot():
+/// its relation to `ss` changes length, and this path models one-to-one substitution only.
+/// The full reasoning is on `AccentRelation.baseLetters`; the ss->ß relation is modelled
+/// in `germanProfile.collapseRules` instead.
+class AccentCostTable {
+public:
+    AccentCostTable();
+
+    /// Install `count` (from, to, cost) triples as three parallel arrays.
+    /// Returns false and leaves the table untouched if the arguments are inconsistent.
+    bool setPairs(const uint16_t* from, const uint16_t* to, const float* costs, int count);
+
+    /// Substitution cost between two accent-related characters.
+    /// Returns >= 0.0 if the pair is a known relation, -1.0 otherwise.
+    float cost(uint16_t from, uint16_t to) const;
+
+private:
+    /// Reset to unrelated: 0.0 against itself, -1.0 against everything else.
+    void reset();
+
+    float costs_[SUBSTITUTION_SLOT_COUNT][SUBSTITUTION_SLOT_COUNT];
 };
 
 /// Weighted edit distance scorer for spell correction.
@@ -27,6 +61,9 @@ public:
     /// Set the active keyboard proximity map.
     void setProximityMap(const ProximityMap* map);
 
+    /// Set the active accent cost table.
+    void setAccentCostTable(const AccentCostTable* table);
+
     /// Find spell corrections for the input word.
     /// input: UTF-16 code units, inputLen: number of code units.
     /// maxEditDist: maximum cumulative edit cost (default 2.0).
@@ -37,11 +74,9 @@ public:
                                    float maxEditDist = 2.0f,
                                    int maxResults = 5) const;
 
-    /// Accent substitution cost. Returns >= 0 if accent pair, -1.0 otherwise.
-    static float accentCost(uint16_t from, uint16_t to);
-
 private:
     const ProximityMap* proximityMap_;
+    const AccentCostTable* accentCostTable_;
 
     void search(const Trie& trie,
                 uint32_t nodeOffset, int childIndex, int childCount,

--- a/DictusKeyboard/Vendored/AOSPTrie/src/dictus_proximity.cpp
+++ b/DictusKeyboard/Vendored/AOSPTrie/src/dictus_proximity.cpp
@@ -1,158 +1,44 @@
 // AOSP-inspired trie engine for Dictus. Apache 2.0.
 #include "dictus_proximity.h"
 
-#include <cmath>
-#include <cstring>
-
 namespace dictus {
 
 ProximityMap::ProximityMap() {
-    // Initialize all distances to 1.0 (maximum)
-    for (int i = 0; i < 26; i++) {
-        for (int j = 0; j < 26; j++) {
+    reset();
+}
+
+void ProximityMap::reset() {
+    for (int i = 0; i < SUBSTITUTION_SLOT_COUNT; i++) {
+        for (int j = 0; j < SUBSTITUTION_SLOT_COUNT; j++) {
             distances_[i][j] = (i == j) ? 0.0f : 1.0f;
         }
     }
 }
 
-void ProximityMap::buildAZERTY() {
-    // AZERTY key positions: (x, y) where x is column offset, y is row
-    // Row 0 (y=0): a z e r t y u i o p
-    // Row 1 (y=1): q s d f g h j k l m  (offset 0.25)
-    // Row 2 (y=2): w x c v b n          (offset 0.75)
+bool ProximityMap::setTable(const uint16_t* characters, int count, const float* distances) {
+    if (!characters || !distances || count <= 0) return false;
 
-    // Map: letter -> index in positions array
-    // We store positions for all 26 letters
+    // Neutral first: keys the new layout does not have must stop scoring as near misses
+    // from whatever layout was installed before.
+    reset();
 
-    float positions[26][2];
-    std::memset(positions, 0, sizeof(positions));
-
-    // Row 0: a(0) z(1) e(2) r(3) t(4) y(5) u(6) i(7) o(8) p(9)
-    auto set = [&](char c, float x, float y) {
-        positions[c - 'a'][0] = x;
-        positions[c - 'a'][1] = y;
-    };
-
-    set('a', 0.0f, 0.0f);
-    set('z', 1.0f, 0.0f);
-    set('e', 2.0f, 0.0f);
-    set('r', 3.0f, 0.0f);
-    set('t', 4.0f, 0.0f);
-    set('y', 5.0f, 0.0f);
-    set('u', 6.0f, 0.0f);
-    set('i', 7.0f, 0.0f);
-    set('o', 8.0f, 0.0f);
-    set('p', 9.0f, 0.0f);
-
-    // Row 1: q s d f g h j k l m (offset 0.25)
-    set('q', 0.25f, 1.0f);
-    set('s', 1.25f, 1.0f);
-    set('d', 2.25f, 1.0f);
-    set('f', 3.25f, 1.0f);
-    set('g', 4.25f, 1.0f);
-    set('h', 5.25f, 1.0f);
-    set('j', 6.25f, 1.0f);
-    set('k', 7.25f, 1.0f);
-    set('l', 8.25f, 1.0f);
-    set('m', 9.25f, 1.0f);
-
-    // Row 2: w x c v b n (offset 0.75)
-    set('w', 0.75f, 2.0f);
-    set('x', 1.75f, 2.0f);
-    set('c', 2.75f, 2.0f);
-    set('v', 3.75f, 2.0f);
-    set('b', 4.75f, 2.0f);
-    set('n', 5.75f, 2.0f);
-
-    // Compute distances: min(1.0, euclidean / 2.5)
-    for (int i = 0; i < 26; i++) {
-        for (int j = i; j < 26; j++) {
-            if (i == j) {
-                distances_[i][j] = 0.0f;
-                continue;
-            }
-            float dx = positions[i][0] - positions[j][0];
-            float dy = positions[i][1] - positions[j][1];
-            float dist = std::sqrt(dx * dx + dy * dy) / 2.5f;
-            if (dist > 1.0f) dist = 1.0f;
-            distances_[i][j] = dist;
-            distances_[j][i] = dist;
+    for (int i = 0; i < count; i++) {
+        int row = substitutionSlot(characters[i]);
+        if (row < 0) continue;
+        for (int j = 0; j < count; j++) {
+            int column = substitutionSlot(characters[j]);
+            if (column < 0) continue;
+            distances_[row][column] = distances[i * count + j];
         }
     }
-}
-
-void ProximityMap::buildQWERTY() {
-    // QWERTY key positions
-    // Row 0 (y=0): q w e r t y u i o p
-    // Row 1 (y=1): a s d f g h j k l  (offset 0.25)
-    // Row 2 (y=2): z x c v b n m      (offset 0.75)
-
-    float positions[26][2];
-    std::memset(positions, 0, sizeof(positions));
-
-    auto set = [&](char c, float x, float y) {
-        positions[c - 'a'][0] = x;
-        positions[c - 'a'][1] = y;
-    };
-
-    // Row 0
-    set('q', 0.0f, 0.0f);
-    set('w', 1.0f, 0.0f);
-    set('e', 2.0f, 0.0f);
-    set('r', 3.0f, 0.0f);
-    set('t', 4.0f, 0.0f);
-    set('y', 5.0f, 0.0f);
-    set('u', 6.0f, 0.0f);
-    set('i', 7.0f, 0.0f);
-    set('o', 8.0f, 0.0f);
-    set('p', 9.0f, 0.0f);
-
-    // Row 1 (offset 0.25)
-    set('a', 0.25f, 1.0f);
-    set('s', 1.25f, 1.0f);
-    set('d', 2.25f, 1.0f);
-    set('f', 3.25f, 1.0f);
-    set('g', 4.25f, 1.0f);
-    set('h', 5.25f, 1.0f);
-    set('j', 6.25f, 1.0f);
-    set('k', 7.25f, 1.0f);
-    set('l', 8.25f, 1.0f);
-
-    // Row 2 (offset 0.75)
-    set('z', 0.75f, 2.0f);
-    set('x', 1.75f, 2.0f);
-    set('c', 2.75f, 2.0f);
-    set('v', 3.75f, 2.0f);
-    set('b', 4.75f, 2.0f);
-    set('n', 5.75f, 2.0f);
-    set('m', 6.75f, 2.0f);
-
-    // Compute distances: min(1.0, euclidean / 2.5)
-    for (int i = 0; i < 26; i++) {
-        for (int j = i; j < 26; j++) {
-            if (i == j) {
-                distances_[i][j] = 0.0f;
-                continue;
-            }
-            float dx = positions[i][0] - positions[j][0];
-            float dy = positions[i][1] - positions[j][1];
-            float dist = std::sqrt(dx * dx + dy * dy) / 2.5f;
-            if (dist > 1.0f) dist = 1.0f;
-            distances_[i][j] = dist;
-            distances_[j][i] = dist;
-        }
-    }
+    return true;
 }
 
 float ProximityMap::cost(uint16_t a, uint16_t b) const {
-    // Lowercase
-    if (a >= 'A' && a <= 'Z') a = a - 'A' + 'a';
-    if (b >= 'A' && b <= 'Z') b = b - 'A' + 'a';
-
-    if (a >= 'a' && a <= 'z' && b >= 'a' && b <= 'z') {
-        return distances_[a - 'a'][b - 'a'];
-    }
-    return 1.0f;
+    int slotA = substitutionSlot(a);
+    int slotB = substitutionSlot(b);
+    if (slotA < 0 || slotB < 0) return 1.0f;
+    return distances_[slotA][slotB];
 }
 
 } // namespace dictus

--- a/DictusKeyboard/Vendored/AOSPTrie/src/dictus_scorer.cpp
+++ b/DictusKeyboard/Vendored/AOSPTrie/src/dictus_scorer.cpp
@@ -9,34 +9,40 @@
 
 namespace dictus {
 
-// --- Accent cost tables ---
+// --- Accent cost table ---
 
-static uint16_t accentBase(uint16_t c) {
-    switch (c) {
-        case 0x00E9: case 0x00E8: case 0x00EA: case 0x00EB: return 'e';
-        case 0x00E0: case 0x00E2: return 'a';
-        case 0x00F9: case 0x00FB: return 'u';
-        case 0x00F4: return 'o';
-        case 0x00EE: case 0x00EF: return 'i';
-        case 0x00E7: return 'c';
-        default: return 0;
+AccentCostTable::AccentCostTable() {
+    reset();
+}
+
+void AccentCostTable::reset() {
+    for (int i = 0; i < SUBSTITUTION_SLOT_COUNT; i++) {
+        for (int j = 0; j < SUBSTITUTION_SLOT_COUNT; j++) {
+            costs_[i][j] = (i == j) ? 0.0f : -1.0f;
+        }
     }
 }
 
-float Scorer::accentCost(uint16_t from, uint16_t to) {
-    if (from == to) return 0.0f;
+bool AccentCostTable::setPairs(const uint16_t* from, const uint16_t* to,
+                               const float* costs, int count) {
+    if (!from || !to || !costs || count <= 0) return false;
 
-    uint16_t baseFrom = accentBase(from);
-    uint16_t baseTo = accentBase(to);
+    reset();
 
-    // Base letter to its accent variant = 0.15
-    if (baseFrom == 0 && from >= 'a' && from <= 'z' && baseTo == from) return 0.15f;
-    if (baseTo == 0 && to >= 'a' && to <= 'z' && baseFrom == to) return 0.15f;
+    for (int i = 0; i < count; i++) {
+        int row = substitutionSlot(from[i]);
+        int column = substitutionSlot(to[i]);
+        if (row < 0 || column < 0) continue;
+        costs_[row][column] = costs[i];
+    }
+    return true;
+}
 
-    // Accent to different accent of same base = 0.2
-    if (baseFrom != 0 && baseTo != 0 && baseFrom == baseTo) return 0.2f;
-
-    return -1.0f;
+float AccentCostTable::cost(uint16_t from, uint16_t to) const {
+    int row = substitutionSlot(from);
+    int column = substitutionSlot(to);
+    if (row < 0 || column < 0) return -1.0f;
+    return costs_[row][column];
 }
 
 // --- UTF-16 to UTF-8 ---
@@ -63,10 +69,14 @@ static void utf16ToUtf8(const uint16_t* src, int srcLen, char* dst, int dstSize)
 
 // --- Scorer ---
 
-Scorer::Scorer() : proximityMap_(nullptr) {}
+Scorer::Scorer() : proximityMap_(nullptr), accentCostTable_(nullptr) {}
 
 void Scorer::setProximityMap(const ProximityMap* map) {
     proximityMap_ = map;
+}
+
+void Scorer::setAccentCostTable(const AccentCostTable* table) {
+    accentCostTable_ = table;
 }
 
 // Compute node byte size for sibling iteration.
@@ -89,11 +99,22 @@ static void insertCandidate(std::vector<Candidate>& results, const Candidate& c,
     if (static_cast<int>(results.size()) > maxResults) results.pop_back();
 }
 
+// The two cost tables the traversal consults, bundled so the recursion carries one
+// parameter instead of two.
+struct CostModel {
+    const ProximityMap* proximity;
+    const AccentCostTable* accents;
+};
+
 // Get substitution cost between two characters.
-static float substitutionCost(uint16_t from, uint16_t to, const ProximityMap* proxMap) {
-    float ac = Scorer::accentCost(from, to);
-    if (ac >= 0.0f) return ac;
-    if (proxMap) return std::max(0.2f, proxMap->cost(from, to));
+// Accent relation first: an accent slip is cheaper than any keyboard near miss, and on a
+// layout where the accented key exists it would otherwise be scored by geometry alone.
+static float substitutionCost(uint16_t from, uint16_t to, const CostModel& costs) {
+    if (costs.accents) {
+        float ac = costs.accents->cost(from, to);
+        if (ac >= 0.0f) return ac;
+    }
+    if (costs.proximity) return std::max(0.2f, costs.proximity->cost(from, to));
     return 1.0f;
 }
 
@@ -106,7 +127,7 @@ static void searchRecursive(const Trie& trie,
                             uint16_t* wordBuf, int wordLen,
                             float cost, float maxEditDist,
                             std::vector<Candidate>& results, int maxResults,
-                            const ProximityMap* proxMap,
+                            const CostModel& costs,
                             int nodeCharPos) {
     if (cost > maxEditDist) return;
 
@@ -122,17 +143,17 @@ static void searchRecursive(const Trie& trie,
             wordBuf[wordLen] = trieChar;
             searchRecursive(trie, node, input, inputLen, inputPos + 1,
                             wordBuf, wordLen + 1, cost, maxEditDist,
-                            results, maxResults, proxMap, nodeCharPos + 1);
+                            results, maxResults, costs, nodeCharPos + 1);
         }
 
         // 2. SUBSTITUTION: input char != trie char
         if (inputPos < inputLen && input[inputPos] != trieChar) {
-            float sc = substitutionCost(input[inputPos], trieChar, proxMap);
+            float sc = substitutionCost(input[inputPos], trieChar, costs);
             if (cost + sc <= maxEditDist) {
                 wordBuf[wordLen] = trieChar;
                 searchRecursive(trie, node, input, inputLen, inputPos + 1,
                                 wordBuf, wordLen + 1, cost + sc, maxEditDist,
-                                results, maxResults, proxMap, nodeCharPos + 1);
+                                results, maxResults, costs, nodeCharPos + 1);
             }
         }
 
@@ -142,7 +163,7 @@ static void searchRecursive(const Trie& trie,
             if (cost + ic <= maxEditDist) {
                 searchRecursive(trie, node, input, inputLen, inputPos + 1,
                                 wordBuf, wordLen, cost + ic, maxEditDist,
-                                results, maxResults, proxMap, nodeCharPos);
+                                results, maxResults, costs, nodeCharPos);
             }
         }
 
@@ -153,7 +174,7 @@ static void searchRecursive(const Trie& trie,
                 wordBuf[wordLen] = trieChar;
                 searchRecursive(trie, node, input, inputLen, inputPos,
                                 wordBuf, wordLen + 1, cost + dc, maxEditDist,
-                                results, maxResults, proxMap, nodeCharPos + 1);
+                                results, maxResults, costs, nodeCharPos + 1);
             }
         }
 
@@ -168,7 +189,7 @@ static void searchRecursive(const Trie& trie,
                     wordBuf[wordLen + 1] = nextTrieChar;
                     searchRecursive(trie, node, input, inputLen, inputPos + 2,
                                     wordBuf, wordLen + 2, cost + tc, maxEditDist,
-                                    results, maxResults, proxMap, nodeCharPos + 2);
+                                    results, maxResults, costs, nodeCharPos + 2);
                 }
             }
         }
@@ -205,7 +226,7 @@ static void searchRecursive(const Trie& trie,
 
             searchRecursive(trie, child, input, inputLen, inputPos,
                             wordBuf, wordLen, cost, maxEditDist,
-                            results, maxResults, proxMap, 0);
+                            results, maxResults, costs, 0);
 
             childOff += computeNodeSize(child);
         }
@@ -220,6 +241,7 @@ std::vector<Candidate> Scorer::correct(const Trie& trie,
     if (inputLen <= 0 || !trie.rootData()) return results;
 
     uint16_t wordBuf[128];
+    CostModel costs{proximityMap_, accentCostTable_};
 
     // Root children start at HEADER_SIZE with known count from header.
     uint32_t offset = HEADER_SIZE;
@@ -230,7 +252,7 @@ std::vector<Candidate> Scorer::correct(const Trie& trie,
 
         searchRecursive(trie, node, input, inputLen, 0,
                         wordBuf, 0, 0.0f, maxEditDist,
-                        results, maxResults, proximityMap_, 0);
+                        results, maxResults, costs, 0);
 
         offset += computeNodeSize(node);
     }

--- a/DictusKeyboard/Vendored/AOSPTrie/src/dictus_scorer.cpp
+++ b/DictusKeyboard/Vendored/AOSPTrie/src/dictus_scorer.cpp
@@ -39,6 +39,12 @@ bool AccentCostTable::setPairs(const uint16_t* from, const uint16_t* to,
 }
 
 float AccentCostTable::cost(uint16_t from, uint16_t to) const {
+    // A character is free to substitute for itself even when it has no slot -- the
+    // contract this table inherited from the accentCost() it replaced. The scorer never
+    // asks (it only substitutes differing characters), but keeping it makes the answer
+    // for every pair identical to the pre-#321 one outside the umlauts.
+    if (from == to) return 0.0f;
+
     int row = substitutionSlot(from);
     int column = substitutionSlot(to);
     if (row < 0 || column < 0) return -1.0f;


### PR DESCRIPTION
## What this was for

German autocorrect could not reason about ä, ö and ü. Both mechanisms that make typo
correction work were blind to them: the accent-cost table had no German entries, so `uber`
and `über` were as unrelated to the scorer as `uber` and `xber`; and the proximity map was
26 ASCII letters *by construction* (`float[26][26]` indexed by `c - 'a'`), so QWERTZ's three
umlaut keys had nowhere to sit at all. A German typist got correction on the ASCII part of
their language and nothing on the part that makes it German — the mechanism behind the
complaint that opened German support in #109.

`refs #321`

## To test by hand

Everything below is device-only: a simulator cannot activate a keyboard extension, and no
trie can run in `swift test`. Steps 4–10 are the ones nothing automated can settle.

1. Install this branch on the iPhone (Xcode run, or the build + `devicectl` route).
2. In DictusApp → Settings, set the dictionary language to **Deutsch** and the keyboard
   layout to **QWERTZ** explicitly. (Selecting German does not rewrite a layout already
   stored, so set it in the picker.) Expect the top row to end with `ü` and the home row
   with `ö ä`.
3. Force the extension to reload its dictionary: switch to another keyboard with the globe
   and back, or kill and relaunch the host app. The cost tables are installed when the
   dictionary loads, so a layout change made while the extension is alive does not take
   effect until then. That timing is pre-existing, not introduced here — but it will make a
   test look like a failure if skipped.
4. Type `uber` then space. Expect `über` offered in the suggestion bar (before this change
   the two spellings were unrelated words to the scorer).
5. Type `fuer` then space. Expect `für`.
6. Type `schoen` then space. Expect `schön`.
7. **Control step — ß must not have changed.** Type `strasse` then space. Expect `straße`
   exactly as it behaves on `develop` today: this PR deliberately left ß out of the accent
   relation, and `germanProfile.collapseRules` still owns that case.
8. **Mistype each umlaut key against its physical neighbour.** Type `supüe` (ü hit instead
   of the second p) — expect `Suppe`. Type `aöso` (ö instead of l) — expect `also`. Type
   `schän` (ä instead of ö) — expect `schön`.
   These three are predictions from the cost model, not verified outputs: the model now
   scores each of those substitutions at 0.36 instead of 1.0, but whether the intended word
   wins the candidate list also depends on dictionary frequencies, which only the device can
   show. If one of them offers something else, that is data worth pasting back, not
   necessarily a bug in this PR.
9. **The other half of the fix, on QWERTY.** Switch the layout to QWERTY, keeping German,
   reload as in step 3, and type `uber` again. Expect `über` still offered: on a layout with
   no umlaut key the accent relation carries the case on its own, which is why the two gaps
   were fixed independently.
10. **French regression pass** (the human half of the no-regression criterion). Switch to
    Français / AZERTY, reload, and check a handful of familiar corrections behave exactly as
    before: `tres` → `très`, `deja` → `déjà`, `ca` → `ça`, and one ordinary proximity typo
    such as `bonjoir` → `bonjour`. Nothing here should have moved; the executed evidence
    below says it did not, but this is the check that costs nothing and would catch a
    surprise.

## What changed and why

**The split:** DictusCore owns the tables, the C++ owns the traversal. Both tables are
computed once per dictionary load, never in the scoring loop, so moving their computation
into Swift costs nothing at runtime and buys the only executable coverage this repo has.
Moving the hot loop was explicitly not wanted and did not happen.

- **New `DictusCore/.../TextCorrection/AccentRelation.swift`** — the accented-to-base
  letter map with ä/ö/ü added, the two cost constants (0.15 base↔accent, 0.20
  accent↔accent), and the ~60 ordered pairs the scorer consumes. The three-case precedence
  exists here only, so the C++ holds no rules of its own to drift.
- **New `DictusCore/.../TextCorrection/KeyboardProximity.swift`** — key geometry for all
  three layouts plus the `min(1, hypot / 2.5)` formula, producing the finished pairwise
  table. QWERTZ's sequence is read from `QWERTZLayout.lowercasedLettersRows` and QWERTY's
  from `QWERTYLayout.lettersRows`, so the proximity model cannot drift from what renders.
  AZERTY's rows are declared locally because AZERTY row data lives in the keyboard target,
  and moving it is a layout refactor this issue must not attempt.
- **`ProximityMap` (C++)** keeps its name and its job but drops the `[26][26]` storage for a
  slot map covering a-z plus the lowercase Latin-1 supplement — where every accented key of
  every layout Dictus ships lives. `buildAZERTY()`/`buildQWERTY()` are deleted: the geometry
  has one home now.
- **`AccentCostTable` (C++, in the existing scorer files)** replaces the `accentBase` switch
  and `Scorer::accentCost`. Adding it to `dictus_scorer.h`/`.cpp` rather than new files also
  means no new `project.pbxproj` references were needed.
- **The layout dispatch is now a real three-way.** QWERTZ no longer borrows the QWERTY
  table, where y and z sit in each other's places — that inversion is fixed as a side effect.
- **Geometry decision:** QWERTZ rows 0 and 1 carry 11 keys in the rendered width of a
  10-key row, so their keys are 10/11 of a unit and every key on those rows shifts left.
  That is the geometry shift the issue asked to model. Row 2 keeps the same 0.75 offset the
  other two layouts use, so the three stay comparable. AZERTY and QWERTY coordinates are
  ported verbatim.
- **ß decision, written at the declaration site** (`AccentRelation.baseLetters`), restated
  in `dictus_scorer.h` and CONTEXT.md: **ß stays out of the accent relation.** Its relation
  to `ss` is one-to-two and this path models one-to-one substitution only. Mapping ß → s
  would make the relation *look* handled while `heisst` → `heißt` still needs a deletion the
  accent path cannot supply, and would make `s` → `ß` cheap everywhere in a language whose
  most frequent consonant is `s` — an over-correction risk for a case it would not fix. The
  `ss` → `ß` relation is modelled where a length change can be expressed:
  `germanProfile.collapseRules`.

## Acceptance criteria: what is executed and what is not

No criterion below is ticked on the strength of a build.

| # | Criterion | Status | Evidence |
|---|---|---|---|
| 1 | ä/ö/ü related to a/o/u in the accent-cost path, both directions | **Executed** | `AccentRelationTests` (16 tests, green). C++ lookup printed `u→ü 0.15`, `ü→u 0.15`, `o→ö 0.15`, `a→ä 0.15` |
| 2 | The ß decision written down at the call site | **Executed** + documented | `testEszettIsNotAnAccentOfS`, `testEszettIsCoveredByTheGermanCollapseRules`; C++ printed `ß→s -1.00`, `s→ß -1.00` |
| 3 | The three QWERTZ keys have positions; ü/p materially lower than ü/far key | **Executed** | `KeyboardProximityTests` (20 tests). C++ lookup: `cost(ü,p) = 0.363636`, `cost(ü,q) = 1.000000`; also `cost(ö,l) = 0.363636`, `cost(ä,ö) = 0.363636` |
| 4 | French/Spanish relations unchanged, AZERTY/QWERTY distances unchanged | **Executed**, old-vs-new | See "the no-regression check" below |
| 5 | Every table moved into DictusCore covered by tests there | **Executed** | 36 new tests across the two new files |
| 6 | `swiftlint lint --strict` clean, `swift test` green | **Executed** | `Found 0 violations, 0 serious in 170 files`; `Executed 770 tests, with 1 test skipped and 0 failures` |
| 7 | PR states executed vs compiled-only | Done | this section |
| 8 | PR carries the device list | Done | "To test by hand" above |

### The no-regression check (criterion 4)

Rather than trusting that the ported geometry produces the same numbers, the pre-#321 C++
tables were compiled alongside the post-#321 ones and diffed pair by pair:

```
azerty: 676 a-z pairs compared, 0 moved (largest delta 0.000000060)
qwerty: 676 a-z pairs compared, 0 moved (largest delta 0.000000060)
accents: 90 x 90 pairs swept, 16 changed, 16 of them gained a relation,
         0 changed that do not involve an umlaut
NO REGRESSION
```

The 16 changed pairs are exactly the umlaut relations this issue asks for (6 for ä, 4 for ö,
6 for ü, counting both directions and the accent-to-accent pairs). The AZERTY/QWERTY deltas
are float noise at 6e-8, not movement.

That check also **found two unintended changes** which are now fixed in
`59f26e4` — see "What I am not comfortable with" below.

A second harness verified that the C++ lookup returns exactly what the DictusCore tables
say, for every pair of every layout:

```
azerty: 26 keys, 676/676 pairs match the Swift table
qwerty: 26 keys, 676/676 pairs match the Swift table
qwertz: 29 keys, 841/841 pairs match the Swift table
accents: 58 pairs, 58 match the Swift table
PARITY OK
```

### Covered only by compilation plus the device list

- **That the scorer's candidate ranking changes as intended on real input** (`uber` → `über`
  surfacing as the top suggestion). The cost model is proven; whether the intended word wins
  the candidate list also depends on dictionary frequencies, and no trie can be loaded in
  `swift test`. Device steps 4–9.
- **That the extension installs the tables at runtime** — the bridge call path from
  `AOSPTrieEngine.load` through `NSData` into the C++. Compilation plus device steps 4–10.
- **Both harnesses above are scratchpad-only and not committed.** They are evidence about
  this branch, not a standing regression gate. Making the parity check permanent would mean
  committing a Swift dumper executable plus a C++ test binary that nothing in CI would run
  (CI runs SwiftLint and a build, never the tests) — worth its own issue, not a silent
  addition here.

Build: `** BUILD SUCCEEDED **` for `DictusApp` on `generic/platform=iOS Simulator`, which
builds all three targets (`DictusApp.app`, `DictusKeyboard.appex`, `DictusCore`). The two
remaining C++ warnings are pre-existing in `dictus_trie_format.h`, untouched here.

## What contradicted the issue, and what I am not comfortable with

- **The issue says the accent table "covers French and Spanish". It does not cover Spanish.**
  á, í, ó, ú and ñ are absent from the map, exactly like the umlauts were — Spanish has the
  same bug German had. Adding them was out of scope (criterion 4 requires Spanish relations
  unchanged) so they were deliberately left out, and a test now pins their absence so the
  next reader sees it is a known gap rather than an oversight. **This deserves its own
  issue.**
- **The old-vs-new diff caught two changes that had nothing to do with German**, both mine,
  both now reverted in `59f26e4`: the shared slot map folded Latin-1 uppercase (newly
  relating `É` to `e` — a French behaviour change smuggled in by a German fix), and the new
  accent lookup had lost the `from == to` short-circuit the old one had. Neither is reachable
  from the scorer today, which is precisely why they would have shipped unnoticed. Worth
  naming because it is the argument for having built that diff at all.
- **The proximity table is installed at dictionary load**, so changing the keyboard layout
  while the extension is alive leaves the previous layout's geometry in place until the
  dictionary reloads. Pre-existing (the old `setProximityMap*` calls sat in the same place)
  and out of scope, but #272 is about to make layout changes more frequent, so it is worth
  knowing. It is also why device step 3 exists.
- **The QWERTZ row-2 offset is the shakiest judgement call in here.** Modelled at 0.75 like
  the other layouts, which under-states the shift/delete keys flanking that row — true of
  all three layouts, so at least they stay comparable. Re-deriving all three from rendered
  geometry would be more accurate and would move AZERTY/QWERTY results, which criterion 4
  forbids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McjofNoZAc33EtyW8Gvoaw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved text correction for AZERTY, QWERTY, and QWERTZ keyboard layouts.
  - Added more accurate handling of French, Spanish, and German accent substitutions.
  - Added support for layout-specific keyboard proximity and accent-cost data.

- **Bug Fixes**
  - Improved correction behavior for accented characters and nearby-key substitutions.
  - Added safer fallback handling for unsupported characters and invalid correction data.

- **Documentation**
  - Added documentation describing keyboard proximity and accent relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->