### PR TITLE
Decouple the keyboard layout from the dictionary language (refs #272)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,7 +20,7 @@ Per-language **must-correct** map: input → forced correction, applied before e
 Per-language map from base letter to accented variants used by `accentExpansion()` to attempt accent insertions when a typed word isn't in the dictionary. Generative, not curated — you list which accents *could* apply to which letters, then the algorithm tries them and picks the highest-frequency hit.
 
 ### Adaptive accent key
-A French-specific feature of the AZERTY layout: the apostrophe/accent key on row 3 changes its label based on context (shows `é` after `e`, apostrophe after `qu`, etc.). **Not generalized to other languages.** Lives in `DictusCore/Languages/French.swift`. Other languages reach accents via standard long-press popups.
+A French-specific feature of the AZERTY layout: the apostrophe/accent key on row 3 changes its label based on context (shows `é` after `e`, apostrophe after `qu`, etc.). **Not generalized to other languages.** Lives in `FrenchAdaptiveKey` (`DictusCore/AccentedCharacters.swift`). Since #272 the layout no longer implies the language, so the key checks the active language and behaves as a plain apostrophe outside French. Other languages reach accents via standard long-press popups, as does French on a non-AZERTY layout — those grids have no adaptive key slot.
 
 ### Seed bigrams
 Hand-curated word pairs injected into the n-gram corpus by `tools/ngram_builder.py` to compensate for underrepresentation in encyclopedic sources (Wikipedia, Google Books). Required for splitting compound input like `pasmal → pas mal`. Per-language list in `SEED_BIGRAMS_BY_LANG`. Policy: empty for new languages onboarded by non-native maintainers; populated post-launch from native-speaker contributions. See ADR 0001.
@@ -62,7 +62,10 @@ A polish backend conforming to `PolishEngineProtocol` (in DictusCore). One imple
 ## Keyboard
 
 ### Layout type
-The physical key arrangement: `LayoutType.azerty` (French), `LayoutType.qwerty` (English, Spanish) or `LayoutType.qwertz` (German, #151). Each `SupportedLanguage` declares its `defaultLayout`, which seeds the layout when that language is *selected* and never rewrites a layout already stored. Layout is global today (one active at a time), not per-language; per-language layout selection is tracked in issue #52, and decoupling layout from dictionary language in #272.
+The physical key arrangement: `LayoutType.azerty` (French), `LayoutType.qwerty` (English, Spanish) or `LayoutType.qwertz` (German, #151). **Per dictionary language since #272**: each `SupportedLanguage` stores its own layout, so French→AZERTY and English→QWERTY are remembered independently and selecting a language no longer reshapes the keyboard. `LayoutType.active` is the layout of the active language; `KeyboardLayoutPreference` owns the storage.
+
+### Inherited vs explicit layout
+A language with no stored layout is **inherited**: it resolves to `SupportedLanguage.defaultLayout` and keeps tracking it, so shipping a new default (QWERTZ for German, #151) reaches users who never expressed a preference. Picking a layout for that language — in Settings or on the keyboard panel's layout pills — makes it **explicit**, and `defaultLayout` stops applying to it. `defaultLayout` is therefore a seed, not a rule.
 
 QWERTZ carries dedicated ä/ö/ü keys, which makes its first two rows 11 units wide against 10 for every other row in every layout. The renderer normalizes each row against its own unit total, so those rows draw narrower keys. Row data lives in `DictusCore/KeyboardLayoutData.swift`; `DictusKeyboard/KeyboardLayouts.swift` builds the keys from it.
 

--- a/DictusApp/DictusApp.swift
+++ b/DictusApp/DictusApp.swift
@@ -90,6 +90,13 @@ struct DictusApp: App {
         if defaults?.string(forKey: SharedKeys.language) == nil {
             defaults?.set("fr", forKey: SharedKeys.language)
         }
+        // Freeze the layout an updating install is already typing on, before anything can
+        // change the active language (#272). The migration is idempotent and also runs from
+        // the first layout read in either process — the keyboard extension can run before
+        // this app is ever launched again — so this call is only about doing it as early as
+        // possible on the app side.
+        KeyboardLayoutPreference.migrateToPerLanguageLayoutsIfNeeded()
+
         // Register liveActivityEnabled default as true for existing users.
         // WHY: UserDefaults.bool(forKey:) returns false for missing keys.
         // Without this, existing users upgrading would see Live Activity disabled.

--- a/DictusApp/Localizable.xcstrings
+++ b/DictusApp/Localizable.xcstrings
@@ -2186,6 +2186,17 @@
         }
       }
     },
+    "The layout is saved for each keyboard language." : {
+      "comment" : "Settings footer: the Layout picker applies to the keyboard language selected above it (issue #272).",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La disposition est enregistrée pour chaque langue du clavier."
+          }
+        }
+      }
+    },
     "The keyboard will be detected automatically" : {
       "localizations" : {
         "fr" : {

--- a/DictusApp/Localizable.xcstrings
+++ b/DictusApp/Localizable.xcstrings
@@ -2186,17 +2186,6 @@
         }
       }
     },
-    "The layout is saved for each keyboard language." : {
-      "comment" : "Settings footer: the Layout picker applies to the keyboard language selected above it (issue #272).",
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La disposition est enregistrée pour chaque langue du clavier."
-          }
-        }
-      }
-    },
     "The keyboard will be detected automatically" : {
       "localizations" : {
         "fr" : {

--- a/DictusApp/Views/SettingsView.swift
+++ b/DictusApp/Views/SettingsView.swift
@@ -260,13 +260,8 @@ struct SettingsView: View {
             } header: {
                 Text("Keyboard")
             } footer: {
-                VStack(alignment: .leading, spacing: 4) {
-                    // Without this the picker looks global, and a user who sets a layout
-                    // for one language would expect to find it on the next one (#272).
-                    Text("The layout is saved for each keyboard language.")
-                    if !liveActivityEnabled {
-                        Text("Dynamic Island and Lock Screen notification are disabled.")
-                    }
+                if !liveActivityEnabled {
+                    Text("Dynamic Island and Lock Screen notification are disabled.")
                 }
             }
 

--- a/DictusApp/Views/SettingsView.swift
+++ b/DictusApp/Views/SettingsView.swift
@@ -30,8 +30,13 @@ struct SettingsView: View {
     @AppStorage(SharedKeys.transcriptionLanguage, store: UserDefaults(suiteName: AppGroup.identifier))
     private var transcriptionLanguage = TranscriptionLanguageMode.followStoredValue
 
-    @AppStorage(SharedKeys.keyboardLayout, store: UserDefaults(suiteName: AppGroup.identifier))
-    private var keyboardLayout = "azerty"
+    /// Bumped whenever the Layout picker writes, to re-evaluate the body.
+    ///
+    /// WHY not @AppStorage like every other preference here: since #272 the layout is
+    /// stored per keyboard language (`KeyboardLayoutPreference`), so there is no single
+    /// key for @AppStorage to observe — the value the picker shows depends on the
+    /// language selected in the row above it.
+    @State private var layoutRevision = 0
 
     @AppStorage(SharedKeys.hapticsEnabled, store: UserDefaults(suiteName: AppGroup.identifier))
     private var hapticsEnabled = true
@@ -58,6 +63,32 @@ struct SettingsView: View {
     @AppStorage(SharedKeys.autocorrectDebugLogging, store: UserDefaults(suiteName: AppGroup.identifier))
     private var autocorrectDebugLogging = false
     #endif
+
+    /// The keyboard language the pickers below operate on.
+    private var keyboardLanguage: SupportedLanguage {
+        SupportedLanguage(rawValue: language) ?? .french
+    }
+
+    /// The Layout picker's selection: the layout of whichever keyboard language is
+    /// currently selected above it (#272).
+    ///
+    /// The getter reads `layoutRevision` so a write re-renders the picker; the setter is
+    /// the only thing that records an explicit layout from this screen. Changing the
+    /// *language* runs neither — which is the whole point, the language no longer
+    /// overwrites the layout.
+    private var layoutSelection: Binding<LayoutType> {
+        let selectedLanguage = keyboardLanguage
+        return Binding(
+            get: {
+                _ = layoutRevision
+                return KeyboardLayoutPreference.layout(for: selectedLanguage)
+            },
+            set: { newLayout in
+                KeyboardLayoutPreference.setLayout(newLayout, for: selectedLanguage)
+                layoutRevision += 1
+            }
+        )
+    }
 
     /// Whether the currently active model uses the Parakeet engine (CTC/TDT).
     /// Parakeet auto-detects language — the language picker has no effect on it.
@@ -165,21 +196,27 @@ struct SettingsView: View {
                     }
                 }
                 .onChange(of: language) { _, newLang in
-                    // Auto-switch keyboard layout to the language's default.
-                    // French -> AZERTY, English/Spanish -> QWERTY, German -> QWERTZ.
+                    // The layout is NOT touched here anymore (#272): it belongs to the
+                    // language being selected, and overwriting it is what made "English
+                    // autocorrect on an AZERTY keyboard" unreachable. The Layout picker
+                    // below now shows the new language's own layout instead.
+                    //
+                    // Routing through activate() keeps the legacy mirror in step — the
+                    // @AppStorage write above has already stored the language, so this
+                    // only adds the mirror.
                     if let lang = SupportedLanguage(rawValue: newLang) {
-                        keyboardLayout = lang.defaultLayout.rawValue
+                        SupportedLanguage.activate(lang)
                     }
                 }
 
                 DefaultLayerPicker()
 
-                Picker("Layout", selection: $keyboardLayout) {
+                Picker("Layout", selection: layoutSelection) {
                     // Iterate over LayoutType so adding a layout (QWERTZ in #151,
                     // any future one) only requires the enum case — the entries used
                     // to be hardcoded here and in the keyboard panel separately.
-                    ForEach(LayoutType.allCases, id: \.rawValue) { layout in
-                        Text(layout.displayName).tag(layout.rawValue)
+                    ForEach(LayoutType.allCases, id: \.self) { layout in
+                        Text(layout.displayName).tag(layout)
                     }
                 }
 
@@ -223,8 +260,13 @@ struct SettingsView: View {
             } header: {
                 Text("Keyboard")
             } footer: {
-                if !liveActivityEnabled {
-                    Text("Dynamic Island and Lock Screen notification are disabled.")
+                VStack(alignment: .leading, spacing: 4) {
+                    // Without this the picker looks global, and a user who sets a layout
+                    // for one language would expect to find it on the next one (#272).
+                    Text("The layout is saved for each keyboard language.")
+                    if !liveActivityEnabled {
+                        Text("Dynamic Island and Lock Screen notification are disabled.")
+                    }
                 }
             }
 

--- a/DictusCore/Sources/DictusCore/AccentedCharacters.swift
+++ b/DictusCore/Sources/DictusCore/AccentedCharacters.swift
@@ -53,6 +53,16 @@ public enum AccentedCharacters {
 /// `"'"` with `alternate: "accent"`. `DictusKeyboardBridge` calls into this
 /// namespace on each keystroke to decide what label the key should display
 /// and what action it should take when tapped.
+///
+/// WHY every entry point takes a language (#272):
+/// the key used to trigger purely off its physical presence on the AZERTY grid, with no
+/// language check at all. That was harmless while AZERTY implied French. Now that the
+/// layout is decoupled from the dictionary language, English/Spanish/German on AZERTY are
+/// reachable combinations, and French adaptive accents on those keyboards would be wrong —
+/// so outside French the key behaves as the plain apostrophe it is labelled with.
+/// French on QWERTY is not the mirror problem: that grid has no adaptive key slot at all,
+/// and those users reach accents through the standard long-press popups, which already
+/// carry the French set.
 public enum FrenchAdaptiveKey {
 
     /// Default accent per vowel (most common in French).
@@ -79,7 +89,15 @@ public enum FrenchAdaptiveKey {
     /// In French, the apostrophe is the most common non-letter character after space.
     /// It appears in "l'", "d'", "n'", "j'", "c'", "s'" etc. Having it one tap away
     /// on the letters layer eliminates the 3-tap layer switch otherwise needed.
-    public static func label(afterTyping lastChar: String?, precedingChar: String? = nil) -> String {
+    ///
+    /// - Parameter language: the active keyboard language by default; outside French the
+    ///   key is a plain apostrophe (#272).
+    public static func label(
+        afterTyping lastChar: String?,
+        precedingChar: String? = nil,
+        language: SupportedLanguage = .active
+    ) -> String {
+        guard language == .french else { return "'" }
         guard let lastChar = lastChar else { return "'" }
         let lowered = lastChar.lowercased()
 
@@ -102,7 +120,13 @@ public enum FrenchAdaptiveKey {
     /// Returns true if the adaptive key should replace the previous character
     /// (i.e., when the key is showing an accent for a vowel, not apostrophe).
     /// Used by the bridge to call `deleteBackward()` before inserting the accent.
-    public static func shouldReplace(afterTyping lastChar: String?, precedingChar: String? = nil) -> Bool {
+    /// Never replaces anything outside French, where the key inserts an apostrophe (#272).
+    public static func shouldReplace(
+        afterTyping lastChar: String?,
+        precedingChar: String? = nil,
+        language: SupportedLanguage = .active
+    ) -> Bool {
+        guard language == .french else { return false }
         guard let lastChar = lastChar?.lowercased() else { return false }
         if let prev = precedingChar?.lowercased() {
             let bigram = prev + lastChar
@@ -115,8 +139,14 @@ public enum FrenchAdaptiveKey {
 
     /// Returns the base vowel that triggered the adaptive key's accent display.
     /// Used to determine which accent variants to show on long-press.
-    /// Returns nil when the adaptive key is showing apostrophe (no long-press popup needed).
-    public static func vowel(afterTyping lastChar: String?, precedingChar: String? = nil) -> String? {
+    /// Returns nil when the adaptive key is showing apostrophe (no long-press popup needed),
+    /// which is every keystroke outside French (#272).
+    public static func vowel(
+        afterTyping lastChar: String?,
+        precedingChar: String? = nil,
+        language: SupportedLanguage = .active
+    ) -> String? {
+        guard language == .french else { return nil }
         guard let lastChar = lastChar?.lowercased() else { return nil }
         if let prev = precedingChar?.lowercased() {
             let bigram = prev + lastChar

--- a/DictusCore/Sources/DictusCore/KeyboardLayoutData.swift
+++ b/DictusCore/Sources/DictusCore/KeyboardLayoutData.swift
@@ -30,14 +30,14 @@ public enum LayoutType: String, Codable, Sendable, CaseIterable {
         }
     }
 
-    /// Reads the active layout from App Group UserDefaults, defaulting to AZERTY.
-    /// AZERTY is the default because Dictus targets French-speaking users.
+    /// The layout the keyboard is currently drawing: the active language's layout.
+    ///
+    /// Since #272 the layout is stored per dictionary language, so "the active layout" is a
+    /// resolution of two values rather than one stored string. Every consumer — the grid
+    /// builder, the trie's proximity map, the spacebar neighbours, the emoji picker — keeps
+    /// reading it here; only what backs it changed. See `KeyboardLayoutPreference`.
     public static var active: LayoutType {
-        guard let raw = AppGroup.defaults.string(forKey: SharedKeys.keyboardLayout),
-              let layout = LayoutType(rawValue: raw) else {
-            return .azerty
-        }
-        return layout
+        KeyboardLayoutPreference.layout(for: .active)
     }
 }
 

--- a/DictusCore/Sources/DictusCore/KeyboardLayoutPreference.swift
+++ b/DictusCore/Sources/DictusCore/KeyboardLayoutPreference.swift
@@ -1,0 +1,129 @@
+// DictusCore/Sources/DictusCore/KeyboardLayoutPreference.swift
+// Per-language keyboard layout storage: which layout each dictionary language uses,
+// and whether that value is the language's default or a choice the user made (#272).
+import Foundation
+
+/// Where the keyboard layout of each `SupportedLanguage` is stored and resolved.
+///
+/// WHY per language and not one global value (#272):
+/// picking a language used to write that language's `defaultLayout` on top of whatever
+/// the user had chosen, so "English autocorrect on the AZERTY my fingers know" was
+/// unreachable. A French/English bilingual needs French→AZERTY *and* English→QWERTY
+/// remembered independently, which one shared override cannot express.
+///
+/// WHY absence means inherited:
+/// a language with no stored entry resolves to `defaultLayout` and keeps tracking it —
+/// so shipping a new default (QWERTZ for German in #151) still reaches the users who
+/// never expressed a preference. Storing an entry stops that tracking for that language
+/// only. The distinction is the presence of the key, not a second flag that could drift
+/// out of step with the value.
+public enum KeyboardLayoutPreference {
+
+    // MARK: - Reading
+
+    /// The layout `language` types on: its explicit choice, or its default when it has none.
+    ///
+    /// This is the only resolution rule in the codebase — `LayoutType.active` is this
+    /// function applied to the active language.
+    public static func layout(for language: SupportedLanguage) -> LayoutType {
+        migrateToPerLanguageLayoutsIfNeeded()
+        return storedLayout(for: language) ?? language.defaultLayout
+    }
+
+    /// The layout the user explicitly chose for `language`, or nil when it still inherits
+    /// `defaultLayout`. UI that wants to distinguish the two reads this; UI that only
+    /// needs to know what the keys look like reads `layout(for:)`.
+    public static func explicitLayout(for language: SupportedLanguage) -> LayoutType? {
+        migrateToPerLanguageLayoutsIfNeeded()
+        return storedLayout(for: language)
+    }
+
+    /// True while `language` still follows `defaultLayout`.
+    public static func isInherited(for language: SupportedLanguage) -> Bool {
+        explicitLayout(for: language) == nil
+    }
+
+    // MARK: - Writing
+
+    /// Records `layout` as `language`'s explicit choice.
+    ///
+    /// WHY a pick equal to `defaultLayout` is still stored as explicit:
+    /// a German user who tries QWERTY and then taps QWERTZ back has chosen QWERTZ. If a
+    /// later release changed German's default, reshaping their keyboard under them would
+    /// break the same promise this issue exists to keep.
+    public static func setLayout(_ layout: LayoutType, for language: SupportedLanguage) {
+        migrateToPerLanguageLayoutsIfNeeded()
+
+        var layouts = storedLayouts()
+        layouts[language.rawValue] = layout.rawValue
+        AppGroup.defaults.set(layouts, forKey: SharedKeys.keyboardLayoutsByLanguage)
+
+        if language == .active {
+            mirrorToLegacyKey(layout)
+        }
+    }
+
+    // MARK: - Migration (#272)
+
+    /// Freezes the layout an existing install is already typing on, once, before the
+    /// per-language store is used for anything.
+    ///
+    /// The rule (spec §6): the **currently active language** keeps whatever layout value is
+    /// actually stored today, frozen as explicit — not recomputed from `defaultLayout`. The
+    /// pre-#272 Settings picker let a layout diverge from the active language's default until
+    /// the next language change, so a divergent pair may already sit in storage; recomputing
+    /// would silently reshape those keyboards. The other languages, never having had a visible
+    /// value, stay absent and therefore seed at their true `defaultLayout`.
+    ///
+    /// WHY the dictionary is written even when it stays empty:
+    /// its presence is the "already migrated" stamp. Without it, a fresh install that picks
+    /// German *after* updating would look, at the next read, exactly like an upgrade sitting
+    /// on German with no stored layout — and would be frozen to AZERTY.
+    ///
+    /// WHY it is lazy instead of a launch hook: both processes read layouts, and the keyboard
+    /// extension can run before DictusApp ever launches again. Every entry point calls this
+    /// first, so no write can precede the freeze.
+    public static func migrateToPerLanguageLayoutsIfNeeded() {
+        let defaults = AppGroup.defaults
+        guard defaults.dictionary(forKey: SharedKeys.keyboardLayoutsByLanguage) == nil else { return }
+
+        var frozen: [String: String] = [:]
+        let legacyRaw = defaults.string(forKey: SharedKeys.keyboardLayout)
+        // An install with something to preserve: it either stored a layout, or it has been
+        // through onboarding and so has been typing on the AZERTY fallback all along.
+        // A fresh install matches neither and stays fully inherited.
+        let hasShapeToPreserve = legacyRaw != nil || defaults.bool(forKey: SharedKeys.hasCompletedOnboarding)
+        if hasShapeToPreserve {
+            // The pre-#272 semantics of `LayoutType.active`, reproduced exactly: the stored
+            // raw value, AZERTY when it is missing or unreadable.
+            let effective = legacyRaw.flatMap(LayoutType.init(rawValue:)) ?? .azerty
+            frozen[SupportedLanguage.active.rawValue] = effective.rawValue
+        }
+        defaults.set(frozen, forKey: SharedKeys.keyboardLayoutsByLanguage)
+    }
+
+    // MARK: - Legacy mirror
+
+    /// Keeps `SharedKeys.keyboardLayout` equal to the active language's effective layout.
+    ///
+    /// Nothing reads that key anymore except migration. It is maintained for one reason:
+    /// a build without #272 (a rollback, or an older TestFlight install) reads it as the
+    /// single global layout, and must find the shape the user is actually on rather than
+    /// whatever they last had before the update.
+    static func mirrorToLegacyKey(_ layout: LayoutType) {
+        AppGroup.defaults.set(layout.rawValue, forKey: SharedKeys.keyboardLayout)
+    }
+
+    // MARK: - Private
+
+    private static func storedLayouts() -> [String: String] {
+        AppGroup.defaults.dictionary(forKey: SharedKeys.keyboardLayoutsByLanguage) as? [String: String] ?? [:]
+    }
+
+    private static func storedLayout(for language: SupportedLanguage) -> LayoutType? {
+        guard let raw = storedLayouts()[language.rawValue] else { return nil }
+        // An unreadable entry is treated as no entry: the language falls back to its
+        // default instead of to AZERTY, which is what a missing value has always meant.
+        return LayoutType(rawValue: raw)
+    }
+}

--- a/DictusCore/Sources/DictusCore/SharedKeys.swift
+++ b/DictusCore/Sources/DictusCore/SharedKeys.swift
@@ -21,8 +21,19 @@ public enum SharedKeys {
     public static let modelLoadState = "dictus.modelLoadState"
 
     // Keyboard-App cross-process contracts (added for Plan 3.1)
-    /// Current keyboard layout type stored as String ("azerty" or "qwerty")
+    /// Legacy single global keyboard layout, stored as String ("azerty"/"qwerty"/"qwertz").
+    /// Since #272 the layout is per dictionary language — see `keyboardLayoutsByLanguage`.
+    /// This key is now only *read* by the one-time migration, and kept up to date as a
+    /// mirror of the active language's layout so a rollback to a build without #272 finds
+    /// the shape the user is on. Nothing else should read or write it.
     public static let keyboardLayout = "dictus.keyboardLayout"
+    /// Keyboard layout per dictionary language (#272): `[SupportedLanguage.rawValue: LayoutType.rawValue]`.
+    /// An entry means the user explicitly chose that layout for that language; a missing
+    /// entry means the language still inherits `SupportedLanguage.defaultLayout` and keeps
+    /// tracking it. The presence of the dictionary itself — even empty — is the marker that
+    /// the migration from `keyboardLayout` has run. Read and written only through
+    /// `KeyboardLayoutPreference`.
+    public static let keyboardLayoutsByLanguage = "dictus.keyboardLayoutsByLanguage"
     /// JSON-encoded [Float] waveform energy data written by app during recording
     public static let waveformEnergy = "dictus.waveformEnergy"
     /// Bool flag set by keyboard to request recording stop

--- a/DictusCore/Sources/DictusCore/SupportedLanguage.swift
+++ b/DictusCore/Sources/DictusCore/SupportedLanguage.swift
@@ -31,9 +31,10 @@ public enum SupportedLanguage: String, CaseIterable, Codable, Sendable {
     /// Default keyboard layout for this language.
     /// French defaults to AZERTY; English and Spanish to QWERTY; German to QWERTZ (#151).
     ///
-    /// This is the layout a user gets when they *select* the language. It does not
-    /// rewrite a layout already stored: a German user who installed before #151 keeps
-    /// QWERTY until they select German again. Nobody's keyboard changes shape on update.
+    /// Since #272 this is a *default*, not a rule: it seeds the layout of a language the
+    /// user has never given one, and it keeps applying while they never do. The moment they
+    /// pick a layout for that language, their choice wins and this stops being consulted —
+    /// see `KeyboardLayoutPreference`. Nobody's keyboard changes shape on update.
     public var defaultLayout: LayoutType {
         switch self {
         case .french: return .azerty
@@ -73,17 +74,24 @@ public enum SupportedLanguage: String, CaseIterable, Codable, Sendable {
 
     /// Makes `language` the active keyboard language.
     ///
-    /// Writes the language AND that language's `defaultLayout`, because the two
-    /// are still welded together: picking English forces QWERTY. Decoupling them
-    /// is #272 — until then this is the one place the pair is written, so the
-    /// coupling is visible instead of being duplicated at each call site.
+    /// Writes the language and nothing else about the layout (#272): the layout the user
+    /// now types on is whatever they chose for this language, or its default while they
+    /// never chose one. Before #272 this overwrote the layout with `defaultLayout`, which
+    /// is exactly what made "English autocorrect on an AZERTY keyboard" unreachable.
     ///
     /// WHY here and not in the picker view: #241 moved language selection from the
-    /// toolbar into the keyboard panel, and the same two writes have to happen
-    /// wherever selection ends up living. In DictusCore they are also testable —
-    /// the keyboard extension target has no test bundle.
+    /// toolbar into the keyboard panel, and the same write has to happen wherever
+    /// selection ends up living. In DictusCore it is also testable — the keyboard
+    /// extension target has no test bundle.
     public static func activate(_ language: SupportedLanguage) {
+        // Before the language moves: the #272 migration freezes the stored layout under
+        // whichever language is active *at that moment*, and that has to be the one the
+        // user has been typing on, not the one they are switching to.
+        KeyboardLayoutPreference.migrateToPerLanguageLayoutsIfNeeded()
+
         AppGroup.defaults.set(language.rawValue, forKey: SharedKeys.language)
-        AppGroup.defaults.set(language.defaultLayout.rawValue, forKey: SharedKeys.keyboardLayout)
+        // The mirror describes the active language's layout, so it is computed after the
+        // switch — see `KeyboardLayoutPreference.mirrorToLegacyKey`.
+        KeyboardLayoutPreference.mirrorToLegacyKey(KeyboardLayoutPreference.layout(for: language))
     }
 }

--- a/DictusCore/Tests/DictusCoreTests/FrenchAdaptiveKeyTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/FrenchAdaptiveKeyTests.swift
@@ -1,0 +1,72 @@
+// DictusCore/Tests/DictusCoreTests/FrenchAdaptiveKeyTests.swift
+// The AZERTY row-3 adaptive key: its French behaviour, and the language guard that keeps
+// it from surfacing French accents to the other languages now reachable on AZERTY (#272).
+import XCTest
+@testable import DictusCore
+
+final class FrenchAdaptiveKeyTests: XCTestCase {
+
+    // MARK: - French behaviour (unchanged by #272)
+
+    func testLabelShowsTheDefaultAccentAfterAVowel() {
+        XCTAssertEqual(FrenchAdaptiveKey.label(afterTyping: "e", language: .french), "\u{00E9}")
+        XCTAssertEqual(FrenchAdaptiveKey.label(afterTyping: "a", language: .french), "\u{00E0}")
+        XCTAssertEqual(FrenchAdaptiveKey.label(afterTyping: "u", language: .french), "\u{00F9}")
+        XCTAssertEqual(FrenchAdaptiveKey.label(afterTyping: "i", language: .french), "\u{00EE}")
+        XCTAssertEqual(FrenchAdaptiveKey.label(afterTyping: "o", language: .french), "\u{00F4}")
+    }
+
+    func testLabelShowsApostropheAfterAConsonant() {
+        XCTAssertEqual(FrenchAdaptiveKey.label(afterTyping: "l", language: .french), "'")
+    }
+
+    func testLabelShowsApostropheAfterTheQuBigram() {
+        XCTAssertEqual(FrenchAdaptiveKey.label(afterTyping: "u", precedingChar: "q", language: .french), "'")
+        XCTAssertFalse(FrenchAdaptiveKey.shouldReplace(afterTyping: "u", precedingChar: "q", language: .french))
+        XCTAssertNil(FrenchAdaptiveKey.vowel(afterTyping: "u", precedingChar: "q", language: .french))
+    }
+
+    func testLabelPreservesTheCaseOfTheTypedVowel() {
+        XCTAssertEqual(FrenchAdaptiveKey.label(afterTyping: "E", language: .french), "\u{00C9}")
+    }
+
+    func testShouldReplaceOnlyAfterAVowel() {
+        XCTAssertTrue(FrenchAdaptiveKey.shouldReplace(afterTyping: "e", language: .french))
+        XCTAssertFalse(FrenchAdaptiveKey.shouldReplace(afterTyping: "l", language: .french))
+        XCTAssertFalse(FrenchAdaptiveKey.shouldReplace(afterTyping: nil, language: .french))
+    }
+
+    func testVowelReportsTheBaseVowel() {
+        XCTAssertEqual(FrenchAdaptiveKey.vowel(afterTyping: "E", language: .french), "e")
+        XCTAssertNil(FrenchAdaptiveKey.vowel(afterTyping: "l", language: .french))
+    }
+
+    // MARK: - Language guard (#272)
+
+    /// Decoupling the layout from the dictionary language makes English/Spanish/German on
+    /// AZERTY reachable. On those keyboards the key is what it is labelled: an apostrophe.
+    func testTheKeyIsAPlainApostropheOutsideFrench() {
+        for language in SupportedLanguage.allCases where language != .french {
+            for typed in ["e", "a", "u", "i", "o", "E", "l", nil] {
+                XCTAssertEqual(FrenchAdaptiveKey.label(afterTyping: typed, language: language), "'",
+                               "\(language.rawValue) must not get a French accent after \(typed ?? "nil")")
+                XCTAssertFalse(FrenchAdaptiveKey.shouldReplace(afterTyping: typed, language: language),
+                               "\(language.rawValue) must never replace the character it just typed")
+                XCTAssertNil(FrenchAdaptiveKey.vowel(afterTyping: typed, language: language))
+            }
+        }
+    }
+
+    /// The guard reads the active language by default, which is how the keyboard bridge
+    /// calls it — one language switch is enough to change the key's behaviour.
+    func testTheGuardFollowsTheActiveLanguageByDefault() {
+        let defaults = UserDefaults(suiteName: AppGroup.identifier)
+        defer { defaults?.removeObject(forKey: SharedKeys.language) }
+
+        defaults?.set(SupportedLanguage.french.rawValue, forKey: SharedKeys.language)
+        XCTAssertEqual(FrenchAdaptiveKey.label(afterTyping: "e"), "\u{00E9}")
+
+        defaults?.set(SupportedLanguage.english.rawValue, forKey: SharedKeys.language)
+        XCTAssertEqual(FrenchAdaptiveKey.label(afterTyping: "e"), "'")
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/FrenchAdaptiveKeyTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/FrenchAdaptiveKeyTests.swift
@@ -61,7 +61,16 @@ final class FrenchAdaptiveKeyTests: XCTestCase {
     /// calls it — one language switch is enough to change the key's behaviour.
     func testTheGuardFollowsTheActiveLanguageByDefault() {
         let defaults = UserDefaults(suiteName: AppGroup.identifier)
-        defer { defaults?.removeObject(forKey: SharedKeys.language) }
+        // Restore rather than clear: the suite is shared with every other test class,
+        // and clearing would hand them a different language than they started with.
+        let previousLanguage = defaults?.string(forKey: SharedKeys.language)
+        defer {
+            if let previousLanguage {
+                defaults?.set(previousLanguage, forKey: SharedKeys.language)
+            } else {
+                defaults?.removeObject(forKey: SharedKeys.language)
+            }
+        }
 
         defaults?.set(SupportedLanguage.french.rawValue, forKey: SharedKeys.language)
         XCTAssertEqual(FrenchAdaptiveKey.label(afterTyping: "e"), "\u{00E9}")

--- a/DictusCore/Tests/DictusCoreTests/KeyboardLayoutPreferenceTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/KeyboardLayoutPreferenceTests.swift
@@ -1,0 +1,260 @@
+// DictusCore/Tests/DictusCoreTests/KeyboardLayoutPreferenceTests.swift
+// Per-language layout storage, the inherited/explicit distinction, and the one-time
+// migration off the single global layout key (#272).
+//
+// This is the part of #272 that can be proven without a device, and the migration is the
+// part that cannot be fixed after the fact — an update that reshapes a keyboard has
+// already reshaped it. Hence the coverage here.
+import XCTest
+@testable import DictusCore
+
+final class KeyboardLayoutPreferenceTests: XCTestCase {
+
+    private var defaults: UserDefaults? {
+        UserDefaults(suiteName: AppGroup.identifier)
+    }
+
+    /// Both keys AND the language are cleared on the way in and out: the migration stamp is
+    /// sticky by design, so a leftover from another test would hide every migration case.
+    override func setUp() {
+        super.setUp()
+        clearStorage()
+    }
+
+    override func tearDown() {
+        clearStorage()
+        super.tearDown()
+    }
+
+    private func clearStorage() {
+        defaults?.removeObject(forKey: SharedKeys.keyboardLayoutsByLanguage)
+        defaults?.removeObject(forKey: SharedKeys.keyboardLayout)
+        defaults?.removeObject(forKey: SharedKeys.language)
+        defaults?.removeObject(forKey: SharedKeys.hasCompletedOnboarding)
+    }
+
+    // MARK: - Inherited (no explicit choice)
+
+    func testEveryLanguageStartsAtItsDefaultLayout() {
+        for language in SupportedLanguage.allCases {
+            XCTAssertEqual(KeyboardLayoutPreference.layout(for: language), language.defaultLayout)
+            XCTAssertTrue(KeyboardLayoutPreference.isInherited(for: language))
+            XCTAssertNil(KeyboardLayoutPreference.explicitLayout(for: language))
+        }
+    }
+
+    /// The point of "inherited": a language nobody chose a layout for still follows the
+    /// default, so shipping a new default (QWERTZ for German, #151) reaches those users.
+    func testAnInheritedLanguageTracksItsDefault() {
+        XCTAssertEqual(KeyboardLayoutPreference.layout(for: .german), .qwertz)
+        XCTAssertTrue(KeyboardLayoutPreference.isInherited(for: .german))
+    }
+
+    // MARK: - Explicit choice
+
+    func testAnExplicitChoiceIsStoredAndReported() {
+        KeyboardLayoutPreference.setLayout(.azerty, for: .english)
+
+        XCTAssertEqual(KeyboardLayoutPreference.layout(for: .english), .azerty)
+        XCTAssertEqual(KeyboardLayoutPreference.explicitLayout(for: .english), .azerty)
+        XCTAssertFalse(KeyboardLayoutPreference.isInherited(for: .english))
+    }
+
+    /// The case in the issue: English autocorrect on the AZERTY the user's fingers know,
+    /// without French losing AZERTY or English losing its own remembered layout.
+    func testLanguagesRememberTheirLayoutsIndependently() {
+        KeyboardLayoutPreference.setLayout(.azerty, for: .english)
+
+        XCTAssertEqual(KeyboardLayoutPreference.layout(for: .english), .azerty)
+        XCTAssertEqual(KeyboardLayoutPreference.layout(for: .french), .azerty, "French keeps its default")
+        XCTAssertEqual(KeyboardLayoutPreference.layout(for: .german), .qwertz, "German is untouched")
+        XCTAssertEqual(KeyboardLayoutPreference.layout(for: .spanish), .qwerty, "Spanish is untouched")
+    }
+
+    func testSwitchingLanguageDoesNotRewriteAnyStoredLayout() {
+        KeyboardLayoutPreference.setLayout(.azerty, for: .english)
+
+        SupportedLanguage.activate(.english)
+        XCTAssertEqual(LayoutType.active, .azerty, "Picking English must not force QWERTY back")
+
+        SupportedLanguage.activate(.french)
+        SupportedLanguage.activate(.english)
+        XCTAssertEqual(KeyboardLayoutPreference.explicitLayout(for: .english), .azerty,
+                       "A round trip through another language must not clear the choice")
+    }
+
+    /// A pick that happens to equal the default is still a pick: it must survive a later
+    /// change of that language's default, exactly like any other explicit choice.
+    func testChoosingTheDefaultLayoutIsStillExplicit() {
+        KeyboardLayoutPreference.setLayout(.qwertz, for: .german)
+
+        XCTAssertFalse(KeyboardLayoutPreference.isInherited(for: .german))
+        XCTAssertEqual(KeyboardLayoutPreference.explicitLayout(for: .german), .qwertz)
+    }
+
+    func testLastChoiceWinsForTheSameLanguage() {
+        KeyboardLayoutPreference.setLayout(.azerty, for: .english)
+        KeyboardLayoutPreference.setLayout(.qwertz, for: .english)
+
+        XCTAssertEqual(KeyboardLayoutPreference.layout(for: .english), .qwertz)
+    }
+
+    func testAnUnreadableStoredEntryFallsBackToTheLanguageDefault() {
+        defaults?.set(["de": "dvorak"], forKey: SharedKeys.keyboardLayoutsByLanguage)
+
+        XCTAssertEqual(KeyboardLayoutPreference.layout(for: .german), .qwertz,
+                       "A layout we cannot parse must behave as no choice at all, not as AZERTY")
+        XCTAssertTrue(KeyboardLayoutPreference.isInherited(for: .german))
+    }
+
+    // MARK: - LayoutType.active resolves through the active language
+
+    func testActiveLayoutFollowsTheActiveLanguage() {
+        KeyboardLayoutPreference.setLayout(.azerty, for: .english)
+
+        SupportedLanguage.activate(.english)
+        XCTAssertEqual(LayoutType.active, .azerty)
+
+        SupportedLanguage.activate(.german)
+        XCTAssertEqual(LayoutType.active, .qwertz, "German never got a choice, so it uses its default")
+    }
+
+    // MARK: - Migration (spec §6)
+
+    /// The common upgrade: one stored layout, matching the active language's default.
+    func testMigrationFreezesTheStoredLayoutOfTheActiveLanguage() {
+        defaults?.set(SupportedLanguage.french.rawValue, forKey: SharedKeys.language)
+        defaults?.set(LayoutType.azerty.rawValue, forKey: SharedKeys.keyboardLayout)
+
+        KeyboardLayoutPreference.migrateToPerLanguageLayoutsIfNeeded()
+
+        XCTAssertEqual(KeyboardLayoutPreference.explicitLayout(for: .french), .azerty,
+                       "The active language's layout is frozen as explicit, not recomputed")
+    }
+
+    /// The reason the value is frozen instead of recomputed: the pre-#272 Settings picker
+    /// let a layout diverge from the active language's default, so some installs already
+    /// hold a combination `defaultLayout` would not produce.
+    func testMigrationPreservesALayoutThatDivergesFromTheLanguageDefault() {
+        defaults?.set(SupportedLanguage.german.rawValue, forKey: SharedKeys.language)
+        defaults?.set(LayoutType.qwerty.rawValue, forKey: SharedKeys.keyboardLayout)
+
+        XCTAssertEqual(LayoutType.active, .qwerty,
+                       "Nobody's keyboard may change shape on update — not even to the new default")
+        XCTAssertEqual(KeyboardLayoutPreference.explicitLayout(for: .german), .qwerty)
+    }
+
+    func testMigrationLeavesTheOtherLanguagesInherited() {
+        defaults?.set(SupportedLanguage.german.rawValue, forKey: SharedKeys.language)
+        defaults?.set(LayoutType.qwerty.rawValue, forKey: SharedKeys.keyboardLayout)
+
+        KeyboardLayoutPreference.migrateToPerLanguageLayoutsIfNeeded()
+
+        for language in SupportedLanguage.allCases where language != .german {
+            XCTAssertTrue(KeyboardLayoutPreference.isInherited(for: language),
+                          "\(language.rawValue) never had a visible value, so it seeds at its default")
+            XCTAssertEqual(KeyboardLayoutPreference.layout(for: language), language.defaultLayout)
+        }
+    }
+
+    /// An unreadable legacy value used to resolve to AZERTY — that is the shape the user
+    /// is looking at, so that is what gets frozen.
+    func testMigrationFreezesAzertyForAnUnreadableLegacyValue() {
+        defaults?.set(SupportedLanguage.spanish.rawValue, forKey: SharedKeys.language)
+        defaults?.set("dvorak", forKey: SharedKeys.keyboardLayout)
+
+        KeyboardLayoutPreference.migrateToPerLanguageLayoutsIfNeeded()
+
+        XCTAssertEqual(KeyboardLayoutPreference.explicitLayout(for: .spanish), .azerty)
+    }
+
+    /// No stored layout but onboarding is behind them: they have been typing on the AZERTY
+    /// fallback, and must keep it.
+    func testMigrationFreezesAzertyForAnOnboardedInstallWithNoStoredLayout() {
+        defaults?.set(true, forKey: SharedKeys.hasCompletedOnboarding)
+        defaults?.set(SupportedLanguage.english.rawValue, forKey: SharedKeys.language)
+
+        KeyboardLayoutPreference.migrateToPerLanguageLayoutsIfNeeded()
+
+        XCTAssertEqual(KeyboardLayoutPreference.explicitLayout(for: .english), .azerty)
+    }
+
+    /// A fresh install has no shape to preserve: everything stays inherited, so a new
+    /// install that picks German gets QWERTZ rather than the AZERTY fallback.
+    func testMigrationFreezesNothingOnAFreshInstall() {
+        KeyboardLayoutPreference.migrateToPerLanguageLayoutsIfNeeded()
+
+        for language in SupportedLanguage.allCases {
+            XCTAssertTrue(KeyboardLayoutPreference.isInherited(for: language))
+        }
+        XCTAssertEqual(defaults?.dictionary(forKey: SharedKeys.keyboardLayoutsByLanguage) as? [String: String], [:],
+                       "The empty dictionary is the stamp that says migration already ran")
+    }
+
+    /// The stamp is what makes a *later* language change safe: without it, this install
+    /// would look like an upgrade sitting on German and be frozen to AZERTY.
+    func testAFreshInstallThatPicksGermanAfterMigrationStillInheritsQwertz() {
+        KeyboardLayoutPreference.migrateToPerLanguageLayoutsIfNeeded()
+
+        SupportedLanguage.activate(.german)
+
+        XCTAssertEqual(LayoutType.active, .qwertz)
+        XCTAssertTrue(KeyboardLayoutPreference.isInherited(for: .german))
+    }
+
+    func testMigrationIsIdempotentAndNeverOverwritesAChoice() {
+        defaults?.set(SupportedLanguage.french.rawValue, forKey: SharedKeys.language)
+        defaults?.set(LayoutType.azerty.rawValue, forKey: SharedKeys.keyboardLayout)
+
+        KeyboardLayoutPreference.migrateToPerLanguageLayoutsIfNeeded()
+        KeyboardLayoutPreference.setLayout(.qwerty, for: .french)
+        KeyboardLayoutPreference.migrateToPerLanguageLayoutsIfNeeded()
+
+        XCTAssertEqual(KeyboardLayoutPreference.layout(for: .french), .qwerty,
+                       "A second migration must not reinstate the legacy value")
+    }
+
+    /// Migration runs from whichever entry point is reached first, in whichever process —
+    /// the keyboard extension can run before DictusApp is ever launched again.
+    func testMigrationRunsFromAPlainRead() {
+        defaults?.set(SupportedLanguage.german.rawValue, forKey: SharedKeys.language)
+        defaults?.set(LayoutType.qwerty.rawValue, forKey: SharedKeys.keyboardLayout)
+
+        _ = KeyboardLayoutPreference.layout(for: .french)
+
+        XCTAssertEqual(defaults?.dictionary(forKey: SharedKeys.keyboardLayoutsByLanguage) as? [String: String],
+                       ["de": "qwerty"])
+    }
+
+    func testMigrationRunsBeforeALanguageSwitchCanMoveTheActiveLanguage() {
+        defaults?.set(SupportedLanguage.french.rawValue, forKey: SharedKeys.language)
+        defaults?.set(LayoutType.qwerty.rawValue, forKey: SharedKeys.keyboardLayout)
+
+        SupportedLanguage.activate(.english)
+
+        XCTAssertEqual(KeyboardLayoutPreference.explicitLayout(for: .french), .qwerty,
+                       "The frozen value belongs to the language the user was typing on")
+        XCTAssertTrue(KeyboardLayoutPreference.isInherited(for: .english),
+                      "The language they switched to must not inherit the other one's frozen value")
+        XCTAssertEqual(LayoutType.active, .qwerty, "English still had no choice, so it uses its own default")
+    }
+
+    // MARK: - Legacy mirror (rollback safety)
+
+    func testTheLegacyKeyMirrorsTheActiveLanguageLayout() {
+        SupportedLanguage.activate(.german)
+        XCTAssertEqual(defaults?.string(forKey: SharedKeys.keyboardLayout), "qwertz")
+
+        KeyboardLayoutPreference.setLayout(.azerty, for: .german)
+        XCTAssertEqual(defaults?.string(forKey: SharedKeys.keyboardLayout), "azerty",
+                       "A build without #272 must find the shape the user is actually on")
+    }
+
+    func testChoosingALayoutForAnotherLanguageLeavesTheMirrorAlone() {
+        SupportedLanguage.activate(.french)
+        KeyboardLayoutPreference.setLayout(.qwerty, for: .english)
+
+        XCTAssertEqual(defaults?.string(forKey: SharedKeys.keyboardLayout), "azerty",
+                       "The mirror describes the active language, not the one being configured")
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/LayoutTypeTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/LayoutTypeTests.swift
@@ -27,6 +27,9 @@ final class LayoutTypeTests: XCTestCase {
         defaults?.removeObject(forKey: SharedKeys.keyboardLayout)
         defaults?.removeObject(forKey: SharedKeys.keyboardLayoutsByLanguage)
         defaults?.removeObject(forKey: SharedKeys.language)
+        // The migration also treats a completed onboarding as "this install predates
+        // #272", so a leftover flag decides the outcome of the tests below.
+        defaults?.removeObject(forKey: SharedKeys.hasCompletedOnboarding)
     }
 
     // MARK: - Persisted raw values

--- a/DictusCore/Tests/DictusCoreTests/LayoutTypeTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/LayoutTypeTests.swift
@@ -10,9 +10,23 @@ final class LayoutTypeTests: XCTestCase {
         UserDefaults(suiteName: AppGroup.identifier)
     }
 
+    /// Since #272 the layout resolves through the per-language store, and the presence of
+    /// that store is a migration stamp — a leftover from another test would decide what
+    /// `LayoutType.active` returns here. Cleared both ways round.
+    override func setUp() {
+        super.setUp()
+        clearStorage()
+    }
+
     override func tearDown() {
+        clearStorage()
         super.tearDown()
+    }
+
+    private func clearStorage() {
         defaults?.removeObject(forKey: SharedKeys.keyboardLayout)
+        defaults?.removeObject(forKey: SharedKeys.keyboardLayoutsByLanguage)
+        defaults?.removeObject(forKey: SharedKeys.language)
     }
 
     // MARK: - Persisted raw values
@@ -31,29 +45,31 @@ final class LayoutTypeTests: XCTestCase {
 
     // MARK: - Round-trip through App Group defaults
 
+    /// Since #272 the stored value is per language (`KeyboardLayoutPreference`); the migration
+    /// off the old single global key has its own coverage in `KeyboardLayoutPreferenceTests`.
     func testEveryLayoutRoundTripsThroughAppGroupDefaults() {
         for layout in LayoutType.allCases {
-            defaults?.set(layout.rawValue, forKey: SharedKeys.keyboardLayout)
+            KeyboardLayoutPreference.setLayout(layout, for: .active)
             XCTAssertEqual(LayoutType.active, layout, "\(layout.rawValue) did not round-trip")
         }
     }
 
     func testQwertzIsResolvedFromTheStoredRawValue() {
-        defaults?.set("qwertz", forKey: SharedKeys.keyboardLayout)
+        KeyboardLayoutPreference.setLayout(.qwertz, for: .active)
         XCTAssertEqual(LayoutType.active, .qwertz)
     }
 
     // MARK: - Fallback
 
     func testUnknownStoredValueFallsBackToAzerty() {
-        defaults?.set("dvorak", forKey: SharedKeys.keyboardLayout)
+        defaults?.set([SupportedLanguage.active.rawValue: "dvorak"], forKey: SharedKeys.keyboardLayoutsByLanguage)
         XCTAssertEqual(LayoutType.active, .azerty,
-                       "An unrecognised stored layout must keep falling back to AZERTY.")
+                       "An unrecognised stored layout must keep falling back to the default, AZERTY for French.")
     }
 
     func testMissingStoredValueFallsBackToAzerty() {
-        defaults?.removeObject(forKey: SharedKeys.keyboardLayout)
-        XCTAssertEqual(LayoutType.active, .azerty)
+        XCTAssertEqual(LayoutType.active, .azerty,
+                       "Nothing stored and no language stored: French, therefore AZERTY.")
     }
 
     // MARK: - Display names

--- a/DictusCore/Tests/DictusCoreTests/SupportedLanguageActivationTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/SupportedLanguageActivationTests.swift
@@ -1,6 +1,7 @@
 // DictusCore/Tests/DictusCoreTests/SupportedLanguageActivationTests.swift
-// Tests for SupportedLanguage.activate — the single place the keyboard language
-// and its layout are written together (#241, coupling tracked by #272).
+// Tests for SupportedLanguage.activate — the single place the keyboard language is
+// written (#241). Since #272 it writes the language only: the layout is per language
+// and activation no longer overrides it (see KeyboardLayoutPreferenceTests).
 import XCTest
 @testable import DictusCore
 
@@ -10,10 +11,20 @@ final class SupportedLanguageActivationTests: XCTestCase {
         UserDefaults(suiteName: AppGroup.identifier)
     }
 
+    override func setUp() {
+        super.setUp()
+        clearStorage()
+    }
+
     override func tearDown() {
+        clearStorage()
         super.tearDown()
+    }
+
+    private func clearStorage() {
         defaults?.removeObject(forKey: SharedKeys.language)
         defaults?.removeObject(forKey: SharedKeys.keyboardLayout)
+        defaults?.removeObject(forKey: SharedKeys.keyboardLayoutsByLanguage)
     }
 
     // MARK: - Language write
@@ -31,7 +42,13 @@ final class SupportedLanguageActivationTests: XCTestCase {
         XCTAssertEqual(LayoutType.active, .qwertz)
     }
 
-    // MARK: - Layout write (the #272 coupling)
+    // MARK: - Resolved layout after activation
+    //
+    // The layout each language resolves to is unchanged for a user who never picked one:
+    // it is that language's default. What changed in #272 is that a user who *did* pick one
+    // keeps it — covered in KeyboardLayoutPreferenceTests. The assertions on
+    // `SharedKeys.keyboardLayout` below read the legacy mirror, kept in step so a build
+    // without #272 finds the same shape.
 
     func testActivateFrenchWritesAzerty() {
         SupportedLanguage.activate(.english)
@@ -54,15 +71,20 @@ final class SupportedLanguageActivationTests: XCTestCase {
         XCTAssertEqual(LayoutType.active, .qwertz)
     }
 
-    /// No migration rewrites a stored layout (#151): a German user who installed
-    /// before QWERTZ existed keeps QWERTY until they select German again. The layout
-    /// is read from what is stored, never re-derived from the active language.
+    /// No migration rewrites a stored layout (#151): a German user who installed before
+    /// QWERTZ existed keeps QWERTY. Since #272 they keep it even across a re-selection of
+    /// German — the stored value is that language's own choice, never re-derived from it.
     func testStoredLayoutSurvivesALanguageItNoLongerMatches() {
         defaults?.set(SupportedLanguage.german.rawValue, forKey: SharedKeys.language)
         defaults?.set(LayoutType.qwerty.rawValue, forKey: SharedKeys.keyboardLayout)
         XCTAssertEqual(SupportedLanguage.active, .german)
         XCTAssertEqual(LayoutType.active, .qwerty,
                        "Nobody's keyboard may change shape without them selecting the language again.")
+
+        SupportedLanguage.activate(.french)
+        SupportedLanguage.activate(.german)
+        XCTAssertEqual(LayoutType.active, .qwerty,
+                       "Re-selecting the language no longer overwrites the layout it is stored with.")
     }
 
     /// Every supported language must leave the pair consistent — a new language

--- a/DictusKeyboard/KeyboardRootView.swift
+++ b/DictusKeyboard/KeyboardRootView.swift
@@ -51,6 +51,11 @@ struct KeyboardRootView: View {
     /// The controller uses this to reload the GiellaKeyboardView with the new layout.
     var onLanguageChanged: ((SupportedLanguage) -> Void)?
 
+    /// Callback when the user picks a layout for a language in the panel (#272).
+    /// The controller decides whether it has to rebuild — only the active language's
+    /// layout is on screen.
+    var onLayoutChanged: ((LayoutType, SupportedLanguage) -> Void)?
+
     /// Whether the Pro entry is hidden from the panel bar.
     ///
     /// WHY @State refreshed on open rather than an observed ProStatusManager:
@@ -228,14 +233,15 @@ struct KeyboardRootView: View {
                             // height constraint has not landed yet, leaving
                             // geo.size.height at the 52 pt bar.
                             availableHeight: max(0, geo.size.height - toolbarHeight),
-                            // Picking a language closes the panel (#241 device
-                            // feedback). The confirmation is the key grid changing
-                            // layout underneath, which is louder than a checkmark,
-                            // and leaving the panel up forced a second trip to the
-                            // close control to get back to typing.
+                            // Neither selection closes the panel (#272). A row carries
+                            // two independent choices now — language and layout — and
+                            // closing on the first one takes the second away. The ✕ in
+                            // the bar is the only way out.
                             onLanguageChanged: { language in
                                 onLanguageChanged?(language)
-                                state.presentAreaMode(.keys)
+                            },
+                            onLayoutChanged: { layout, language in
+                                onLayoutChanged?(layout, language)
                             }
                         )
                     }

--- a/DictusKeyboard/KeyboardViewController.swift
+++ b/DictusKeyboard/KeyboardViewController.swift
@@ -199,6 +199,9 @@ class KeyboardViewController: UIInputViewController {
             bridge: keyBridge,
             onLanguageChanged: { [weak self] newLang in
                 self?.handleLanguageChange(newLang)
+            },
+            onLayoutChanged: { [weak self] layout, language in
+                self?.handleLayoutChange(layout, for: language)
             }
         )
         let hosting = UIHostingController(rootView: rootView)
@@ -979,8 +982,9 @@ class KeyboardViewController: UIInputViewController {
             ))
 
         case .panel:
-            // Reserved for #241. No view is attached yet, but the geometry is:
-            // adding the panel is adding a SwiftUI branch, not editing this switch.
+            // Same geometry as the emoji picker: the bar keeps its height and the panel
+            // fills the rest. A grid rebuild triggered from the panel (a language or
+            // layout pick) ends by re-applying this case, so the panel survives it.
             giellaKeyboard?.isHidden = true
             let fullHeight = computeKeyboardHeight()
             hostingHeightConstraint?.constant = fullHeight
@@ -1092,6 +1096,24 @@ class KeyboardViewController: UIInputViewController {
             instanceID: controllerID,
             action: "languageChanged",
             details: "lang=\(newLang.rawValue) layout=\(LayoutType.active.rawValue)"
+        ))
+    }
+
+    /// Handles a layout pick from the keyboard panel (#272).
+    ///
+    /// Only the active language's layout is on screen. A layout chosen for one of the
+    /// other rows is already stored, and costing the user a ~200 ms grid rebuild to
+    /// redraw the same keys is worse than doing nothing.
+    private func handleLayoutChange(_ layout: LayoutType, for language: SupportedLanguage) {
+        guard language == SupportedLanguage.active else { return }
+
+        reloadKeyboardLayout()
+
+        PersistentLog.log(.diagnosticProbe(
+            component: "KeyboardViewController",
+            instanceID: controllerID,
+            action: "layoutChanged",
+            details: "lang=\(language.rawValue) layout=\(LayoutType.active.rawValue)"
         ))
     }
 

--- a/DictusKeyboard/Localizable.xcstrings
+++ b/DictusKeyboard/Localizable.xcstrings
@@ -82,6 +82,17 @@
         }
       }
     },
+    "Layout" : {
+      "comment" : "Column header in the keyboard panel, above the per-language layout pills (issue #272).",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disposition"
+          }
+        }
+      }
+    },
     "Listening..." : {
       "localizations" : {
         "fr" : {

--- a/DictusKeyboard/Views/KeyboardPanelView.swift
+++ b/DictusKeyboard/Views/KeyboardPanelView.swift
@@ -15,11 +15,12 @@ import DictusCore
 /// optimises — a list with a checkmark on the active entry is legible and stops
 /// being a puzzle as languages are added.
 ///
-/// WHY the layout column:
-/// Selecting a language still writes that language's default layout — the two are
-/// welded together. Showing the layout beside each language makes that coupling
-/// visible, which is what will make #272 comprehensible when the column becomes
-/// editable. It is display-only here.
+/// WHY the layout column is editable (#272):
+/// the layout is stored per dictionary language and no longer follows from it, so each
+/// row's right side is one pill per `LayoutType` and tapping one sets that language's
+/// layout. Generating the pills from `LayoutType.allCases` is what made QWERTZ (#151)
+/// appear here for free. There is no sub-picker: at three layouts a sheet would cost a
+/// tap and a screen to show three words.
 struct KeyboardPanelView: View {
     /// Space available below the bar, measured by the parent GeometryReader.
     /// Same contract as EmojiPickerView: the hosting controller does not always
@@ -30,9 +31,18 @@ struct KeyboardPanelView: View {
     /// language. The panel deliberately stays open across that rebuild.
     var onLanguageChanged: ((SupportedLanguage) -> Void)?
 
+    /// Notifies the controller that `language` now types on `layout`. The controller
+    /// decides whether that means a rebuild — it only does when the language is the
+    /// active one; the other rows are stored for the next time they are selected.
+    var onLayoutChanged: ((LayoutType, SupportedLanguage) -> Void)?
+
     /// Mirrors the App Group value so the checkmark moves the instant the row is
     /// tapped, without waiting for the ~200 ms grid rebuild that follows.
     @State private var language: SupportedLanguage = .active
+
+    /// Effective layout per language, mirrored for the same reason as `language`:
+    /// the pill has to fill in on touch-up, not after the grid rebuild.
+    @State private var layouts: [SupportedLanguage: LayoutType] = [:]
 
     /// The open transition, and the only animation in the panel.
     ///
@@ -51,13 +61,19 @@ struct KeyboardPanelView: View {
         VStack(alignment: .leading, spacing: 0) {
             Divider()
 
-            Text("Keyboard language")
-                .font(.system(size: 12, weight: .semibold))
-                .textCase(.uppercase)
-                .foregroundColor(.secondary)
-                .padding(.horizontal, 16)
-                .padding(.top, 10)
-                .padding(.bottom, 4)
+            // Two column headers: the rows carry two independent choices since #272,
+            // and without the second label the pills read as a state badge.
+            HStack(spacing: 8) {
+                Text("Keyboard language")
+                Spacer(minLength: 8)
+                Text("Layout")
+            }
+            .font(.system(size: 12, weight: .semibold))
+            .textCase(.uppercase)
+            .foregroundColor(.secondary)
+            .padding(.horizontal, 16)
+            .padding(.top, 10)
+            .padding(.bottom, 4)
 
             // Scrollable so a short keyboard area (landscape, or a small device)
             // clips nothing. With four languages it never actually scrolls.
@@ -75,9 +91,14 @@ struct KeyboardPanelView: View {
         .frame(height: availableHeight)
         .opacity(contentOpacity)
         .onAppear {
-            // The language can have been changed in DictusApp since this view was
-            // last built; the panel is cheap to re-read on every open.
+            // The language and the layouts can have been changed in DictusApp since this
+            // view was last built; the panel is cheap to re-read on every open.
             language = .active
+            layouts = Dictionary(
+                uniqueKeysWithValues: SupportedLanguage.allCases.map {
+                    ($0, KeyboardLayoutPreference.layout(for: $0))
+                }
+            )
 
             if reduceMotion {
                 contentOpacity = 1
@@ -89,39 +110,80 @@ struct KeyboardPanelView: View {
         }
     }
 
+    /// One row: the language on the left, its layout pills on the right.
+    ///
+    /// WHY two sibling buttons instead of one row button containing the pills:
+    /// a Button nested inside another Button's label never receives the touch — the
+    /// outer one swallows it. The row is therefore an HStack of independent controls,
+    /// each with its own full-height hit area.
     private func languageRow(_ entry: SupportedLanguage) -> some View {
         let isActive = entry == language
-        return Button {
-            select(entry)
-        } label: {
-            HStack(spacing: 12) {
-                Image(systemName: "checkmark")
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundColor(Color(.label))
-                    .frame(width: 18)
-                    .opacity(isActive ? 1 : 0)
+        return HStack(spacing: 8) {
+            Button {
+                select(entry)
+            } label: {
+                HStack(spacing: 12) {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundColor(Color(.label))
+                        .frame(width: 18)
+                        .opacity(isActive ? 1 : 0)
 
-                Text(entry.displayName)
-                    .font(.system(size: 17))
-                    .foregroundColor(Color(.label))
+                    Text(entry.displayName)
+                        .font(.system(size: 17))
+                        .foregroundColor(Color(.label))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
 
-                Spacer(minLength: 8)
-
-                Text(entry.defaultLayout.displayName)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(.secondary)
+                    Spacer(minLength: 8)
+                }
+                .frame(height: rowHeight)
+                .contentShape(Rectangle())
             }
-            .padding(.horizontal, 16)
-            .frame(height: rowHeight)
-            .contentShape(Rectangle())
+            .buttonStyle(.plain)
+            .accessibilityAddTraits(isActive ? [.isSelected] : [])
+
+            // One pill per layout, so a new LayoutType case surfaces here with no
+            // further work — that is how QWERTZ (#151) arrived in this panel.
+            ForEach(LayoutType.allCases, id: \.self) { layout in
+                layoutPill(layout, for: entry)
+            }
         }
-        .accessibilityAddTraits(isActive ? [.isSelected] : [])
+        .padding(.horizontal, 16)
+        .frame(height: rowHeight)
     }
 
-    /// Applies the language. The parent closes the panel on this callback (#241
-    /// device feedback): the key grid changing layout underneath is a louder
-    /// confirmation than a checkmark, and staying open cost the user a second
-    /// trip to the close control before they could type.
+    private func layoutPill(_ layout: LayoutType, for entry: SupportedLanguage) -> some View {
+        let isSelected = layouts[entry] == layout
+        return Button {
+            selectLayout(layout, for: entry)
+        } label: {
+            Text(layout.displayName)
+                .font(.system(size: 11, weight: .semibold))
+                .lineLimit(1)
+                // The three pills plus a language name have to fit a 320 pt row.
+                .minimumScaleFactor(0.75)
+                .foregroundColor(isSelected ? .white : .secondary)
+                .padding(.horizontal, 8)
+                .frame(height: 28)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(isSelected ? Color.dictusAccent : Color(.tertiarySystemFill))
+                )
+                // Visually 28 pt, tappable over the full row: a 28 pt target in a
+                // keyboard panel is small enough to miss, and the row has the height
+                // to give away.
+                .frame(height: rowHeight)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Text(verbatim: "\(entry.displayName), \(layout.displayName)"))
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+
+    /// Applies the language. The panel stays open (#272): a row now carries two
+    /// choices, and closing on the first one takes the second away. Nothing here
+    /// dismisses the panel — the ✕ in the bar is the only way out.
     private func select(_ entry: SupportedLanguage) {
         // Re-selecting the active language would cost a full key-grid rebuild for
         // no visible change, so it is a no-op.
@@ -135,8 +197,31 @@ struct KeyboardPanelView: View {
             component: "KeyboardPanelView",
             instanceID: "",
             action: "languageSelected",
-            details: "language=\(entry.rawValue) layout=\(entry.defaultLayout.rawValue)"
+            details: "language=\(entry.rawValue) layout=\(KeyboardLayoutPreference.layout(for: entry).rawValue)"
         ))
         onLanguageChanged?(entry)
+    }
+
+    /// Applies a layout to one language (#272), whether or not it is the active one.
+    private func selectLayout(_ layout: LayoutType, for entry: SupportedLanguage) {
+        HapticFeedback.keyTapped()
+
+        // Written even when the pill is already filled: the pill shows the *effective*
+        // layout, which may still be the inherited default. Tapping it is the user
+        // saying they want this layout for this language, and that has to stop the
+        // language tracking a future change of default.
+        KeyboardLayoutPreference.setLayout(layout, for: entry)
+
+        // Nothing on screen changes below this point, so no rebuild either.
+        guard layouts[entry] != layout else { return }
+        layouts[entry] = layout
+
+        PersistentLog.log(.diagnosticProbe(
+            component: "KeyboardPanelView",
+            instanceID: "",
+            action: "layoutSelected",
+            details: "language=\(entry.rawValue) layout=\(layout.rawValue) active=\(language.rawValue)"
+        ))
+        onLayoutChanged?(layout, entry)
     }
 }


### PR DESCRIPTION
refs #272

## What this was for

Dictus has four language-shaped concepts and users experience them as four choices. Two of
them were still welded together: picking a keyboard language also wrote that language's
default layout. So "English autocorrect and suggestions, on the AZERTY my fingers know" was
unreachable — choosing English relayouted the keyboard under the user's hands. That is the
normal condition of anyone bilingual who learned to type on one physical layout.

Built against the spec in the 2026-08-06 comment on the issue (the six numbered decisions),
not the three open questions in the body.

## What changed

- **The layout is stored per dictionary language** (`KeyboardLayoutPreference`, DictusCore).
  An entry means the user chose that layout; no entry means the language still inherits
  `defaultLayout` and keeps tracking it, so a future default change still reaches users who
  never expressed a preference. `LayoutType.active` remains the single effective read, so the
  grid builder, the trie's proximity map, the spacebar neighbours and the emoji picker are
  untouched — only what backs the value moved.
- **Migration** freezes the layout an updating install is already typing on, under the
  language it is typing it on, as explicit — including the divergent pairs the old Settings
  picker could produce. The other languages stay inherited at their true default. The
  dictionary is written even when empty: its presence is the "already migrated" stamp, which
  is what stops a language change made after the update from being mistaken for pre-update
  state.
- **The old global key** is kept as a write-only mirror of the active language's layout, so a
  rollback to a build without this change finds the shape the user is on.
- **The AZERTY adaptive accent key is guarded to French.** It used to trigger purely off its
  presence on the AZERTY grid; with the axes decoupled, English/Spanish/German on AZERTY are
  reachable and would have got French accents replacing the vowel they just typed. Outside
  French it is now the plain apostrophe it is labelled with. `AccentedCharacters.mappings`
  (the standard long-press popups) is untouched — that stays #157.
- **Panel**: each row's read-only layout badge becomes one tappable pill per `LayoutType`
  (generated from `allCases`, so QWERTZ is already there). Neither a language nor a layout
  pick closes the panel anymore; the ✕ is the only way out. A layout pick rebuilds the key
  grid only when it lands on the active language.
- **Settings**: the Layout picker reads and writes the layout of whichever keyboard language
  is selected above it, and the overwrite-on-language-change is gone. New footer: "The layout
  is saved for each keyboard language." (fr: "La disposition est enregistrée pour chaque
  langue du clavier.")
- Transcription language untouched (spec §3). `CONTEXT.md` updated: it still described the
  layout as global and pointed the adaptive key at a file it does not live in.

## Coverage: executed vs device-only

Executed here:

- `cd DictusCore && swift test` — 761 test cases pass. New: `KeyboardLayoutPreferenceTests`
  (21 cases: inherited vs explicit, independence per language, and 8 migration cases including
  the divergent pair, the unreadable value, the onboarded-with-no-layout install, the fresh
  install, idempotence and the ordering against a language switch) and `FrenchAdaptiveKeyTests`
  (8 cases, the guard over all four languages). `LayoutTypeTests` and
  `SupportedLanguageActivationTests` updated to the new storage.
- `xcodebuild build -scheme DictusApp` — BUILD SUCCEEDED, all three targets plus the widgets.
- `swiftlint lint --strict` — 0 violations in 169 files.
- **Migration verified in the running app on a headless simulator.** Seeded a pre-#272 install
  in the App Group container (`dictus.language = de`, `dictus.keyboardLayout = qwerty`,
  `hasCompletedOnboarding = true` — a pair `defaultLayout` would never produce, German's
  default being QWERTZ), launched the new build, read the container back:
  `"dictus.keyboardLayoutsByLanguage" => { "de" => "qwerty" }`. A fresh container produced
  `"dictus.keyboardLayoutsByLanguage" => { }` — the empty stamp, everything inherited. This
  also proves the launch-time migration call is live and not dead code.

Compilation only, needs eyes:

- The panel's layout pills, the panel staying open, and the AZERTY adaptive-key guard. A
  simulator cannot enable a keyboard extension (`docs/agents/simulator.md` §7).
- The Settings Layout picker. Settings is tab 2 of `MainTabView` driven by in-memory
  `@State`; no preference or launch argument selects it and `simctl` cannot tap, so the
  headless screenshot is not available — this one is on the manual list too.

## To test by hand

Build and install from this branch (`feature/272-layout-language-decoupling`).

**A — Settings, per-language layout**

1. Settings → Keyboard. The footer reads "La disposition est enregistrée pour chaque langue du
   clavier."
2. Keyboard language = Français. Layout shows AZERTY.
3. Set Keyboard language = English. Layout must switch to QWERTY **on its own** and nothing
   else must change.
4. With English selected, set Layout = AZERTY.
5. Switch Keyboard language to Français → Layout shows AZERTY. Switch back to English →
   Layout must still show **AZERTY**. Before this change it snapped back to QWERTY.
6. Set Keyboard language = Deutsch → Layout shows QWERTZ (German never got a choice).

**B — Keyboard panel**

7. Open any text field, Dictus keyboard, tap ☰. Each row shows the language on the left and
   three pills (AZERTY / QWERTY / QWERTZ) on the right, the effective one filled in blue.
8. Tap the language **English** row. The checkmark moves, the key grid rebuilds underneath,
   and **the panel stays open** (this is the behaviour change: it used to close).
9. Tap the **AZERTY** pill on the English row. The pill fills and the grid behind rebuilds to
   AZERTY while the language stays English.
10. Tap the **QWERTZ** pill on the German row (German is not active). The pill fills; nothing
    else moves, no rebuild.
11. Tap ✕ — the only way out. The key grid comes back at the normal height with no gap.
12. Re-open ☰: the pills must show what you left (English → AZERTY, German → QWERTZ).

**C — The adaptive accent key (the reason §2 is in scope)**

13. Language English, layout AZERTY (from step 9). On row 3, the key between `n` and delete
    must show a plain `'` and stay `'` after typing a vowel. Typing `e` then that key must
    insert `e'` — it must **not** replace the `e` with `é`.
14. Switch the language back to Français on AZERTY. The same key must resume showing `é`
    after `e`, `à` after `a`, and `'` after `qu`. Long-press accents (long-press `a`, `e`)
    must be unchanged in both languages.
15. Language Français, layout QWERTY: there is no adaptive key on that grid — accents come
    from long-press on the vowels, which must still offer the French set.

**D — Migration, over an existing install** (the case no test on the branch can cover for you)

16. Install the **current TestFlight/develop build** first (not this branch). Set Keyboard
    language = Deutsch, then set Layout = QWERTY in Settings — do not touch the language
    afterwards. That is the divergent pair.
17. Now install this branch **over it** (upgrade, do not delete the app — deleting wipes the
    App Group and there is nothing left to migrate).
18. Open Settings → Keyboard: language Deutsch, Layout must still read **QWERTY**. Open the
    keyboard: the keys must still be QWERTY. Nothing may have become QWERTZ.
19. Same install: switch to English → QWERTY, back to Deutsch → still QWERTY. The frozen
    value belongs to German now, permanently, until German is given another layout.
20. Second pass, fresh install of this branch (delete the app first): Français → AZERTY,
    Deutsch → QWERTZ, English/Español → QWERTY, all untouched.

**E — Regression, since the grid rebuild path was touched**

21. Cold start: force-quit Dictus, open the keyboard in another app, tap ☰, change the
    language, close with ✕, type a few keys. No shrunken keys, no gap between the toolbar and
    the grid, no frozen keyboard.
22. Open the emoji picker, close it, then open ☰ and close it. The 52 pt toolbar must come
    back both times.

## Notes and judgement calls

- **Any pick is recorded as explicit, including one that equals the default.** Tapping QWERTZ
  back on German means German is now explicitly QWERTZ and a future change of its default
  will not reshape it. The spec's wording ("until the user explicitly picks a different one")
  admits the other reading; this one keeps the promise the issue exists for.
- **One theoretical migration gap.** The freeze needs a signal that the install predates the
  update; it uses the presence of the legacy layout key, or `hasCompletedOnboarding`. An
  install that had a non-French language stored with no layout at all and had not completed
  onboarding would seed at the new default instead of AZERTY. Every pre-#272 code path that
  wrote a language also wrote a layout, so I believe this is unreachable; it is the only case
  not covered by a test.
- The `.panel` case comment in `KeyboardViewController.applyLayout` still said "reserved for
  #241, no view attached yet" — corrected while working next to it.
- Files owned by the concurrent #321 (`AOSPTrieEngine.swift`, `Vendored/AOSPTrie/**`) and #322
  (`Vendored/Views/KeyboardView.swift`) were not touched. #321's `LayoutType.active == .azerty`
  proximity dispatch keeps working unchanged and now follows the active language's layout,
  which is the correct behaviour for it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard layouts can be selected and saved independently for each language.
  * The keyboard panel displays layout options alongside each language and remains open after selections.
  * Layout changes apply immediately for the active language.

* **Bug Fixes**
  * Switching languages no longer overwrites saved layouts.
  * French accent-key behavior uses a standard apostrophe outside French.
  * Existing layout preferences are preserved during upgrades.

* **Documentation**
  * Updated documentation for per-language layouts and adaptive accent-key behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->