### PR TITLE
Emit the git revision as its own bundled resource (refs #344)

### DIFF
--- a/.claude/skills/device-build/SKILL.md
+++ b/.claude/skills/device-build/SKILL.md
@@ -33,7 +33,7 @@ Device id as of 2026-08-09: `B05E304C-D238-5A94-B0D9-F4BF366A7FC6` ("Iphone de B
 
 ## Build from the dedicated worktree, never the main clone
 
-```
+```text
 /Users/pierreviviere/dev/dictus-wt/device
 ```
 
@@ -82,7 +82,7 @@ Both must print the sha you checked out. **Anything else — a different sha, or
 
 The build log carries the same line if you would rather grep it:
 
-```
+```text
 note: build info f31f7da@fix/344-git-sha-injection -> …/DictusApp.app/DictusBuildInfo.plist
 ```
 

--- a/.claude/skills/device-build/SKILL.md
+++ b/.claude/skills/device-build/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: device-build
+description: Build Dictus and install it on Pierre's physical iPhone over Wi-Fi, from any commit, without him touching the Mac. Use when he asks for a build on his phone ("build ça sur mon téléphone", "installe la PR sur l'iPhone", "je veux tester X sur device") — including when he is away from the computer.
+---
+
+# Build onto the iPhone, remotely
+
+Pierre is usually not at the Mac. He tests on his phone and talks to you from it. This skill puts a named commit on that phone and proves which commit it is.
+
+**The whole point is the proof.** He validates PRs by reading `rev` on line 2 of an exported log. A build that installs but reports the wrong commit is worse than no build: it produces a validation of code that was never tested. One mechanism in this repo still makes that failure easy, and it has bitten already (see Traps).
+
+## What must be true before you start
+
+Check, don't assume — each of these has its own error and its own fix.
+
+```bash
+xcrun devicectl list devices
+```
+
+The iPhone must be listed `available (paired)`. Then:
+
+```bash
+xcrun devicectl device info details --device <id> \
+  | grep -E "tunnelState|developerModeStatus|osVersionNumber"
+```
+
+Wanted: `tunnelState: connected`, `developerModeStatus: enabled`.
+
+- **Not listed, or `unavailable`** — the Mac is asleep, off Wi-Fi, or the phone left the network. Pierre has to wake something; say which.
+- **Xcode older than the phone's iOS** is fine and expected. It blocks installing *from Xcode's UI*, which is why this skill exists. `devicectl` does not care.
+
+Device id as of 2026-08-09: `B05E304C-D238-5A94-B0D9-F4BF366A7FC6` ("Iphone de Bob", iPhone 15 Pro Max). Re-read it from `devicectl list devices` rather than trusting this line.
+
+## Build from the dedicated worktree, never the main clone
+
+```
+/Users/pierreviviere/dev/dictus-wt/device
+```
+
+Its `HEAD` is yours. The main clone's is not: Xcode is open on this project and other sessions share the machine, and a checkout there has been observed moving back under an agent **twelve seconds** after it was made. That produced a signed, installable build of the wrong branch.
+
+The worktree also keeps its own `build/DerivedData`, so package resolution survives between runs.
+
+```bash
+git -C /Users/pierreviviere/dev/dictus-wt/device fetch -q origin
+git -C /Users/pierreviviere/dev/dictus-wt/device checkout --detach <sha-or-ref> -q
+git -C /Users/pierreviviere/dev/dictus-wt/device rev-parse --short HEAD
+```
+
+Create it if missing: `git worktree add --detach ../dictus-wt/device <sha>`, then resolve once (below). Leave it in place afterwards — it is not per-issue, it is the build machine.
+
+**First use of a fresh worktree only** — packages resolve from zero and FluidAudio needs its Swift 5 patch or the build fails (#285):
+
+```bash
+cd /Users/pierreviviere/dev/dictus-wt/device
+xcodebuild -resolvePackageDependencies -project Dictus.xcodeproj -scheme DictusApp \
+  -derivedDataPath build/DerivedData
+./scripts/patch-fluidaudio-swift5.sh build/DerivedData
+```
+
+## Build, then verify, then install
+
+An incremental build is fine since #344. Add `clean` only when you have a reason of your own; it is no longer needed to make the revision correct.
+
+```bash
+cd /Users/pierreviviere/dev/dictus-wt/device
+xcodebuild build -project Dictus.xcodeproj -scheme DictusApp -configuration Debug \
+  -destination 'id=<device-id>' -derivedDataPath build/DerivedData -allowProvisioningUpdates
+```
+
+Signing needs nothing from Pierre: `-allowProvisioningUpdates` renews the team profile itself.
+
+**Verify before installing anyway.** The build no longer drops the revision on its own, but the wrong *checkout* still stamps the wrong sha, and that failure is invisible until he has already tested. Check both bundles — the app and the keyboard extension are separate binaries and the keyboard is what he is usually testing:
+
+```bash
+APP=build/DerivedData/Build/Products/Debug-iphoneos/DictusApp.app
+plutil -p "$APP/DictusBuildInfo.plist"
+plutil -p "$APP/PlugIns/DictusKeyboard.appex/DictusBuildInfo.plist"
+```
+
+Both must print the sha you checked out. **Anything else — a different sha, or the file absent — stop and do not install.** Re-read `git rev-parse --short HEAD` in the worktree: if it moved, something else is driving this checkout and Pierre needs to know before he tests anything.
+
+The build log carries the same line if you would rather grep it:
+
+```
+note: build info f31f7da@fix/344-git-sha-injection -> …/DictusApp.app/DictusBuildInfo.plist
+```
+
+```bash
+xcrun devicectl device install app --device <device-id> "$APP"
+xcrun devicectl device process launch --device <device-id> com.pivi.dictus
+```
+
+## Report
+
+Give him three things, always:
+
+- the sha now on the phone, and that `rev <sha>@HEAD` is what line 2 of the log must say
+- what the build was *for* — the issue or PR in his terms, not the diff
+- that installing resets the app's container: learned dictionary, settings and any stored dictation state are gone
+
+That last one is not a detail. A dev install has already invalidated a test run (learned words) and produced a bogus Live Activity issue (#294).
+
+## Traps
+
+**The revision no longer needs `clean` — but do not assume the old advice is gone from elsewhere.** Until #344 the `Inject Git SHA into Info.plist` phase wrote into the built `Info.plist`, which `ProcessInfoPlistFile` also produces. Nothing ordered the two, and an incremental build ran them the other way round, so a no-op rebuild four seconds after a good build left the key **absent** from both plists. The phase now writes its own `DictusBuildInfo.plist`, which nothing else produces, so no ordering can exist to get wrong. Any note you find telling you to `clean build` for the sha, or to `plutil` the `Info.plist`, predates that.
+
+**`git rev-parse` reads the worktree you are standing in.** The injection script runs `cd "$SRCROOT"`, so building the main clone stamps the main clone's HEAD no matter which sha you meant. This is the failure the worktree removes.
+
+**A green build is not an install.** `devicectl install` can fail after `BUILD SUCCEEDED` on a locked device or a dropped tunnel. Read its output; it prints `App installed:` and a bundle path on success.
+
+## When he asks for "the current develop"
+
+Fetch first, then build `origin/develop`'s tip by sha, not by branch name — a detached sha is what you can quote back to him and what he can check against the log.

--- a/Dictus.xcodeproj/project.pbxproj
+++ b/Dictus.xcodeproj/project.pbxproj
@@ -716,7 +716,7 @@
 				AA300001 /* Frameworks */,
 				AA600003 /* Resources */,
 				AA060001 /* Embed App Extensions */,
-				AA060010 /* Inject Git SHA into Info.plist */,
+				AA060010 /* Generate build info */,
 			);
 			buildRules = (
 			);
@@ -741,7 +741,7 @@
 				AA600002 /* Sources */,
 				AA300002 /* Frameworks */,
 				AA600004 /* Resources */,
-				AA060011 /* Inject Git SHA into Info.plist */,
+				AA060011 /* Generate build info */,
 			);
 			buildRules = (
 			);
@@ -763,7 +763,7 @@
 				BB600001 /* Sources */,
 				BB300001 /* Frameworks */,
 				BB600002 /* Resources */,
-				AA060012 /* Inject Git SHA into Info.plist */,
+				AA060012 /* Generate build info */,
 			);
 			buildRules = (
 			);
@@ -869,7 +869,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		AA060010 /* Inject Git SHA into Info.plist */ = {
+		AA060010 /* Generate build info */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -879,16 +879,16 @@
 			);
 			inputPaths = (
 			);
-			name = "Inject Git SHA into Info.plist";
+			name = "Generate build info";
 			outputFileListPaths = (
 			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Inject the current git commit short SHA + branch into the built Info.plist\n# so that PersistentLog can expose them at runtime without any manual discipline.\n# We write to the COPY of Info.plist in TARGET_BUILD_DIR, not the source file,\n# so `git status` stays clean.\nset -e\nGIT_COMMIT=$(cd \"$SRCROOT\" && git rev-parse --short HEAD 2>/dev/null || echo \"unknown\")\nGIT_BRANCH=$(cd \"$SRCROOT\" && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo \"unknown\")\nPLIST=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\nif [ ! -f \"$PLIST\" ]; then\n  echo \"warning: Info.plist not found at $PLIST — skipping git SHA injection\"\n  exit 0\nfi\n/usr/libexec/PlistBuddy -c \"Set :GitCommitSHA $GIT_COMMIT\" \"$PLIST\" 2>/dev/null || \\\n  /usr/libexec/PlistBuddy -c \"Add :GitCommitSHA string $GIT_COMMIT\" \"$PLIST\"\n/usr/libexec/PlistBuddy -c \"Set :GitBranch $GIT_BRANCH\" \"$PLIST\" 2>/dev/null || \\\n  /usr/libexec/PlistBuddy -c \"Add :GitBranch string $GIT_BRANCH\" \"$PLIST\"\n";
+			shellScript = "# Write the current git commit short SHA + branch into a generated resource inside\n# the built bundle, so PersistentLog can report at runtime which commit the binary\n# came from without any manual discipline.\n#\n# WHY a file of its own rather than the built Info.plist (#344): Info.plist is\n# produced by ProcessInfoPlistFile and nothing ordered this phase against it, so an\n# incremental build scheduled the two the other way round and the injected keys were\n# wiped. Nothing else produces DictusBuildInfo.plist, so no ordering question exists.\n#\n# The phase stays \"always out of date\" on purpose: HEAD moves without any input file\n# changing, so dependency analysis would skip it exactly when it matters.\nset -e\nGIT_COMMIT=$(cd \"$SRCROOT\" && git rev-parse --short HEAD 2>/dev/null || echo \"unknown\")\nGIT_BRANCH=$(cd \"$SRCROOT\" && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo \"unknown\")\nBUILD_INFO=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/DictusBuildInfo.plist\"\nmkdir -p \"$(dirname \"$BUILD_INFO\")\"\nrm -f \"$BUILD_INFO\"\n/usr/libexec/PlistBuddy \\\n  -c \"Add :GitCommitSHA string $GIT_COMMIT\" \\\n  -c \"Add :GitBranch string $GIT_BRANCH\" \\\n  \"$BUILD_INFO\" >/dev/null\necho \"note: build info ${GIT_COMMIT}@${GIT_BRANCH} -> ${BUILD_INFO}\"\n";
 		};
-		AA060011 /* Inject Git SHA into Info.plist */ = {
+		AA060011 /* Generate build info */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -898,16 +898,16 @@
 			);
 			inputPaths = (
 			);
-			name = "Inject Git SHA into Info.plist";
+			name = "Generate build info";
 			outputFileListPaths = (
 			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Inject git commit short SHA + branch into the built Info.plist (keyboard extension).\nset -e\nGIT_COMMIT=$(cd \"$SRCROOT\" && git rev-parse --short HEAD 2>/dev/null || echo \"unknown\")\nGIT_BRANCH=$(cd \"$SRCROOT\" && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo \"unknown\")\nPLIST=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\nif [ ! -f \"$PLIST\" ]; then\n  echo \"warning: Info.plist not found at $PLIST — skipping git SHA injection\"\n  exit 0\nfi\n/usr/libexec/PlistBuddy -c \"Set :GitCommitSHA $GIT_COMMIT\" \"$PLIST\" 2>/dev/null || \\\n  /usr/libexec/PlistBuddy -c \"Add :GitCommitSHA string $GIT_COMMIT\" \"$PLIST\"\n/usr/libexec/PlistBuddy -c \"Set :GitBranch $GIT_BRANCH\" \"$PLIST\" 2>/dev/null || \\\n  /usr/libexec/PlistBuddy -c \"Add :GitBranch string $GIT_BRANCH\" \"$PLIST\"\n";
+			shellScript = "# Write the current git commit short SHA + branch into a generated resource inside\n# the built bundle, so PersistentLog can report at runtime which commit the binary\n# came from without any manual discipline.\n#\n# WHY a file of its own rather than the built Info.plist (#344): Info.plist is\n# produced by ProcessInfoPlistFile and nothing ordered this phase against it, so an\n# incremental build scheduled the two the other way round and the injected keys were\n# wiped. Nothing else produces DictusBuildInfo.plist, so no ordering question exists.\n#\n# The phase stays \"always out of date\" on purpose: HEAD moves without any input file\n# changing, so dependency analysis would skip it exactly when it matters.\nset -e\nGIT_COMMIT=$(cd \"$SRCROOT\" && git rev-parse --short HEAD 2>/dev/null || echo \"unknown\")\nGIT_BRANCH=$(cd \"$SRCROOT\" && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo \"unknown\")\nBUILD_INFO=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/DictusBuildInfo.plist\"\nmkdir -p \"$(dirname \"$BUILD_INFO\")\"\nrm -f \"$BUILD_INFO\"\n/usr/libexec/PlistBuddy \\\n  -c \"Add :GitCommitSHA string $GIT_COMMIT\" \\\n  -c \"Add :GitBranch string $GIT_BRANCH\" \\\n  \"$BUILD_INFO\" >/dev/null\necho \"note: build info ${GIT_COMMIT}@${GIT_BRANCH} -> ${BUILD_INFO}\"\n";
 		};
-		AA060012 /* Inject Git SHA into Info.plist */ = {
+		AA060012 /* Generate build info */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -917,14 +917,14 @@
 			);
 			inputPaths = (
 			);
-			name = "Inject Git SHA into Info.plist";
+			name = "Generate build info";
 			outputFileListPaths = (
 			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Inject git commit short SHA + branch into the built Info.plist (widgets extension).\nset -e\nGIT_COMMIT=$(cd \"$SRCROOT\" && git rev-parse --short HEAD 2>/dev/null || echo \"unknown\")\nGIT_BRANCH=$(cd \"$SRCROOT\" && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo \"unknown\")\nPLIST=\"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\nif [ ! -f \"$PLIST\" ]; then\n  echo \"warning: Info.plist not found at $PLIST — skipping git SHA injection\"\n  exit 0\nfi\n/usr/libexec/PlistBuddy -c \"Set :GitCommitSHA $GIT_COMMIT\" \"$PLIST\" 2>/dev/null || \\\n  /usr/libexec/PlistBuddy -c \"Add :GitCommitSHA string $GIT_COMMIT\" \"$PLIST\"\n/usr/libexec/PlistBuddy -c \"Set :GitBranch $GIT_BRANCH\" \"$PLIST\" 2>/dev/null || \\\n  /usr/libexec/PlistBuddy -c \"Add :GitBranch string $GIT_BRANCH\" \"$PLIST\"\n";
+			shellScript = "# Write the current git commit short SHA + branch into a generated resource inside\n# the built bundle, so PersistentLog can report at runtime which commit the binary\n# came from without any manual discipline.\n#\n# WHY a file of its own rather than the built Info.plist (#344): Info.plist is\n# produced by ProcessInfoPlistFile and nothing ordered this phase against it, so an\n# incremental build scheduled the two the other way round and the injected keys were\n# wiped. Nothing else produces DictusBuildInfo.plist, so no ordering question exists.\n#\n# The phase stays \"always out of date\" on purpose: HEAD moves without any input file\n# changing, so dependency analysis would skip it exactly when it matters.\nset -e\nGIT_COMMIT=$(cd \"$SRCROOT\" && git rev-parse --short HEAD 2>/dev/null || echo \"unknown\")\nGIT_BRANCH=$(cd \"$SRCROOT\" && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo \"unknown\")\nBUILD_INFO=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/DictusBuildInfo.plist\"\nmkdir -p \"$(dirname \"$BUILD_INFO\")\"\nrm -f \"$BUILD_INFO\"\n/usr/libexec/PlistBuddy \\\n  -c \"Add :GitCommitSHA string $GIT_COMMIT\" \\\n  -c \"Add :GitBranch string $GIT_BRANCH\" \\\n  \"$BUILD_INFO\" >/dev/null\necho \"note: build info ${GIT_COMMIT}@${GIT_BRANCH} -> ${BUILD_INFO}\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/DictusCore/Sources/DictusCore/PersistentLog.swift
+++ b/DictusCore/Sources/DictusCore/PersistentLog.swift
@@ -30,20 +30,53 @@ public enum PersistentLog {
     /// unreliable in keyboard extensions (can return the host app's ID).
     public static var source: String = "?"
 
+    /// Basename of the resource the "Generate build info" build phase writes into
+    /// every target's bundle. Changing it here means changing it in all three
+    /// script phases in `Dictus.xcodeproj`.
+    static let buildInfoResourceName = "DictusBuildInfo"
+
     /// Human-readable code revision marker, auto-injected at build time.
     ///
-    /// The "Inject Git SHA into Info.plist" Xcode build phase writes `GitCommitSHA`
-    /// (and `GitBranch`) into every target's built Info.plist on each build. This
-    /// computed property reads that value at runtime, so every log export carries
-    /// the exact commit the binary was built from with zero manual discipline.
+    /// The "Generate build info" Xcode build phase writes `DictusBuildInfo.plist`
+    /// (`GitCommitSHA` + `GitBranch`) into every target's bundle on each build. This
+    /// computed property reads that file at runtime, so every log export carries the
+    /// exact commit the binary was built from with zero manual discipline.
     ///
-    /// Fallbacks: returns "unknown" in environments where the Info.plist keys are
-    /// missing (unit tests linking DictusCore standalone, Swift Package previews,
-    /// or a build done outside the Xcode build phase).
+    /// WHY a file of its own rather than the built Info.plist (#344): the injection
+    /// used to write its two keys into `Info.plist`, which `ProcessInfoPlistFile`
+    /// also produces from the source plist. Nothing ordered the two tasks, and an
+    /// incremental build scheduled them the other way round, so a no-op rebuild
+    /// silently dropped the keys and the header read `rev unknown`. Nothing else
+    /// produces `DictusBuildInfo.plist`, so the ordering question cannot come back.
+    ///
+    /// Fallbacks: returns "unknown" wherever the file is absent (unit tests linking
+    /// DictusCore standalone, Swift Package previews, or a build done outside the
+    /// Xcode build phase). A build with no revision information has to keep saying
+    /// so — this never guesses and never reads git at runtime.
     public static var codeRevision: String {
-        let info = Bundle.main.infoDictionary
-        let sha = info?["GitCommitSHA"] as? String ?? "unknown"
-        if let branch = info?["GitBranch"] as? String, !branch.isEmpty, branch != "unknown" {
+        codeRevision(in: .main)
+    }
+
+    /// `codeRevision` against an explicit bundle, so tests can drive the lookup.
+    static func codeRevision(in bundle: Bundle) -> String {
+        codeRevision(readingBuildInfoAt: bundle.url(forResource: buildInfoResourceName, withExtension: "plist"))
+    }
+
+    /// The revision marker held in the build-info plist at `url`, or "unknown" when
+    /// there is no file, it cannot be parsed, or it carries no sha.
+    ///
+    /// A URL rather than a Bundle is the seam because bundle resource lookup follows
+    /// the host platform's layout, and these tests run on macOS while the code ships
+    /// on iOS. The parse is what is worth testing; the lookup is one line above.
+    static func codeRevision(readingBuildInfoAt url: URL?) -> String {
+        guard let url,
+              let data = try? Data(contentsOf: url),
+              let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
+              let info = plist as? [String: String] else {
+            return "unknown"
+        }
+        let sha = info["GitCommitSHA"] ?? "unknown"
+        if let branch = info["GitBranch"], !branch.isEmpty, branch != "unknown" {
             return "\(sha)@\(branch)"
         }
         return sha

--- a/DictusCore/Tests/DictusCoreTests/PersistentLogTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/PersistentLogTests.swift
@@ -297,6 +297,69 @@ final class PersistentLogTests: XCTestCase {
         XCTAssertTrue(result.contains("Another unparseable"), "Unparseable lines should be kept")
     }
 
+    // MARK: - Code revision
+
+    /// Issue #344: the revision comes from a generated `DictusBuildInfo.plist`, so
+    /// the happy path is "the build phase ran and the file is in the bundle".
+    func testCodeRevisionReadsGeneratedBuildInfo() throws {
+        let url = try writeBuildInfo(["GitCommitSHA": "3e9bdda", "GitBranch": "fix/344-git-sha-injection"])
+
+        XCTAssertEqual(
+            PersistentLog.codeRevision(readingBuildInfoAt: url),
+            "3e9bdda@fix/344-git-sha-injection")
+    }
+
+    /// A detached build stamps `GitBranch = HEAD`, which is meaningful, but a branch
+    /// that is empty or literally "unknown" would only add noise to the header.
+    func testCodeRevisionDropsAnUninformativeBranch() throws {
+        let noBranch = try writeBuildInfo(["GitCommitSHA": "3e9bdda"])
+        XCTAssertEqual(PersistentLog.codeRevision(readingBuildInfoAt: noBranch), "3e9bdda")
+
+        let unknownBranch = try writeBuildInfo(["GitCommitSHA": "3e9bdda", "GitBranch": "unknown"])
+        XCTAssertEqual(PersistentLog.codeRevision(readingBuildInfoAt: unknownBranch), "3e9bdda")
+
+        let emptyBranch = try writeBuildInfo(["GitCommitSHA": "3e9bdda", "GitBranch": ""])
+        XCTAssertEqual(PersistentLog.codeRevision(readingBuildInfoAt: emptyBranch), "3e9bdda")
+    }
+
+    /// A build with no revision information has to keep announcing itself. Never a
+    /// crash, never an invented sha, never a stale one carried over.
+    func testCodeRevisionFallsBackToUnknown() throws {
+        XCTAssertEqual(PersistentLog.codeRevision(readingBuildInfoAt: nil), "unknown")
+
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("absent_\(UUID().uuidString).plist")
+        XCTAssertEqual(PersistentLog.codeRevision(readingBuildInfoAt: missing), "unknown")
+
+        let garbage = FileManager.default.temporaryDirectory
+            .appendingPathComponent("garbage_\(UUID().uuidString).plist")
+        try Data("not a plist".utf8).write(to: garbage)
+        addTeardownBlock { try? FileManager.default.removeItem(at: garbage) }
+        XCTAssertEqual(PersistentLog.codeRevision(readingBuildInfoAt: garbage), "unknown")
+
+        let noSHA = try writeBuildInfo(["GitBranch": "develop"])
+        XCTAssertEqual(PersistentLog.codeRevision(readingBuildInfoAt: noSHA), "unknown@develop")
+    }
+
+    /// Acceptance criterion of #344: a build outside the Xcode build phase — this
+    /// very test bundle — reports "unknown" rather than crashing or guessing.
+    /// `Bundle.main` here is the XCTest runner, which carries no build info.
+    func testCodeRevisionIsUnknownOutsideTheXcodeBuildPhase() {
+        XCTAssertEqual(PersistentLog.codeRevision(in: .main), "unknown")
+        XCTAssertEqual(PersistentLog.codeRevision, "unknown")
+    }
+
+    /// Write a build-info plist to a temp file and register it for cleanup.
+    private func writeBuildInfo(_ contents: [String: String]) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("buildinfo_\(UUID().uuidString).plist")
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: contents, format: .xml, options: 0)
+        try data.write(to: url)
+        return url
+    }
+
     // MARK: - Export header
 
     func testExportHeaderFormat() {

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -91,7 +91,7 @@ CFBundleVersion            (build no.)  →  what Apple tracks: 18    (integer, 
 | Points at | the `chore: bump…` commit on develop | the release merge commit on main |
 | Answers | "when/what was build N" + promotion anchor | "exactly what is in production" |
 
-Why two tiers: build tags give full per-build traceability **without** cluttering the GitHub Releases page (only the Tags page) — this is what CI systems do. Release tags stay rare and meaningful: each one is a real, shipped version. Runtime traceability is *also* covered independently by the git-SHA injected into every built Info.plist (a build phase writes `GitCommitSHA` + `GitBranch`), so even an untagged build is identifiable from the app's debug log.
+Why two tiers: build tags give full per-build traceability **without** cluttering the GitHub Releases page (only the Tags page) — this is what CI systems do. Release tags stay rare and meaningful: each one is a real, shipped version. Runtime traceability is *also* covered independently by the git-SHA generated into every built bundle (a `Generate build info` build phase writes `GitCommitSHA` + `GitBranch` into `DictusBuildInfo.plist`), so even an untagged build is identifiable from the app's debug log.
 
 ## TestFlight → App Store: promote, don't rebuild
 


### PR DESCRIPTION
## What this was for

You validate a PR by reading `rev` on line 2 of an exported log. Today that line only tells the truth after a `clean build`: any incremental build silently drops the git sha and the header reads `rev unknown`, leaving you with a build you cannot identify. This makes the revision correct on every build, so line 2 is trustworthy again without anyone having to remember anything.

## To test by hand

The build-graph ordering is fully covered by the commands in **Verification** below, including the exact reproduction from the issue. Two things are left, and the first is the important one.

1. **Build from Xcode, in your own clone.** Xcode's build graph is the one case that already worked and must keep working, and it is the only build I could not exercise (an agent cannot open Xcode without stealing your focus). Check out this branch, build `DictusApp` normally with ⌘B, then in Terminal:
   ```bash
   APP=$(ls -dt ~/Library/Developer/Xcode/DerivedData/Dictus-*/Build/Products/Debug-iphoneos/DictusApp.app | head -1)
   plutil -p "$APP/DictusBuildInfo.plist"
   plutil -p "$APP/PlugIns/DictusKeyboard.appex/DictusBuildInfo.plist"
   ```
   Expected: both print `GitCommitSHA` equal to `git rev-parse --short HEAD`. Then press ⌘B again with nothing edited and re-run the two commands: same sha, still present.

2. **Read line 2 of a real export.** Run the app on the phone from that build, export the debug log from Settings, and check the header says `rev <sha>@fix/344-git-sha-injection` rather than `rev unknown`. This is the only step that proves the runtime read end to end on a device; everything below proves the file is in the bundle and that the identical lookup code resolves it, but the export itself needs a tap.

3. **Before you pull `develop` after merging**, delete the local untracked copy of the skill or git will refuse to check out over it:
   ```bash
   rm /Users/pierreviviere/dev/dictus/.claude/skills/device-build/SKILL.md
   ```
   See "One thing that contradicted the issue" below.

## What changed

The `Inject Git SHA into Info.plist` phase wrote `GitCommitSHA` and `GitBranch` into the built `Info.plist`, a file `ProcessInfoPlistFile` also produces from the source plist. Nothing declared an ordering between the two tasks, so the build system was free to schedule them either way, and it chose differently for a clean build than for an incremental one.

This is **option A** from the issue. The phase is now called `Generate build info` and writes `DictusBuildInfo.plist` straight into each target's bundle, never touching `Info.plist`. Nothing else produces that file, so there is no second writer to order against and the failure cannot reappear. Option B was not taken for the reason the issue gives: a positional guarantee is one a future edit can silently undo.

- `Dictus.xcodeproj/project.pbxproj` — all three phases (`DictusApp`, `DictusKeyboard`, `DictusWidgets`) rewritten, now byte-identical to each other. They stay "always out of date" on purpose: `HEAD` moves without any input file changing, so dependency analysis would skip them exactly when it matters. Each build now also echoes `note: build info <sha>@<branch> -> <path>` so the sha is greppable straight out of a build log.
- `DictusCore/Sources/DictusCore/PersistentLog.swift` — `codeRevision` reads the generated resource instead of `Bundle.main.infoDictionary`. Header format unchanged. The fallback stays `"unknown"`: no invented sha, no stale one, no git read at runtime.
- `DictusCore/Tests/.../PersistentLogTests.swift` — four new tests over the lookup, including the `"unknown"` path as an assertion rather than an observation.
- `.claude/skills/device-build/SKILL.md`, `docs/VERSIONING.md` — the workaround retired, the prose corrected.

**No `Copy Bundle Resources` entry, deliberately.** There is no source file to reference: the phase writes into the built product. A checked-in placeholder would be copied by `CpResource`, which is a second writer of the same node — exactly the failure being removed here. The past pbxproj trouble with explicit refs was about *source* files added to a target; there is no source file in this design.

## Verification

Simulator destination (`iPhone 17 Pro`, iOS 26.5), `-derivedDataPath build/DerivedData`. A simulator build exercises the same build-graph ordering as a device build.

**1. A clean build and an incremental build of the same commit both report that commit** — ✅

```
$ xcodebuild clean build … && plutil -extract GitCommitSHA raw …
HEAD = f31f7da / fix/344-git-sha-injection
DictusApp.app            f31f7da
DictusKeyboard.appex     f31f7da
DictusWidgets.appex      f31f7da

$ xcodebuild build …          # nothing edited, 3.4 s
note: build info f31f7da@fix/344-git-sha-injection -> …/DictusKeyboard.appex/DictusBuildInfo.plist
note: build info f31f7da@fix/344-git-sha-injection -> …/DictusWidgets.appex/DictusBuildInfo.plist
note: build info f31f7da@fix/344-git-sha-injection -> …/DictusApp.app/DictusBuildInfo.plist
** BUILD SUCCEEDED **
DictusApp.app            f31f7da
DictusKeyboard.appex     f31f7da
DictusWidgets.appex      f31f7da
```

**2. Verified on `DictusApp` and `DictusKeyboard.appex`** — ✅ Both, plus `DictusWidgets.appex`, in every run above. `Info.plist` was also checked to no longer carry either key (`grep -c` returned `0` for all three bundles).

**3. A no-op rebuild immediately after a good build does not change the reported revision** — ✅ Two consecutive no-op rebuilds, the second four seconds after the first, per the issue's reproduction. All three bundles still `f31f7da`.

Stronger evidence that this is the phase running rather than a stale file surviving: after committing the docs, an incremental build picked the new sha up.

```
HEAD is now 9a07685 (was f31f7da at the last build)
note: build info 9a07685@fix/344-git-sha-injection -> …
DictusApp.app            9a07685
DictusKeyboard.appex     9a07685
DictusWidgets.appex      9a07685
```

**4. A build outside the Xcode build phase still reports `unknown`** — ✅ Written as a test, not observed:

```
Test Case '-[PersistentLogTests testCodeRevisionIsUnknownOutsideTheXcodeBuildPhase]' passed
Test Case '-[PersistentLogTests testCodeRevisionFallsBackToUnknown]' passed
Test Case '-[PersistentLogTests testCodeRevisionReadsGeneratedBuildInfo]' passed
Test Case '-[PersistentLogTests testCodeRevisionDropsAnUninformativeBranch]' passed
```

It asserts `PersistentLog.codeRevision == "unknown"` under `swift test`, where `Bundle.main` is the XCTest runner and no build phase ever ran. The others cover a missing file, an unparseable file, and a file with no sha.

**5. `swift test` passes and `swiftlint lint --strict` is clean** — ✅

```
$ cd DictusCore && swift test
Executed 878 tests, with 1 test skipped and 0 failures (0 unexpected) in 3.513 seconds

$ swiftlint lint --strict
Done linting! Found 0 violations, 0 serious in 176 files.
```

`.swiftlint.yml` does not include `DictusCore/Tests`, so the new test file is outside the default scope. Linted explicitly: `Done linting! Found 0 violations, 0 serious in 1 file.`

**6. `.claude/skills/device-build` loses its mandatory `clean`** — ✅ In this PR. The `clean` is gone, the verification step stays (it no longer guards against the build dropping the sha, but it still guards against the wrong checkout stamping the wrong one), and the Traps entry keeps the old symptom on record so a stale `clean build` note found elsewhere is recognisable rather than obeyed.

**Beyond the criteria:**

- **Code signing** — the new resource is sealed into all three bundles and both signatures verify (`valid on disk`, `satisfies its Designated Requirement`). The phase runs before the implicit signing step.
- **Bundle lookup** — `Bundle.url(forResource:withExtension:)` resolves the file in an iOS flat-layout bundle. Proven by running the exact lookup code from `codeRevision(in:)` against the three built bundles: all three returned `f31f7da@fix/344-git-sha-injection`. This is a macOS-hosted `Bundle` reading an iOS bundle, so it is strong evidence rather than the real thing — see hand-test 2.
- **Runtime smoke test** — installed and launched on a simulator; the app stays alive, `pluginkit` registers the keyboard extension, and the resource survives installation into the container.

## One thing that contradicted the issue

The issue says to update `.claude/skills/device-build` "in the same PR". That file was **untracked** on this machine — it exists only at `/Users/pierreviviere/dev/dictus/.claude/skills/device-build/SKILL.md` and was never committed (`.claude/skills/` was removed from the repo in `fde2815` when `ship-issue` moved to the plugin).

Editing the untracked copy in place would have been actively harmful: it would have dropped the mandatory `clean` while `develop` still needed it, breaking device builds until this merges. So it is committed here instead, which makes the doc land at the same moment as the code and makes it reviewable. The cost is hand-test 3 above: delete the local untracked copy before pulling.

Its Traps section also claimed the proper fix was "move that script phase last in each target". That was already true — all three phases were already last in their target's `buildPhases`. Scheduling is by dependency graph, not phase order, which is why being last changed nothing. Corrected.

refs #344


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a documented workflow for building, verifying, and installing a selected app revision on a paired iPhone.
  - App diagnostics now report the build’s commit revision from generated build information.

- **Bug Fixes**
  - Improved revision reporting when build metadata is missing, malformed, or incomplete.

- **Documentation**
  - Updated versioning guidance to reflect the new build-information format.

- **Tests**
  - Added coverage for valid, missing, and invalid build metadata scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->