### PR TITLE
Let each status message own its own three seconds (refs #342)

### DIFF
--- a/DictusCore/Sources/DictusCore/StatusMessageLifetime.swift
+++ b/DictusCore/Sources/DictusCore/StatusMessageLifetime.swift
@@ -1,0 +1,93 @@
+// DictusCore/Sources/DictusCore/StatusMessageLifetime.swift
+// How long the keyboard's toolbar message stays up, and which pending clear is
+// allowed to take it down.
+
+import Foundation
+
+/// Identity for the toolbar's status message, so a clear scheduled for one message
+/// can never take down the one that replaced it (#342).
+///
+/// ### The failure this exists for
+///
+/// Every status message used to schedule an unconditional clear three seconds out:
+///
+/// ```swift
+/// assignStatusMessage(errorMsg, reason: "appError")
+/// DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
+///     self?.assignStatusMessage(nil, reason: "appError-timeout")
+/// }
+/// ```
+///
+/// That closure clears whatever is on the toolbar when it fires, not the message it
+/// was scheduled for. Two dictations failing two seconds apart is enough to see it,
+/// and two mic taps are enough to produce that -- both attempts fail on "recording
+/// too short". The second message inherits the remainder of the first one's timer and
+/// dies after a second, observed on device on `1.8.0 (25)`:
+///
+/// ```
+/// [13:42:27Z] KBD dictationMessageCleared reason=replaced displayedCount=3
+/// [13:42:27Z] KBD dictationMessageSet reason=appError owner=952A01A2 visible=true
+/// [13:42:28Z] KBD dictationMessageCleared reason=appError-timeout displayedCount=0
+/// ```
+///
+/// The cost is not cosmetic. Two failures in a row are rarely the same failure twice:
+/// the first is usually the cheap one the user caused, the second the one that needs
+/// an action from them ("no model downloaded", "microphone unavailable"). Losing the
+/// second loses the informative one. It also manufactures `displayedCount=0`, which
+/// #261 defined as the signal that a message was never seen and mapped to `.warning`
+/// so an agent reading an exported log can find it -- noise in the one channel built
+/// to answer that question (#255).
+///
+/// ### Why a token rather than a cancellable work item
+///
+/// Holding the pending `DispatchWorkItem` and cancelling it before scheduling the next
+/// one has fewer moving parts, but it only works while every future message source
+/// remembers to route through the cancelling funnel. A token is checked by the clear
+/// itself, so a message assigned by a site that has never heard of any of this still
+/// invalidates the clears that came before it.
+///
+/// Lives in DictusCore because the keyboard extension has no test bundle, so a rule
+/// left there is unprovable. Same reasoning as `TranscribingStageHold`,
+/// `DictationSessionGeneration` and `KeyboardAreaMode`.
+public struct StatusMessageLifetime: Equatable, Sendable {
+
+    /// How long a status message stays on the toolbar.
+    ///
+    /// WHY one constant for every message: the two sites that raise one used to carry
+    /// their own three seconds, one as a literal and one as a named constant, and they
+    /// cross-cleared each other precisely because they were the same length by accident
+    /// rather than by construction.
+    ///
+    /// Whether three seconds is the right number, whether the message should be
+    /// dismissible, and whether some failures deserve no message at all, are #313's
+    /// questions. This is the place that number lives, not a judgement about it.
+    public static let displayDuration: TimeInterval = 3
+
+    /// Token of the message currently holding the toolbar.
+    public private(set) var current: Int
+
+    public init(current: Int = 0) {
+        self.current = current
+    }
+
+    /// A message was assigned. Whatever was on the toolbar before no longer owns it,
+    /// and neither does any clear scheduled for it.
+    ///
+    /// Called for clears as well as for messages: a message taken down early by a
+    /// cancel or an insertion invalidates its own pending timeout the same way a
+    /// replacement does.
+    @discardableResult
+    public mutating func advance() -> Int {
+        current += 1
+        return current
+    }
+
+    /// Whether a clear scheduled under `token` may still take the toolbar down.
+    ///
+    /// Fails closed: a clear only fires while the message it was scheduled for is
+    /// still the current one, so any future reason to change the message invalidates
+    /// outstanding clears as soon as it advances the token.
+    public func mayClear(_ token: Int) -> Bool {
+        token == current
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/StatusMessageLifetimeTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/StatusMessageLifetimeTests.swift
@@ -1,0 +1,140 @@
+// DictusCore/Tests/DictusCoreTests/StatusMessageLifetimeTests.swift
+// Which pending clear is allowed to take the toolbar message down (#342).
+
+import XCTest
+@testable import DictusCore
+
+/// Coverage for the rule that stops one status message's timeout from clearing the
+/// message that replaced it.
+///
+/// The timer itself is unreachable from a test: it lives in `KeyboardState` in the
+/// keyboard extension, a target with no test bundle, and reproducing it needs two
+/// dictations failing seconds apart in front of a user. What is testable is the rule
+/// the timer consults, and the rule is where the bug was -- there was no rule at all,
+/// only an unconditional clear.
+final class StatusMessageLifetimeTests: XCTestCase {
+
+    // MARK: - The rule
+
+    /// The ordinary case, which has to keep working: nothing happened during the
+    /// three seconds, so the message clears itself on time.
+    func testAMessageClearsItselfWhenNothingReplacedIt() {
+        var lifetime = StatusMessageLifetime()
+        let message = lifetime.advance()
+
+        XCTAssertTrue(lifetime.mayClear(message))
+    }
+
+    /// The bug. A clear scheduled for the first message must not fire against the
+    /// second.
+    func testAClearScheduledForAReplacedMessageMayNotFire() {
+        var lifetime = StatusMessageLifetime()
+        let first = lifetime.advance()
+
+        lifetime.advance()
+
+        XCTAssertFalse(
+            lifetime.mayClear(first),
+            "the first message's timeout cleared the message that replaced it"
+        )
+    }
+
+    /// The replacement keeps its own full duration -- which is the point of the fix,
+    /// not just that the stale timer goes quiet.
+    func testTheReplacingMessageOwnsItsOwnClear() {
+        var lifetime = StatusMessageLifetime()
+        lifetime.advance()
+        let second = lifetime.advance()
+
+        XCTAssertTrue(lifetime.mayClear(second))
+    }
+
+    /// A message taken down early -- by a cancel, an insertion or a watchdog reset --
+    /// invalidates its own pending timeout too. Otherwise that timeout would survive
+    /// to clear whatever came next.
+    func testAMessageClearedEarlyInvalidatesItsOwnPendingTimeout() {
+        var lifetime = StatusMessageLifetime()
+        let message = lifetime.advance()
+
+        // `forceResetToIdle` / `requestCancel` / `insertTranscription` all assign nil.
+        lifetime.advance()
+
+        XCTAssertFalse(lifetime.mayClear(message))
+    }
+
+    /// Once invalidated, always invalidated. A late timer must not come back to life
+    /// because the token happened to move again.
+    func testAnInvalidatedClearStaysInvalidatedAcrossFurtherMessages() {
+        var lifetime = StatusMessageLifetime()
+        let first = lifetime.advance()
+
+        lifetime.advance()
+        lifetime.advance()
+        lifetime.advance()
+
+        XCTAssertFalse(lifetime.mayClear(first))
+    }
+
+    /// A token is never reissued, so no two messages can ever answer to the same
+    /// pending clear.
+    func testEveryAssignmentGetsATokenOfItsOwn() {
+        var lifetime = StatusMessageLifetime()
+        let tokens = (0..<10).map { _ in lifetime.advance() }
+
+        XCTAssertEqual(Set(tokens).count, tokens.count, "a token was handed out twice")
+    }
+
+    // MARK: - The device sequence
+
+    /// The exact shape of the 2026-08-06 device report: the mic is tapped twice, two
+    /// seconds apart, both recordings are too short to transcribe. Before the fix the
+    /// second message lived one second and its `dictationMessageCleared` line carried
+    /// `displayedCount=0`.
+    func testASecondFailureTwoSecondsLaterKeepsItsOwnThreeSeconds() {
+        var lifetime = StatusMessageLifetime()
+
+        // t=0: first failure raises a message and schedules its clear for t=3.
+        let firstFailure = lifetime.advance()
+
+        // t=2: second failure replaces it and schedules its own clear for t=5.
+        let secondFailure = lifetime.advance()
+
+        // t=3: the first clear fires. It must find nothing of its own left to do.
+        XCTAssertFalse(lifetime.mayClear(firstFailure), "the second message died at t=3")
+
+        // t=5: the second clear fires, having had its full three seconds on screen.
+        XCTAssertTrue(lifetime.mayClear(secondFailure))
+    }
+
+    /// The cross-source case named in the issue: the two sites that raise a message
+    /// are `refreshFromDefaults` (`appError`) and `reconcileAbandonedDictation`
+    /// (`reconciled`). They clear each other as readily as each clears itself, and the
+    /// log then names the wrong `reason` on the clear line.
+    func testAReconciledMessageIsNotTruncatedByAnEarlierAppError() {
+        var lifetime = StatusMessageLifetime()
+        let appError = lifetime.advance()
+        let reconciled = lifetime.advance()
+
+        XCTAssertFalse(lifetime.mayClear(appError), "appError-timeout cleared the reconciled message")
+        XCTAssertTrue(lifetime.mayClear(reconciled))
+    }
+
+    /// And the other way round, since the ordering is not fixed: a dictation can be
+    /// reconciled as abandoned and then fail, as readily as the reverse.
+    func testAnAppErrorIsNotTruncatedByAnEarlierReconciledMessage() {
+        var lifetime = StatusMessageLifetime()
+        let reconciled = lifetime.advance()
+        let appError = lifetime.advance()
+
+        XCTAssertFalse(lifetime.mayClear(reconciled), "reconciled-timeout cleared the app error")
+        XCTAssertTrue(lifetime.mayClear(appError))
+    }
+
+    // MARK: - The duration
+
+    /// One constant, so the two sites cannot drift apart. Its value is #313's
+    /// question; that there is exactly one of it is this issue's.
+    func testTheDisplayDurationIsLongEnoughToBeRead() {
+        XCTAssertEqual(StatusMessageLifetime.displayDuration, 3)
+    }
+}

--- a/DictusKeyboard/KeyboardState.swift
+++ b/DictusKeyboard/KeyboardState.swift
@@ -181,6 +181,13 @@ class KeyboardState: ObservableObject {
     /// it lives, or what it says.
     @Published var statusMessage: String? {
         didSet {
+            // Advanced before the guard, and before anything else here, so it counts
+            // writes rather than changes (#342): a message re-raised with the exact
+            // same text is still a new message and deserves a full three seconds, and
+            // the guard below would swallow it. The funnel argument applies to the
+            // token for the same reason it applies to the log line -- a writer that
+            // skipped `assignStatusMessage` would otherwise leave a stale clear armed.
+            messageLifetime.advance()
             guard oldValue != statusMessage else { return }
             logStatusMessageTransition(from: oldValue)
             statusMessageReason = Self.unspecifiedMessageReason
@@ -191,6 +198,11 @@ class KeyboardState: ObservableObject {
     /// observer above.
     private var statusMessageReason = KeyboardState.unspecifiedMessageReason
     private static let unspecifiedMessageReason = "unspecified"
+
+    /// Which message currently holds the toolbar, so a clear scheduled three seconds
+    /// ago can only take down the message it was scheduled for (#342). Advanced by the
+    /// observer above; read by `presentStatusMessage`. The rule is tested in DictusCore.
+    private var messageLifetime = StatusMessageLifetime()
 
     /// How many live views have reported putting the current message on screen.
     /// Reset when a message is assigned, reported when it ends: `displayedCount=0`
@@ -624,10 +636,11 @@ class KeyboardState: ObservableObject {
                        let errorMsg = DictationErrorChannel.current,
                        errorMsg != presentedErrorMessage {
                         presentedErrorMessage = errorMsg
-                        assignStatusMessage(errorMsg, reason: "appError")
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
-                            self?.assignStatusMessage(nil, reason: "appError-timeout")
-                        }
+                        presentStatusMessage(
+                            errorMsg,
+                            reason: "appError",
+                            timeoutReason: "appError-timeout"
+                        )
                     }
                 }
             }
@@ -1375,11 +1388,6 @@ class KeyboardState: ObservableObject {
 /// class's private members, so nothing had to be widened to make room.
 private extension KeyboardState {
 
-    /// How long the "the recording was interrupted" message stays on the toolbar.
-    /// Matches the `.failed` message lifetime in `refreshFromDefaults`, deliberately:
-    /// this is the same failure UX, reached from a different direction.
-    static let interruptedMessageDuration: TimeInterval = 3
-
     /// What the App Group says about the dictation, and what that means.
     struct DictationLivenessReading {
         let verdict: DictationSessionLiveness
@@ -1487,13 +1495,11 @@ private extension KeyboardState {
         // wording is "interrupted", not "crashed": from the user's side that is both
         // truer and less alarming, and it is what they need to know -- the recording
         // is gone and the next tap starts fresh.
-        assignStatusMessage(
+        presentStatusMessage(
             String(localized: "Recording interrupted. Please try again."),
-            reason: "reconciled-\(source)"
+            reason: "reconciled-\(source)",
+            timeoutReason: "reconciled-timeout"
         )
-        DispatchQueue.main.asyncAfter(deadline: .now() + Self.interruptedMessageDuration) { [weak self] in
-            self?.assignStatusMessage(nil, reason: "reconciled-timeout")
-        }
     }
 }
 
@@ -1523,6 +1529,30 @@ extension KeyboardState {
     func assignStatusMessage(_ message: String?, reason: String) {
         statusMessageReason = reason
         statusMessage = message
+    }
+
+    /// Put a message on the toolbar and take it down again once it has had its time.
+    ///
+    /// WHY the token rather than a bare `asyncAfter` (#342): the pending clear used to
+    /// capture nothing, so it cleared whatever was current when it fired. Two mic taps
+    /// two seconds apart were enough to lose the second message after one second, and
+    /// to name `appError-timeout` on a clear that took down a `reconciled` message. The
+    /// token is read here and checked in the closure, so a clear can only ever take
+    /// down the message it was scheduled for. Nothing is logged when it declines: the
+    /// `set` and `cleared` pair already bracket every message's life, and #255 makes a
+    /// line that says "I did nothing" a cost rather than a neutral.
+    ///
+    /// WHY every timed message goes through one function: it is the same argument
+    /// `assignStatusMessage` makes for itself above. A future site that schedules its
+    /// own clear would reintroduce the bug in full, and there would be nothing to stop
+    /// it -- here there is no reason to write one.
+    func presentStatusMessage(_ message: String, reason: String, timeoutReason: String) {
+        assignStatusMessage(message, reason: reason)
+        let token = messageLifetime.current
+        DispatchQueue.main.asyncAfter(deadline: .now() + StatusMessageLifetime.displayDuration) { [weak self] in
+            guard let self, self.messageLifetime.mayClear(token) else { return }
+            self.assignStatusMessage(nil, reason: timeoutReason)
+        }
     }
 
     /// Record a message assignment or its end. Called only from `statusMessage`'s


### PR DESCRIPTION
## What this was for

When two dictations failed within about three seconds of each other, the user read the
first message and never saw the second. The second was set, inherited whatever was left of
the *first* message's timer, and vanished — sometimes after less than a second. Two mic taps
in quick succession were enough to produce it.

That matters because of what the second message usually is. Two failures in a row are rarely
the same failure twice: the first is often the cheap one the user caused ("recording too
short"), the second the one that actually needs an action from them ("no model downloaded",
"microphone unavailable, relaunch the app"). Losing the second loses the informative one.

It also polluted the instrumentation. `displayedCount=0` is what #261 defined as "the user
was never told", and it is mapped to `.warning` so an agent reading an exported log can find
it. A timer that manufactures `displayedCount=0` out of ordinary double taps puts noise in
the one channel built to answer that question (#255).

## To test by hand

The keyboard extension cannot be enabled on a simulator (`docs/agents/simulator.md` §7), so
everything below needs the device. Check `rev` on line 2 of the exported log matches this
branch before trusting any of it.

1. Build and install this branch on the iPhone, and open any app with a text field.
2. Tap the mic and stop it almost immediately, so the recording is too short to transcribe.
   Expected: a red message appears in the keyboard toolbar.
3. Within two seconds, do it again. Expected: the toolbar shows the second failure's message
   and it stays readable for a full three seconds from the moment it appeared — not one
   second, and it does not vanish the instant the first message's three seconds are up.
4. Export the log and read the `dictationMessageSet` / `dictationMessageCleared` lines.
   Expected: every `dictationMessageCleared` carries a non-zero `displayedCount`, and no line
   reads `reason=appError-timeout displayedCount=0`.
   Note: if both failures produce the *same* sentence, the toolbar keeps showing it
   continuously and you will see one `set` / `cleared` pair rather than two — that is correct
   and is what "the second message got its full time" looks like when the text is identical.
   The check that matters is that nothing carries `displayedCount=0`.
5. Regression, single failure: tap the mic, stop it immediately, then do nothing. Expected:
   the message stays about three seconds and then disappears on its own. It must not stay up
   forever.
6. Regression, message replaced by success: fail one dictation, then immediately do a normal
   dictation that succeeds. Expected: the error message is gone as soon as the text is
   inserted, and the log shows its `dictationMessageCleared` with `reason=textInserted`.
7. Regression, the reconciled path (this one is awkward but it is the second timed message):
   start a dictation from the keyboard, swipe back to the host app, force-quit Dictus from
   the app switcher, then return to the text field. Expected: the overlay drops within about
   a second and the toolbar says "Recording interrupted. Please try again." for three
   seconds. In the log, its clear line reads `reason=reconciled-timeout`, never
   `reason=appError-timeout`.

Steps 3, 4 and 7 are the acceptance criteria that only a device can settle. Everything else
in this PR is covered by the commands in the table below.

## What changed

**`DictusCore/Sources/DictusCore/StatusMessageLifetime.swift`** (new). A monotonic token
plus `mayClear(_:)`, and the one display-duration constant. It fails closed: a clear only
fires while the message it was scheduled for is still the current one, so any future reason
to change the message invalidates outstanding clears without knowing they exist.

A token rather than a held `DispatchWorkItem`, per the issue's own recommendation: cancelling
only works while every future message source remembers to route through the canceller,
whereas a token is checked by the clear itself. It lives in DictusCore because the keyboard
extension has no test bundle — same reasoning as `TranscribingStageHold` and
`DictationSessionGeneration`.

**`DictusKeyboard/KeyboardState.swift`**. Both timed messages now go through one
`presentStatusMessage(_:reason:timeoutReason:)`, which captures the token of the message it
just assigned and checks it before clearing. The token is advanced from `statusMessage`'s own
observer, *before* its equality guard, for two reasons: a writer that skipped
`assignStatusMessage` would otherwise leave a stale clear armed (the funnel argument #261
already makes for the log line), and a message re-raised with identical text is still a new
message that deserves its full duration — which is exactly what two identical "recording too
short" failures produce. `interruptedMessageDuration` and the literal `3` are gone.

Nothing is logged when a superseded clear declines to fire. `set` and `cleared` already
bracket every message's life, so the reader loses nothing, and #255 makes a line that says "I
did nothing" a cost rather than a neutral. The `dictationMessage*` event shapes and
`displayedCount` are untouched, and so is anything #313 owns — the duration's value, the copy
and the presentation.

I checked every site that writes the message, not only the two the issue quotes: the other
five (`forceResetToIdle`, `requestCancel`, `insertTranscription`, and the two timeout clears)
assign `nil` and schedule nothing, so exactly two sites had this shape and both are fixed.

## Acceptance criteria

| criterion | status | evidence |
| --- | --- | --- |
| Two failures two seconds apart produce two messages, the second displayed for its full duration | rule proven, device pending | `testASecondFailureTwoSecondsLaterKeepsItsOwnThreeSeconds` passes; manual step 3 |
| Each `dictationMessageCleared` names the reason belonging to the message it cleared | rule proven, device pending | each site now passes its own `timeoutReason`; `testAClearScheduledForAReplacedMessageMayNotFire`; manual steps 4 and 7 |
| A `reconciled` message is not truncated by an earlier `appError`, and vice versa | rule proven, device pending | `testAReconciledMessageIsNotTruncatedByAnEarlierAppError` and the reverse; manual step 7 |
| One named constant for the display duration, used by both sites | done | `grep -rn "displayDuration" DictusKeyboard/ DictusCore/Sources/` returns the definition and exactly one use; `grep -n "asyncAfter" DictusKeyboard/KeyboardState.swift` shows one scheduled clear where there were two |
| `swift test` passes and `swiftlint lint --strict` is clean | done | `Executed 861 tests, with 1 test skipped and 0 failures`; `Done linting! Found 0 violations, 0 serious in 176 files.` |

Build: `xcodebuild build -scheme DictusApp -destination 'platform=iOS Simulator,id=…'` with
`-derivedDataPath build/DerivedData` after `./scripts/patch-fluidaudio-swift5.sh
build/DerivedData` — `** BUILD SUCCEEDED **`. That covers all three targets, since DictusApp
embeds the keyboard, the widgets and Core.

## Not verified

The three criteria marked "device pending" above. The rule they depend on is unit-tested, but
that a real double tap now leaves two readable messages on a real toolbar is only observable
on a device, and CI never runs the tests either, so the numbers above are from a local run.

Closes nothing automatically — this targets `develop`, so #342 needs closing by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Status messages now remain visible for their full display duration, including when the same message is shown again.
  * Newer messages are no longer cleared prematurely by delayed expiration from earlier messages.
  * Error and recovery notifications now reliably replace previous status messages without losing visibility time.
* **User Experience**
  * Toolbar notifications provide more consistent and predictable timing across repeated updates and interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->