### PR TITLE
docs: add the out-of-scope knowledge base

### DIFF
--- a/.out-of-scope/per-language-long-press-accents.md
+++ b/.out-of-scope/per-language-long-press-accents.md
@@ -1,0 +1,78 @@
+# Per-Language Long-Press Accents
+
+Long-press accent popups stay a single global union shared by every keyboard
+language. They are not scoped per language.
+
+## What this means in practice
+
+`AccentedCharacters.mappings` maps a base letter to its accented variants, and
+`accents(for:)` takes a key and nothing else — no language argument. A French
+user long-pressing `n` sees `ñ`; a German user long-pressing `c` sees `ç`; every
+user long-pressing `s` sees `ß`. The popup contents do not depend on which
+language the keyboard is set to.
+
+## Why this is out of scope
+
+The migration was proposed on the grounds that Apple scopes popups per language
+and that the union would become a mosaic as languages are added. Both were
+reasonable in May 2026. Neither has produced a problem worth the change.
+
+**The union is small.** At four keyboard languages (French, English, Spanish,
+German) it is 9 base letters and 22 variants, with at most 4 variants on any one
+key:
+
+```swift
+"e": ["é", "è", "ê", "ë"]      "c": ["ç"]
+"a": ["à", "â", "ä", "á"]      "y": ["ÿ"]
+"u": ["ù", "û", "ü", "ú"]      "n": ["ñ"]
+"i": ["î", "ï", "í"]           "s": ["ß"]
+"o": ["ô", "ö", "ó"]
+```
+
+That is fewer options than iOS itself shows on `a`. The predicted mosaic did not
+arrive.
+
+**Nobody complained.** `ß` was added to the global `s` popup by #109 in May 2026
+and shipped to every language. Three months and a TestFlight cycle later there
+is no report about it, on that or on any other cross-language variant. Weak
+evidence rather than proof, but it is precisely the signal the May triage note
+said it would decide on.
+
+**Scoping makes code-switching worse.** The union's one real benefit is that a
+French user citing *Spaß* reaches `ß` without switching keyboards. Per-language
+maps take that away in exchange for removing characters nobody has objected to.
+
+**And the language axis is the wrong place to add surface right now.** #272
+decoupled keyboard layout from dictionary language and deliberately left
+long-press accents alone. The design leans on the union: `FrenchAdaptiveKey`
+documents that French-on-QWERTY has no adaptive accent key and that those users
+"reach accents through the standard long-press popups, which already carry the
+French set". Adding a per-language dependency here would cut against work that
+has only just landed.
+
+## When to reopen this
+
+This is a decision for the current size of the product, not a permanent one.
+Reopen when either of these becomes true:
+
+- **A single base letter's variant list stops fitting one popup row.** That is
+  the point where the union starts costing the user a scan rather than a glance.
+- **A language with a large diacritic inventory onboards** — Polish (ą ę ć ł ń ó
+  ś ź ż), Czech, Turkish, or similar. Polish alone would roughly double the
+  table, and the arithmetic above stops holding.
+
+At that point the middle path from the original issue becomes the likely answer:
+a per-language map with the global union as an opt-in fallback for
+code-switchers, rather than a straight migration.
+
+## Related work that is not affected
+
+- **#322** — Shift plus long-press `S` offering `SS` instead of `ẞ`. That is the
+  uppercase transformation applied to candidates, not the candidate table, and
+  it is being fixed independently.
+- **#157's second half** — per-language `apostropheOverrides` for the French
+  adaptive key. A separate concern, already handled by #272's language guard.
+
+## Prior requests
+
+- #157 — "Migrate AccentedCharacters.mappings to per-language LanguageProfile.longPressAccents" (2026-05-06)

--- a/.out-of-scope/spoken-output-travel-mode.md
+++ b/.out-of-scope/spoken-output-travel-mode.md
@@ -1,0 +1,54 @@
+# Spoken Output and Travel / Conversation Mode
+
+Dictus does not speak. Text-to-speech output, and the travel or conversation
+product it implies, are out of scope.
+
+## Why this is out of scope
+
+Dictus is a keyboard extension. Its output is text inserted into whatever app
+the user is already in. Speaking a result aloud is not a variant of that — it is
+a different kind of output, and there is no surface in the product that can
+carry it.
+
+The keyboard cannot carry it. It runs under a ~50 MB ceiling and owns no audio
+session; recording itself had to be moved into DictusApp for exactly that
+reason, and the cross-process machinery that move required is the source of a
+long tail of issues (#249, #260, #261, #262). Adding audio *output* to the
+extension would mean rebuilding that machinery in the opposite direction, for a
+feature that plays sound while the user is typing in someone else's app.
+
+DictusApp could technically speak. But in that scenario the user is looking at
+DictusApp, not typing — so the keyboard, which is the entire product, is not
+involved. What is being built at that point is a conversation app.
+
+And a travel conversation app is not an increment on a dictation keyboard. It
+needs the round trip in both directions, a two-sided interface, and speaker and
+microphone handover between two people. Apple ships that in Translate: free,
+on-device, preinstalled on every target device. Meeting it head-on from a
+dictation keyboard has no winning path.
+
+## What is in scope, and where it lives
+
+The *translation* half of the original request is a real Dictus feature and it
+already has an owner. **#79 (Smart Modes)** ships `Translate → X` as a
+first-class entry in the v1 mode catalogue, alongside Notes and Email, with the
+design settled: a flat entry in the mode list rather than a sub-menu, a prompt
+that names its target language, and validation through
+`detectedLanguageMatches(polished:target:)` — the one mode where the output
+language check becomes an asset, because it catches the model failing to
+translate at all.
+
+So Dictus translates. It renders the result as text, into the user's keyboard,
+like everything else it does. It does not read it out.
+
+## If this is reconsidered
+
+The decision turns on what Dictus is, not on effort. If the product direction
+ever becomes a voice companion rather than a keyboard, this file should be
+deleted and the request re-triaged from scratch — the reasoning above would no
+longer apply, because its whole premise is that text insertion is the only
+output.
+
+## Prior requests
+
+- #111 — "Explore translated text-to-speech / travel mode for Dictus" (2026-04-13)


### PR DESCRIPTION
Adds `.out-of-scope/`, the knowledge base the triage skill reads before evaluating any new feature request. One file per rejected **concept**, not per issue.

## Why it is committed and not local

Agents run in **git worktrees**, which do not carry untracked or ignored files. A local-only knowledge base would be invisible to exactly the readers it exists for — the dedup check would silently do nothing on every agent-run triage.

The closing comments on #111 and #157 also reference these paths on a public repo, so leaving them uncommitted leaves dangling references.

## The two entries

| File | Issue | Decision |
|---|---|---|
| `spoken-output-travel-mode.md` | #111 | Dictus does not speak. TTS has no surface in a keyboard extension, and the travel conversation app it implies is a different product Apple Translate already ships. The **translation** half is in scope and lives in #79. |
| `per-language-long-press-accents.md` | #157 | Long-press accents stay one global union. At four languages that is 9 base letters and 22 variants — fewer than iOS shows on `a`. Scoping per language would remove the only thing the union buys: reaching `ß` while writing French. |

Both entries carry an explicit **reopen trigger**, so these are decisions with tripwires rather than permanent refusals. Polish, Czech or Turkish onboarding reopens the accents one; a shift in product direction toward a voice companion reopens the other.

## Risk

Documentation only. No target builds, no code paths, no strings. Nothing to validate on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUUyDpuVjZnLoXMdB2Ynn4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the current global behavior for long-press accent popups across keyboard languages.
  * Clarified that spoken output, travel mode, and conversation mode are not supported.
  * Documented the existing text-based translation approach and criteria for revisiting these decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->