### PR TITLE
Route undo-bar suggestion taps by the live document (refs #335)

### DIFF
--- a/DictusCore/Sources/DictusCore/SuggestionTapRouting.swift
+++ b/DictusCore/Sources/DictusCore/SuggestionTapRouting.swift
@@ -1,0 +1,63 @@
+// DictusCore/Sources/DictusCore/SuggestionTapRouting.swift
+// Routes a suggestion-bar tap to replace-or-insert (issue #335).
+//
+// THE BUG THIS PREVENTS:
+// The bar's `.undoAvailable` mode fills slots 1-2 with completions of the word
+// currently being typed, but the tap handler routed every non-zero slot of that
+// mode to the insert-only prediction path. Tapping "concerné" while "concerne"
+// was on screen produced "concerneconcerné" — the partial word was never deleted.
+//
+// THE INVARIANT:
+// What a tap must do is decided by the LIVE document, never by the bar's mode
+// and never by `currentWord` alone: the suggestion state keeps a stale
+// `currentWord` when the cursor sits right after a space. If the live context
+// ends mid-word, the tap replaces that word (with the #191 boundary check
+// gating the delete); if it ends on a boundary, the tap inserts. When the live
+// context ends mid-word but no longer matches `currentWord`, the tap does
+// nothing: a tap that does nothing is recoverable, one that corrupts the text
+// is not.
+
+import Foundation
+
+public enum SuggestionTapRouting {
+
+    /// What the caller must do with the tapped suggestion.
+    public enum Decision: Equatable {
+        /// The cursor is mid-word and the word matches: delete exactly
+        /// `deleteCount` characters (one deleteBackward() call each), then
+        /// insert the suggestion.
+        case replace(deleteCount: Int)
+        /// The cursor is on a word boundary: insert the suggestion as-is.
+        case insert
+        /// The cursor is mid-word but the document no longer ends with the word
+        /// the bar was built from. Do nothing. `reason` is the machine-readable
+        /// slug from `AutocorrectReplacement` for DEBUG logs.
+        case abort(reason: String)
+    }
+
+    /// Decides how a suggestion tap must be applied to the document.
+    ///
+    /// - Parameters:
+    ///   - context: the LIVE documentContextBeforeInput, re-read at tap time
+    ///     (never a value captured when the bar was built).
+    ///   - currentWord: the partial word the suggestion bar was computed from.
+    ///     Only consulted when the live context ends mid-word.
+    public static func decide(context: String?, currentWord: String) -> Decision {
+        // No context at all, or a context ending on a boundary: there is no
+        // partial word to replace, whatever `currentWord` still holds.
+        guard let lastChar = context?.last else {
+            return .insert
+        }
+        if lastChar.isWhitespace || lastChar.isNewline {
+            return .insert
+        }
+        // Mid-word: the delete is only safe if the live context still ends with
+        // the word, preceded by a boundary (#191).
+        switch AutocorrectReplacement.check(context: context, word: currentWord) {
+        case .ok(let deleteCount):
+            return .replace(deleteCount: deleteCount)
+        case .failed(let reason):
+            return .abort(reason: reason)
+        }
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/SuggestionTapRoutingTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/SuggestionTapRoutingTests.swift
@@ -1,0 +1,99 @@
+// DictusCore/Tests/DictusCoreTests/SuggestionTapRoutingTests.swift
+// Tests for the suggestion-tap routing table (issue #335): a tap must replace
+// the word in progress when the cursor is mid-word, and insert only when the
+// document really ends on a boundary — mode and `currentWord` alone lie.
+
+import XCTest
+@testable import DictusCore
+
+final class SuggestionTapRoutingTests: XCTestCase {
+
+    // MARK: - Mid-word: the tap replaces
+
+    func testMidWordWithMatchingCurrentWordReplaces() {
+        // The reported repro: bar in .undoAvailable, "concerne" typed after an
+        // autocorrect, tapping "concerné" used to append instead of replacing.
+        let decision = SuggestionTapRouting.decide(
+            context: "Mais j'avais des clients concerne",
+            currentWord: "concerne"
+        )
+        XCTAssertEqual(decision, .replace(deleteCount: 8))
+    }
+
+    func testMidWordAtStartOfFieldReplaces() {
+        let decision = SuggestionTapRouting.decide(context: "concerne", currentWord: "concerne")
+        XCTAssertEqual(decision, .replace(deleteCount: 8))
+    }
+
+    func testAccentedCurrentWordReplacesWithGraphemeCount() {
+        // é is ONE grapheme, so ONE deleteBackward call.
+        let decision = SuggestionTapRouting.decide(context: "la théori", currentWord: "théori")
+        XCTAssertEqual(decision, .replace(deleteCount: 6))
+    }
+
+    func testDecomposedContextMatchesPrecomposedCurrentWord() {
+        // Some hosts report decomposed Unicode (e + combining acute). Canonical
+        // equivalence must still match, with the same grapheme count.
+        let decomposedContext = "la the\u{0301}ori"      // "théori" decomposed
+        let precomposedWord = "th\u{00E9}ori"            // "théori" precomposed
+        let decision = SuggestionTapRouting.decide(
+            context: decomposedContext,
+            currentWord: precomposedWord
+        )
+        XCTAssertEqual(decision, .replace(deleteCount: 6))
+    }
+
+    // MARK: - Mid-word with a stale word: the tap does nothing
+
+    func testMidWordWithStaleCurrentWordAborts() {
+        // The user typed one more letter between the bar's async computation
+        // and the tap. Deleting a blind count would eat into the previous word.
+        let decision = SuggestionTapRouting.decide(
+            context: "des clients concernee",
+            currentWord: "concerne"
+        )
+        XCTAssertEqual(decision, .abort(reason: "suffix-mismatch"))
+    }
+
+    func testMidWordWithEmptyCurrentWordAborts() {
+        let decision = SuggestionTapRouting.decide(context: "des clients", currentWord: "")
+        XCTAssertEqual(decision, .abort(reason: "empty-word"))
+    }
+
+    func testMidWordGluedToPreviousWordAborts() {
+        let decision = SuggestionTapRouting.decide(context: "je penseque", currentWord: "que")
+        XCTAssertEqual(decision, .abort(reason: "no-boundary-before"))
+    }
+
+    // MARK: - Boundary: the tap inserts, whatever `currentWord` holds
+
+    func testContextEndingInSpaceInsertsDespiteStaleCurrentWord() {
+        // updateAsync early-returns on a whitespace-terminated context WITHOUT
+        // clearing currentWord in .predictions/.undoAvailable mode: type a word
+        // after an autocorrect then backspace it away, and currentWord survives.
+        // Inserting is right here — aborting would swallow the tap.
+        let decision = SuggestionTapRouting.decide(
+            context: "des clients ",
+            currentWord: "concerne"
+        )
+        XCTAssertEqual(decision, .insert)
+    }
+
+    func testContextEndingInNewlineInserts() {
+        let decision = SuggestionTapRouting.decide(
+            context: "Bonjour,\n",
+            currentWord: "concerne"
+        )
+        XCTAssertEqual(decision, .insert)
+    }
+
+    func testEmptyContextInserts() {
+        let decision = SuggestionTapRouting.decide(context: "", currentWord: "concerne")
+        XCTAssertEqual(decision, .insert)
+    }
+
+    func testNilContextInserts() {
+        let decision = SuggestionTapRouting.decide(context: nil, currentWord: "concerne")
+        XCTAssertEqual(decision, .insert)
+    }
+}

--- a/DictusKeyboard/KeyboardRootView.swift
+++ b/DictusKeyboard/KeyboardRootView.swift
@@ -401,6 +401,8 @@ struct KeyboardRootView: View {
     ///   - Tap index 1 (bold correction): apply correction + space
     ///   - Tap index 2 (alternative): apply alternative + space
     /// - Accent mode: replace just the vowel without adding a space.
+    /// - Undo mode: tap index 0 reverts the autocorrect; slots 1-2 are routed by
+    ///   the live document, see applyUndoModeSuggestion.
     private func handleSuggestionTap(index: Int) {
         guard index < suggestionState.suggestions.count else { return }
         let suggestion = suggestionState.suggestions[index]
@@ -420,8 +422,7 @@ struct KeyboardRootView: View {
                 suggestionState.pendingUndo = nil
                 suggestionState.clear()
             } else {
-                suggestionState.pendingUndo = nil
-                bridge?.handlePredictionTap(word: suggestion)
+                applyUndoModeSuggestion(suggestion, proxy: proxy)
             }
             HapticFeedback.keyTapped()
             return
@@ -456,6 +457,43 @@ struct KeyboardRootView: View {
         suggestionState.pendingUndo = nil
         suggestionState.clear()
         HapticFeedback.keyTapped()
+    }
+
+    /// Applies a tap on slot 1-2 of the undo bar (#335).
+    ///
+    /// WHY this is not a plain prediction tap: `.undoAvailable` only says an undo
+    /// chip is showing in slot 0. Slots 1-2 hold predictions when the cursor is
+    /// after a space, but completions of the word IN PROGRESS when the user has
+    /// started typing again — and inserting one of those glued the suggestion to
+    /// the partial word ("concerne" + "concerné" -> "concerneconcerné").
+    /// The live document decides, not the mode: see SuggestionTapRouting.
+    private func applyUndoModeSuggestion(_ suggestion: String, proxy: UITextDocumentProxy) {
+        switch SuggestionTapRouting.decide(
+            context: proxy.documentContextBeforeInput,
+            currentWord: suggestionState.currentWord
+        ) {
+        case .insert:
+            // Cursor is on a boundary: a prediction lands here, insert + space,
+            // and let the bridge chain the next predictions. Unchanged behavior.
+            suggestionState.pendingUndo = nil
+            bridge?.handlePredictionTap(word: suggestion)
+
+        case .replace(let deleteCount):
+            applyReplacement(
+                proxy: proxy,
+                deleteCount: deleteCount,
+                replacement: suggestion,
+                addSpace: true
+            )
+            suggestionState.pendingUndo = nil
+            suggestionState.clear()
+
+        case .abort(let reason):
+            // Stale `currentWord` mid-word: inserting here would reproduce the
+            // very bug this fixes. Swallow the tap — the bar refreshes on the
+            // next keystroke (same outcome as replaceCurrentWord, #191).
+            logReplacementAborted(proxy: proxy, word: suggestionState.currentWord, reason: reason)
+        }
     }
 
     /// Reverts an autocorrection, preserving any characters typed after the correction.
@@ -524,22 +562,42 @@ struct KeyboardRootView: View {
             word: currentWord
         ) {
         case .ok(let deleteCount):
-            for _ in 0..<deleteCount {
-                proxy.deleteBackward()
-            }
-        case .failed(let reason):
-            #if DEBUG
-            AutocorrectDebugLog.replacementAborted(
-                word: currentWord,
-                reason: reason,
-                contextTail: DictusKeyboardBridge.contextTail(proxy.documentContextBeforeInput)
+            applyReplacement(
+                proxy: proxy,
+                deleteCount: deleteCount,
+                replacement: replacement,
+                addSpace: addSpace
             )
-            #endif
-            return
+        case .failed(let reason):
+            logReplacementAborted(proxy: proxy, word: currentWord, reason: reason)
+        }
+    }
+
+    /// Executes a validated replacement: deletes exactly `deleteCount` graphemes,
+    /// then inserts. Only ever called with a count that a boundary check produced.
+    private func applyReplacement(
+        proxy: UITextDocumentProxy,
+        deleteCount: Int,
+        replacement: String,
+        addSpace: Bool
+    ) {
+        for _ in 0..<deleteCount {
+            proxy.deleteBackward()
         }
         proxy.insertText(replacement)
         if addSpace {
             proxy.insertText(" ")
         }
+    }
+
+    /// Logs a replacement the boundary check refused (#191). Debug builds only.
+    private func logReplacementAborted(proxy: UITextDocumentProxy, word: String, reason: String) {
+        #if DEBUG
+        AutocorrectDebugLog.replacementAborted(
+            word: word,
+            reason: reason,
+            contextTail: DictusKeyboardBridge.contextTail(proxy.documentContextBeforeInput)
+        )
+        #endif
     }
 }


### PR DESCRIPTION
refs #335

## What this was for

Tapping a suggestion while a word was being typed sometimes **appended** it instead of replacing the partial word — `concerne` + a tap on `concerné` gave `concerneconcerné` (observed on device, French, WhatsApp, 1.8.0 build 25).

It was not random. The suggestion bar has an `.undoAvailable` mode, active for as long as an autocorrect undo chip is showing, and `pendingUndo` survives every ordinary character — so **the entire word typed right after an autocorrect fell in the broken window**. In that mode the bar fills slots 1-2 with completions of the word in progress, but the tap handler routed every non-zero slot to `handlePredictionTap`, which is insert-only by design (a prediction lands after a space). No delete, no boundary check: the suggestion got glued to the partial word.

## What changed

**`DictusCore/Sources/DictusCore/SuggestionTapRouting.swift`** (new) — `decide(context:currentWord:) -> Decision` with `.replace(deleteCount:)` / `.insert` / `.abort(reason:)`. It reuses `AutocorrectReplacement.check` for the mid-word case, so the #191 boundary rule stays a single source of truth. Pure, in DictusCore, therefore covered by the only test suite in the repo — exactly why `AutocorrectReplacement` was extracted in the first place.

The routing table, as specified in the issue:

| live context ends with | check | action |
| --- | --- | --- |
| non-whitespace (mid-word) | `.ok(deleteCount)` | delete `deleteCount`, insert suggestion + space |
| non-whitespace (mid-word) | `.failed` (stale `currentWord`) | do nothing, log `replacementAborted` |
| whitespace, newline, empty, nil | not consulted | insert + space (`handlePredictionTap`), unchanged |

`currentWord` alone would have been an unsafe discriminator: `updateAsync` early-returns on a whitespace-terminated context **without** clearing `currentWord` in `.predictions`/`.undoAvailable` mode, so it can hold a word that is no longer in the document. The decision is taken from `documentContextBeforeInput`, re-read at tap time.

The abort row is deliberate: falling back to an insert there would reproduce this exact bug. A tap that does nothing is recoverable, a tap that corrupts the text is not.

**`DictusKeyboard/KeyboardRootView.swift`** — the `.undoAvailable` slots 1-2 branch now executes that decision (`applyUndoModeSuggestion`). Slot 0 (undo) is untouched. `replaceCurrentWord`'s body is split into `applyReplacement` and `logReplacementAborted` so both paths share one executor and one abort log.

`handlePredictionTap` is unchanged.

## To test by hand

The bug needs a real host app; no simulator can produce it. **Reset the user dictionary before the run** (Settings → autocorrect debug section), otherwise learned words shadow the corrections.

1. French keyboard, autocorrect on, open WhatsApp (or Messages).
2. Type `cliengd` then space. → The word is autocorrected and the bar shows the undo chip in slot 0.
3. Without pressing space again, type `concerne`. → Slots 1-2 now show completions (`concerné`, …).
4. Tap slot 1 or 2. → **The partial word is replaced**: `... concerné ` — not `concerneconcerné`. This is the regression under test.
5. Redo steps 2-3, then tap **slot 0**. → The autocorrect is reverted to `cliengd`, the characters typed after it are preserved.
6. Redo step 2 only (autocorrect fired, undo chip showing, cursor after a space). Tap slot 1. → The predicted word is inserted followed by a space, and the bar immediately shows the next chained predictions.
7. Redo steps 2-3, then **backspace the partial word away entirely** so the cursor sits right after the space. Tap slot 1. → The prediction is inserted, nothing is deleted, the previous word is intact.
8. With **no** pending undo, type a partial word and tap a completion/correction. → Unchanged: the word is replaced.

## Verification already done

- `cd DictusCore && swift test` → `Executed 842 tests, with 1 test skipped and 0 failures`, including 11 new `SuggestionTapRoutingTests`: mid-word matching, mid-word stale (`suffix-mismatch`), empty `currentWord`, word glued to the previous token, **space-terminated context with a non-empty stale `currentWord` (routes to insert, not abort)**, newline-terminated, empty context, nil context, accented word (grapheme count), decomposed-vs-precomposed canonical equivalence.
- `swiftlint lint --strict` → `Found 0 violations, 0 serious in 174 files`.
- `xcodebuild build -scheme DictusApp -configuration Debug -destination 'platform=iOS Simulator,id=…'` (all three targets) → `** BUILD SUCCEEDED **`, after `-resolvePackageDependencies` + `./scripts/patch-fluidaudio-swift5.sh build/DerivedData`.

## Note, not addressed here

The keyboard bridge's `lastInsertedCharacter` is `private(set)`, so a suggestion tap that replaces a word cannot update it. That is pre-existing behaviour of the `.completions` tap path and the new `.replace` path inherits it — out of scope for this fix, worth its own issue if the adaptive accent key ever misbehaves right after a suggestion tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQWUbjeFs9yoYsxrsweweZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved suggestion taps in undo mode by inserting predictions at word boundaries and replacing matching words in progress.
  * Added safer handling for outdated or mismatched suggestions.

* **Bug Fixes**
  * Prevented stale suggestions from overwriting changed text.
  * Improved support for Unicode and normalized text matching.
  * Preserved existing validated replacement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->