### PR TITLE
Keep only genuinely personal words in the user dictionary (refs #287)

### DIFF
--- a/DictusCore/Sources/DictusCore/AutocorrectDebugLog.swift
+++ b/DictusCore/Sources/DictusCore/AutocorrectDebugLog.swift
@@ -201,6 +201,20 @@ public enum AutocorrectDebugLog {
         write("USERDICT-MIGRATE words=[\(quoted(words))]")
     }
 
+    /// The words a load discarded for going unused too long (#287).
+    public static func userDictionaryStaleDiscarded(words: [String]) {
+        guard enabled else { return }
+        write("USERDICT-STALE words=[\(quoted(words))]")
+    }
+
+    /// The words the one-shot prune dropped for already being in the base
+    /// dictionary (#287). This is the line that tells a given user exactly what
+    /// the migration took off them.
+    public static func userDictionaryPruned(words: [String]) {
+        guard enabled else { return }
+        write("USERDICT-PRUNE words=[\(quoted(words))]")
+    }
+
     /// Words as a sorted, quoted, comma-separated list.
     ///
     /// WHY sorted: dictionary iteration order is not stable across runs, so an

--- a/DictusCore/Sources/DictusCore/LogEvent.swift
+++ b/DictusCore/Sources/DictusCore/LogEvent.swift
@@ -123,6 +123,14 @@ public enum LogEvent: Sendable {
     /// was no longer learned. This is the line that answers "did the update keep
     /// this install's vocabulary" — the #304 criterion no log could settle.
     case userDictionaryMigrated(stamped: Int, droppedStamps: Int, learnedCount: Int)
+    /// Entries unused for `days` were discarded on load (#287). Below the cap this
+    /// is the only thing that ever removes an entry, so it is the line that says
+    /// a dictionary is being kept honest over time.
+    case userDictionaryStaleDiscarded(removed: Int, learnedCount: Int, days: Int)
+    /// The one-shot prune of entries the base dictionary already knew (#287).
+    /// `removed` is what this install was carrying for nothing; the words
+    /// themselves are in the debug log.
+    case userDictionaryPruned(removed: Int, learnedCount: Int)
 
     // MARK: Animation
     case overlayShown(status: String)
@@ -258,7 +266,7 @@ public enum LogEvent: Sendable {
              .overlayBodyEvaluated, .overlayTimerStarted, .overlayTimerStopped, .overlayRecreated,
              .diagnosticProbe,
              .userDictionaryWordLearned, .userDictionaryEvicted, .userDictionaryReset,
-             .userDictionaryMigrated:
+             .userDictionaryMigrated, .userDictionaryStaleDiscarded, .userDictionaryPruned:
             return .keyboard
         case .statusChanged, .watchdogReset, .idleInvariantViolation:
             return .dictation
@@ -340,7 +348,8 @@ public enum LogEvent: Sendable {
              .waveformEnergyTransition, .overlayBodyEvaluated, .overlayRecreated,
              .audioInterruptionEnded, .audioRouteChanged,
              .warmStateReleased, .warmStateRestored,
-             .userDictionaryEvicted, .userDictionaryReset, .userDictionaryMigrated:
+             .userDictionaryEvicted, .userDictionaryReset, .userDictionaryMigrated,
+             .userDictionaryStaleDiscarded, .userDictionaryPruned:
             return .info
 
         // Debug (internal state transitions)
@@ -470,6 +479,8 @@ public enum LogEvent: Sendable {
         case .userDictionaryEvicted: return "userDictionaryEvicted"
         case .userDictionaryReset: return "userDictionaryReset"
         case .userDictionaryMigrated: return "userDictionaryMigrated"
+        case .userDictionaryStaleDiscarded: return "userDictionaryStaleDiscarded"
+        case .userDictionaryPruned: return "userDictionaryPruned"
         }
     }
 
@@ -689,6 +700,10 @@ public enum LogEvent: Sendable {
             return "clearedCount=\(clearedCount)"
         case .userDictionaryMigrated(let stamped, let droppedStamps, let learnedCount):
             return "stamped=\(stamped) droppedStamps=\(droppedStamps) learnedCount=\(learnedCount)"
+        case .userDictionaryStaleDiscarded(let removed, let learnedCount, let days):
+            return "removed=\(removed) learnedCount=\(learnedCount) days=\(days)"
+        case .userDictionaryPruned(let removed, let learnedCount):
+            return "removed=\(removed) learnedCount=\(learnedCount)"
 
         // Polish (#315)
         case .polishEngineFailed(let reason, let engine, let mode, let engineMs):

--- a/DictusCore/Sources/DictusCore/TextCorrection/FrequencyProvider.swift
+++ b/DictusCore/Sources/DictusCore/TextCorrection/FrequencyProvider.swift
@@ -26,3 +26,27 @@ public protocol FrequencyProvider {
     /// Used as a fallback when frequency is 0 but the word may still be valid.
     func wordExists(_ word: String) -> Bool
 }
+
+public extension FrequencyProvider {
+
+    /// Whether the dictionary already knows `word`, asked exactly the way the
+    /// corrector asks it (#287): lowercased, and for a contraction only the part
+    /// after the last apostrophe — "j'ai" is stored in the trie as "ai", and
+    /// `TextPredictionEngine.spellCheck` splits the same way before its
+    /// `already-valid` skip.
+    ///
+    /// WHY this lives on the protocol rather than at either call site: the two
+    /// users of it are the word-boundary learning gate in the keyboard extension
+    /// and the duplicate prune in `UserDictionary`, and a word must mean the same
+    /// thing to both — a gate that refuses to learn "j'ai" while the prune keeps
+    /// it would leave entries no reader can reach.
+    func knowsWord(_ word: String) -> Bool {
+        let lowered = word.lowercased()
+        guard let apostrophe = lowered.lastIndex(of: "'") else {
+            return wordExists(lowered)
+        }
+        let afterApostrophe = String(lowered[lowered.index(after: apostrophe)...])
+        guard !afterApostrophe.isEmpty else { return false }
+        return wordExists(afterApostrophe)
+    }
+}

--- a/DictusCore/Sources/DictusCore/UserDictionary.swift
+++ b/DictusCore/Sources/DictusCore/UserDictionary.swift
@@ -163,6 +163,17 @@ public final class UserDictionary {
     /// Number of learned words.
     public var count: Int { learnedWords.count }
 
+    /// Whether the one-shot duplicate prune has already run on this install.
+    ///
+    /// WHY it is public: the prune needs a loaded base dictionary, which only the
+    /// keyboard extension has, and only at moments it does not control. Its
+    /// callers use this to know whether there is still anything to attempt — so
+    /// they can stay silent once there is not, and report when there is and they
+    /// cannot.
+    public var hasPrunedTrieDuplicates: Bool {
+        AppGroup.defaults.bool(forKey: Self.prunedTrieDuplicatesKey)
+    }
+
     /// Learn a word on this single occurrence, bypassing the repetition counter.
     /// The word is stored lowercase. If already learned, increments usage count.
     /// Returns true when this call created the entry.
@@ -387,7 +398,7 @@ public final class UserDictionary {
     @discardableResult
     public func pruneTrieDuplicatesIfNeeded(using provider: FrequencyProvider) -> Int {
         let defaults = AppGroup.defaults
-        guard !defaults.bool(forKey: Self.prunedTrieDuplicatesKey), provider.isReady else {
+        guard !hasPrunedTrieDuplicates, provider.isReady else {
             return 0
         }
 

--- a/DictusCore/Sources/DictusCore/UserDictionary.swift
+++ b/DictusCore/Sources/DictusCore/UserDictionary.swift
@@ -4,16 +4,30 @@ import Foundation
 
 /// Stores words the user has taught the keyboard through usage patterns.
 ///
+/// WHAT BELONGS IN IT (#287):
+/// Only words the base dictionary does not know. A learned word is immune from
+/// autocorrect for as long as it is in here, and #288 will propagate this set
+/// into speech recognition — so an entry that merely duplicates the trie costs
+/// storage, a write per word boundary, and a wrong word in another subsystem,
+/// while protecting nothing (the trie never corrects a word it knows).
+///
 /// HOW WORDS ARE LEARNED:
-/// 1. Rejection learning: user types "helo" → autocorrected to "hello" → user
-///    presses backspace to undo → "helo" is immediately learned (strong signal).
-/// 2. Repetition learning: user types an unknown word multiple times → after
-///    `repetitionThreshold` occurrences, the word is learned.
+/// 1. Rejection learning: user types "helo" → autocorrected to "hello" → the
+///    user rejects the correction → `learn()` records "helo" on that single
+///    occurrence. The user stated what they meant, so no repetition is asked for.
+/// 2. Repetition learning: the user types a word the trie does not know and the
+///    pipeline declines to correct → `recordUsage()` counts it, and the word is
+///    learned on the `repetitionThreshold`-th occurrence. The caller is the one
+///    that checks the trie (see `recordUsage`) — passive typing says nothing on
+///    its own, so it buys the weaker evidence a second occurrence.
 ///
 /// HOW WORDS ARE FORGOTTEN:
-/// The dictionary is capped at `maxLearnedWords`. Past the cap the
-/// least-recently-used entries are dropped — see `shouldEvictFirst()` for why
-/// recency and not usage count.
+/// The dictionary is bounded without the user having to do anything (#287
+/// decision 6 ships no per-word removal UI, so an entry that should not be there
+/// has to age out on its own):
+/// - the dictionary is capped at `maxLearnedWords`, and past the cap the
+///   least-recently-used entries are dropped — see `shouldEvictFirst()` for why
+///   recency and not usage count.
 ///
 /// HOW THE LIFECYCLE IS REPORTED (#307):
 /// Learning, eviction, reset and the load-time migration each write two lines:
@@ -63,10 +77,19 @@ public final class UserDictionary {
     /// boundary.
     static let lastUsedKey = "dictus.userDictionary.lastUsed"
 
-    /// Number of times an unknown word must be typed/rejected before it's learned.
-    /// 1 = learn immediately. Safe now that autocorrect undo requires an intentional
-    /// tap in the suggestion bar (no more accidental backspace-undo learning).
-    public static let repetitionThreshold = 1
+    /// Number of times a word the base dictionary does not know must be typed
+    /// before `recordUsage` learns it (#287 decision 3).
+    ///
+    /// WHY 2 and not 1: at 1 the `pendingWords` counter below could never hold
+    /// anything, so passive typing — which states nothing about intent — was
+    /// enough to grant a word permanent immunity from autocorrect. Two
+    /// occurrences is the probation AOSP LatinIME uses for the same signal, and
+    /// it is the cheapest gate that costs no new stored data.
+    ///
+    /// This threshold gates `recordUsage` only. Rejecting an autocorrection is a
+    /// different, much stronger signal and goes through `learn()`, which is not
+    /// subject to it.
+    public static let repetitionThreshold = 2
 
     /// Maximum number of learned words. When exceeded, the least-recently-used
     /// words are dropped — see `shouldEvictFirst()`.
@@ -74,6 +97,20 @@ public final class UserDictionary {
     /// Generous cap for personal vocabulary (names, slang, jargon, brands).
     /// Prevents unbounded growth from accidental learning over months/years.
     public static let maxLearnedWords = 1000
+
+    /// Maximum number of words held in probation at once.
+    ///
+    /// WHY a cap exists at all: raising `repetitionThreshold` above 1 is what
+    /// brings `pendingWords` to life, and everything that reaches it is by
+    /// definition a word the base dictionary does not know — a name, a piece of
+    /// jargon, or a typo the corrector had no candidate for. Typos never come
+    /// back for a second occurrence, so without a bound the pad would grow for
+    /// the life of the install, and `savePendingToDefaults()` runs on every word
+    /// boundary.
+    ///
+    /// WHY half the learned cap: a pending entry is weaker evidence than a
+    /// learned one, so it deserves less room than the vocabulary it feeds.
+    static let maxPendingWords = 500
 
     /// In-memory cache of learned words. Synced to UserDefaults on mutation.
     private var learnedWords: [String: Int] = [:]
@@ -107,11 +144,20 @@ public final class UserDictionary {
     /// Number of learned words.
     public var count: Int { learnedWords.count }
 
-    /// Learn a word immediately (e.g., after user rejects autocorrection).
+    /// Learn a word on this single occurrence, bypassing the repetition counter.
     /// The word is stored lowercase. If already learned, increments usage count.
-    public func learn(_ word: String) {
+    /// Returns true when this call created the entry.
+    ///
+    /// WHY this bypasses `repetitionThreshold` while `recordUsage` does not
+    /// (#287 decision 4): the caller is the undo of an applied autocorrection,
+    /// where the user has explicitly said "no, I meant this word". That is the
+    /// same trigger Apple documents for its own keyboard dictionary, and asking
+    /// for a second occurrence would mean rejecting the same correction twice
+    /// before the keyboard stopped making it.
+    @discardableResult
+    public func learn(_ word: String) -> Bool {
         let key = word.lowercased()
-        guard !key.isEmpty, key.count > 1 else { return }
+        guard !key.isEmpty, key.count > 1 else { return false }
         // A word already in the dictionary is a usage bump, not a learning event,
         // so only a first entry is reported below.
         let isNew = learnedWords[key] == nil
@@ -124,11 +170,19 @@ public final class UserDictionary {
         if isNew {
             logLearned(key, usageCount: usageCount)
         }
+        return isNew
     }
 
-    /// Record that an unknown word was typed. If it reaches the repetition
-    /// threshold, it's automatically learned. Returns true if the word was
-    /// just learned (crossed the threshold this call).
+    /// Record that a word the base dictionary does not know was typed. If it
+    /// reaches the repetition threshold, it's automatically learned. Returns true
+    /// if the word was just learned (crossed the threshold this call).
+    ///
+    /// The caller is responsible for the trie check (#287 decision 2). It is not
+    /// done here on purpose: `learn()`'s caller must NOT be subject to it — a word
+    /// restored by undoing an autocorrection is absent from the trie by
+    /// construction — and expressing that would mean handing `UserDictionary` a
+    /// `FrequencyProvider` to make the two call sites share a rule only one of
+    /// them wants.
     @discardableResult
     public func recordUsage(_ word: String) -> Bool {
         let key = word.lowercased()
@@ -156,8 +210,21 @@ public final class UserDictionary {
             return true
         }
 
+        boundPendingWords()
         savePendingToDefaults()
         return false
+    }
+
+    /// Keeps the probation pad bounded — see `maxPendingWords`.
+    ///
+    /// WHY it empties the pad instead of picking victims: at a threshold of 2
+    /// every pending entry has been seen exactly once, so there is nothing to
+    /// rank them by. The alternative would be a second timestamp map for entries
+    /// that are not even vocabulary yet. Emptying costs the words in flight one
+    /// extra occurrence, which is the cheapest possible failure for a memo pad.
+    private func boundPendingWords() {
+        guard pendingWords.count > Self.maxPendingWords else { return }
+        pendingWords.removeAll()
     }
 
     /// Remove a learned word (e.g., user removes it from dictionary management UI).

--- a/DictusCore/Sources/DictusCore/UserDictionary.swift
+++ b/DictusCore/Sources/DictusCore/UserDictionary.swift
@@ -22,18 +22,22 @@ import Foundation
 ///    its own, so it buys the weaker evidence a second occurrence.
 ///
 /// HOW WORDS ARE FORGOTTEN:
-/// The dictionary is bounded without the user having to do anything (#287
-/// decision 6 ships no per-word removal UI, so an entry that should not be there
-/// has to age out on its own):
+/// Three bounds, none of which needs the user to do anything (#287 decisions 6
+/// and 7 — there is deliberately no per-word removal UI, so an entry that should
+/// not be there has to age out on its own):
 /// - the dictionary is capped at `maxLearnedWords`, and past the cap the
 ///   least-recently-used entries are dropped — see `shouldEvictFirst()` for why
-///   recency and not usage count.
+///   recency and not usage count;
+/// - an entry not used for `staleAfterDays` is discarded on load;
+/// - entries the base dictionary already knows are pruned once, on the first
+///   load that can ask a loaded dictionary — see `pruneTrieDuplicatesIfNeeded`.
 ///
 /// HOW THE LIFECYCLE IS REPORTED (#307):
-/// Learning, eviction, reset and the load-time migration each write two lines:
-/// a count to `PersistentLog`, which any exported log carries, and the words
-/// themselves to `AutocorrectDebugLog`, which only exists in Debug builds and
-/// only writes once the Developer toggle is on. See `logLearned()`.
+/// Every event above — learning, eviction, reset, the load-time migration, the
+/// stale discard and the duplicate prune — writes two lines: a count to
+/// `PersistentLog`, which any exported log carries, and the words themselves to
+/// `AutocorrectDebugLog`, which only exists in Debug builds and only writes once
+/// the Developer toggle is on. See `logLearned()`.
 ///
 /// WHY App Group UserDefaults:
 /// The dictionary must be shared between DictusApp and DictusKeyboard extension.
@@ -77,6 +81,10 @@ public final class UserDictionary {
     /// boundary.
     static let lastUsedKey = "dictus.userDictionary.lastUsed"
 
+    /// Key for the one-shot flag recording that the trie-duplicate prune has run.
+    /// See `pruneTrieDuplicatesIfNeeded(using:)`.
+    static let prunedTrieDuplicatesKey = "dictus.userDictionary.prunedTrieDuplicates"
+
     /// Number of times a word the base dictionary does not know must be typed
     /// before `recordUsage` learns it (#287 decision 3).
     ///
@@ -111,6 +119,17 @@ public final class UserDictionary {
     /// WHY half the learned cap: a pending entry is weaker evidence than a
     /// learned one, so it deserves less room than the vocabulary it feeds.
     static let maxPendingWords = 500
+
+    /// A learned word unused for this long is discarded on load (#287 decision 7).
+    ///
+    /// WHY 300 days: it is AOSP LatinIME's own constant for the same policy, and
+    /// what actually ships there — its documented forgetting curve is dead code
+    /// at HEAD, so a flat discard plus the recency eviction above is the whole of
+    /// the mechanism worth copying. See `docs/research/287-user-dictionary-learning.md`.
+    ///
+    /// WHY a keyboard needs one: decision 6 leaves "Reset learned words" as the
+    /// only exit, so a wrong entry the user cannot see has no other way out.
+    static let staleAfterDays = 300
 
     /// In-memory cache of learned words. Synced to UserDefaults on mutation.
     private var learnedWords: [String: Int] = [:]
@@ -302,6 +321,97 @@ public final class UserDictionary {
         pendingWords = defaults.dictionary(forKey: Self.pendingKey) as? [String: Int] ?? [:]
         lastUsed = defaults.dictionary(forKey: Self.lastUsedKey) as? [String: Int] ?? [:]
         stampEntriesMissingATimestamp()
+        discardStaleEntries()
+    }
+
+    /// Drops entries unused for `staleAfterDays` (#287 decision 7).
+    ///
+    /// WHY it runs after `stampEntriesMissingATimestamp()` and not before: that
+    /// migration stamps a legacy entry with **the moment the gap was noticed**,
+    /// not with a maximally old value, so a dictionary written before recency
+    /// existed arrives here fully stamped as of now and nothing in it is old
+    /// enough to discard. Running this first would delete the entire cohort on
+    /// the first launch after the update.
+    ///
+    /// WHY on every load rather than once: this is a standing policy, not a
+    /// version step. It is also the only thing that ever removes a wrong entry
+    /// below the cap, since #287 decision 6 deliberately ships no per-word
+    /// removal UI.
+    private func discardStaleEntries() {
+        let cutoff = Self.nowStamp() - Self.staleAfterDays * 86_400
+        // `?? 0` cannot fire: every learned word carries a stamp by the time this
+        // runs. Treating an unstamped entry as maximally old is the safe reading
+        // if that ever breaks — it discards an entry rather than keeping one
+        // forever with no way for the user to remove it.
+        let stale = learnedWords.keys.filter { (lastUsed[$0] ?? 0) < cutoff }
+        guard !stale.isEmpty else { return }
+
+        for word in stale {
+            learnedWords.removeValue(forKey: word)
+            lastUsed.removeValue(forKey: word)
+        }
+        let defaults = AppGroup.defaults
+        defaults.set(learnedWords, forKey: Self.storageKey)
+        defaults.set(lastUsed, forKey: Self.lastUsedKey)
+
+        PersistentLog.log(.userDictionaryStaleDiscarded(
+            removed: stale.count,
+            learnedCount: learnedWords.count,
+            days: Self.staleAfterDays
+        ))
+        #if DEBUG
+        AutocorrectDebugLog.userDictionaryStaleDiscarded(words: stale)
+        #endif
+    }
+
+    /// Removes, once ever, every entry the base dictionary already knows
+    /// (#287 decision 9). Returns how many entries were dropped.
+    ///
+    /// WHY this is safe: a word present in the base dictionary is never
+    /// autocorrected — `TextPredictionEngine.spellCheck` returns nil at its
+    /// `already-valid` branch before any candidate is generated — so the entry's
+    /// immunity was protecting nothing. And a word learned by rejecting an
+    /// autocorrection is absent from the dictionary by construction, since
+    /// otherwise there would have been no correction to reject.
+    ///
+    /// WHY once and not on every load: the caller can only offer the *active*
+    /// language's dictionary. Running repeatedly would delete a bilingual user's
+    /// other-language entries again after each re-learning, which is a churn loop;
+    /// running once bounds the exposure to a single pass, and normal learning
+    /// puts back anything it took (see the PR for the full argument).
+    ///
+    /// - Parameter provider: the loaded base dictionary. A provider that is not
+    ///   ready is not asked and the flag is not set, so the prune simply waits
+    ///   for a load that can answer.
+    @discardableResult
+    public func pruneTrieDuplicatesIfNeeded(using provider: FrequencyProvider) -> Int {
+        let defaults = AppGroup.defaults
+        guard !defaults.bool(forKey: Self.prunedTrieDuplicatesKey), provider.isReady else {
+            return 0
+        }
+
+        let duplicates = learnedWords.keys.filter { provider.knowsWord($0) }
+        for word in duplicates {
+            learnedWords.removeValue(forKey: word)
+            lastUsed.removeValue(forKey: word)
+        }
+        // The pad holds the same class of entry and is subject to the same rule,
+        // so a word about to be promoted into a duplicate is dropped with them.
+        pendingWords = pendingWords.filter { !provider.knowsWord($0.key) }
+
+        defaults.set(true, forKey: Self.prunedTrieDuplicatesKey)
+        defaults.set(learnedWords, forKey: Self.storageKey)
+        defaults.set(lastUsed, forKey: Self.lastUsedKey)
+        defaults.set(pendingWords, forKey: Self.pendingKey)
+
+        PersistentLog.log(.userDictionaryPruned(
+            removed: duplicates.count,
+            learnedCount: learnedWords.count
+        ))
+        #if DEBUG
+        AutocorrectDebugLog.userDictionaryPruned(words: duplicates)
+        #endif
+        return duplicates.count
     }
 
     /// MIGRATION RULE for entries written before recency existed: a learned word

--- a/DictusCore/Sources/DictusCore/UserDictionary.swift
+++ b/DictusCore/Sources/DictusCore/UserDictionary.swift
@@ -281,6 +281,16 @@ public final class UserDictionary {
         lastUsed.removeAll()
         pendingWords.removeAll()
         saveToDefaults()
+        // The prune flag describes the stored dictionary — "this one has been
+        // cleaned" — so destroying that dictionary leaves it describing nothing,
+        // and it is re-armed with everything else (#287). Re-arming costs the
+        // user nothing: every entry learned after a reset is absent from the base
+        // dictionary by construction, at both call sites, so the prune that
+        // follows has nothing it could take. What it buys is that the migration
+        // stays observable — without this, a device that has pruned once can
+        // never show that the mechanism still works, and "already done" and
+        // "broken" read identically in an export forever after.
+        AppGroup.defaults.removeObject(forKey: Self.prunedTrieDuplicatesKey)
 
         PersistentLog.log(.userDictionaryReset(clearedCount: clearedCount))
         #if DEBUG

--- a/DictusCore/Sources/DictusCore/UserDictionary.swift
+++ b/DictusCore/Sources/DictusCore/UserDictionary.swift
@@ -339,11 +339,12 @@ public final class UserDictionary {
     /// removal UI.
     private func discardStaleEntries() {
         let cutoff = Self.nowStamp() - Self.staleAfterDays * 86_400
-        // `?? 0` cannot fire: every learned word carries a stamp by the time this
-        // runs. Treating an unstamped entry as maximally old is the safe reading
-        // if that ever breaks — it discards an entry rather than keeping one
-        // forever with no way for the user to remove it.
-        let stale = learnedWords.keys.filter { (lastUsed[$0] ?? 0) < cutoff }
+        // `<=` and not `<`: an entry stamped exactly at the cutoff has had the
+        // full period elapse, so it goes. `?? 0` cannot fire — every learned word
+        // carries a stamp by the time this runs. Treating an unstamped entry as
+        // maximally old is the safe reading if that ever breaks: it discards an
+        // entry rather than keeping one forever with no way to remove it.
+        let stale = learnedWords.keys.filter { (lastUsed[$0] ?? 0) <= cutoff }
         guard !stale.isEmpty else { return }
 
         for word in stale {

--- a/DictusCore/Sources/DictusCore/UserDictionaryPruneGate.swift
+++ b/DictusCore/Sources/DictusCore/UserDictionaryPruneGate.swift
@@ -1,0 +1,76 @@
+// DictusCore/Sources/DictusCore/UserDictionaryPruneGate.swift
+// The single precondition the one-shot user-dictionary prune runs under.
+import Foundation
+
+/// Decides whether the one-shot duplicate prune (#287) may run right now.
+///
+/// WHY this is a named type in DictusCore rather than a condition at the call
+/// site. The prune's precondition is not "a dictionary is loaded" — it is **"the
+/// dictionary I am about to ask is the one the user is typing in"**. Three
+/// separate defects came from picking a call site that happened to satisfy that
+/// and trusting it:
+///
+/// 1. a completion from a superseded load could prune against whichever trie was
+///    mounted at that instant;
+/// 2. the load completion was the only trigger, and it was systematically
+///    starved, so the prune never ran at all;
+/// 3. the pre-load attempt added to fix (2) runs before `setLanguage`, so a
+///    language changed from the app while the keyboard process stayed alive left
+///    the *previous* language's trie mounted and prunable.
+///
+/// Each fix moved the language question rather than closing it. Stating the
+/// invariant once, where it can be tested, is what closes it: any call site is
+/// safe, because the operation checks for itself instead of being trusted.
+///
+/// WHY it lives here and not in the keyboard extension: DictusCore is the only
+/// target in this repo with a test bundle, and after three defects this rule has
+/// earned coverage more than it has earned brevity.
+public enum UserDictionaryPruneGate {
+
+    /// What the caller should do, and — when the answer is no — what to report.
+    public enum Decision: Equatable {
+        /// The mounted dictionary is the active language's. Prune.
+        case run
+        /// Already pruned on this install. Nothing to do, nothing owed.
+        case alreadyDone
+        /// No dictionary is mounted: none loaded yet, or a load is in flight and
+        /// has torn the previous one down. Wait for a load to finish.
+        case notMounted
+        /// A dictionary is mounted, but not the one the user is typing in.
+        /// Pruning here would judge one language's words by another language's
+        /// vocabulary, and consume the one shot doing it.
+        case languageMismatch(mounted: String, active: String)
+
+        /// Cause as a log-safe token. Language codes only — never user content.
+        public var reason: String {
+            switch self {
+            case .run: return "ok"
+            case .alreadyDone: return "already-done"
+            case .notMounted: return "dictionary-not-mounted"
+            case .languageMismatch(let mounted, let active):
+                return "language-mismatch mounted=\(mounted) active=\(active)"
+            }
+        }
+    }
+
+    /// - Parameters:
+    ///   - alreadyPruned: `UserDictionary.hasPrunedTrieDuplicates`.
+    ///   - mountedLanguage: the language whose data is mmap'd right now, or nil
+    ///     when nothing is. Must describe what is *mounted*, not what was last
+    ///     requested — a load that has been asked for but has not finished has
+    ///     already torn down the dictionary it is replacing.
+    ///   - activeLanguage: the language the user is typing in
+    ///     (`SupportedLanguage.active`).
+    public static func decide(
+        alreadyPruned: Bool,
+        mountedLanguage: String?,
+        activeLanguage: String
+    ) -> Decision {
+        guard !alreadyPruned else { return .alreadyDone }
+        guard let mounted = mountedLanguage else { return .notMounted }
+        guard mounted == activeLanguage else {
+            return .languageMismatch(mounted: mounted, active: activeLanguage)
+        }
+        return .run
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/FrequencyProviderTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/FrequencyProviderTests.swift
@@ -1,0 +1,40 @@
+// DictusCore/Tests/DictusCoreTests/FrequencyProviderTests.swift
+// Tests for FrequencyProvider.knowsWord — the shape of the question #287 asks.
+import XCTest
+@testable import DictusCore
+
+/// WHY these exist: `knowsWord` is the single rule two things now depend on —
+/// the word-boundary learning gate in the keyboard extension and the duplicate
+/// prune in `UserDictionary`. If it disagrees with the split
+/// `TextPredictionEngine.spellCheck` makes before its `already-valid` skip, the
+/// gate and the corrector stop describing the same dictionary.
+final class FrequencyProviderTests: XCTestCase {
+
+    private let provider = MockFrequencyProvider(frequencies: [
+        "chat": 900, "ai": 8000, "est": 7000
+    ])
+
+    func testKnowsWordIsCaseInsensitive() {
+        XCTAssertTrue(provider.knowsWord("Chat"))
+        XCTAssertTrue(provider.knowsWord("CHAT"))
+    }
+
+    func testKnowsWordIsFalseForAWordTheDictionaryDoesNotHave() {
+        XCTAssertFalse(provider.knowsWord("zorglub"))
+    }
+
+    /// The trie stores "j'ai" as "ai", so a contraction is judged on the part
+    /// after the last apostrophe — the same way the corrector looks it up.
+    func testKnowsWordJudgesAContractionOnThePartAfterTheApostrophe() {
+        XCTAssertTrue(provider.knowsWord("j'ai"))
+        XCTAssertTrue(provider.knowsWord("C'est"))
+        XCTAssertFalse(provider.knowsWord("qu'zorglub"))
+    }
+
+    /// A trailing apostrophe leaves nothing to look up. Reporting "known" would
+    /// be the dangerous answer: the boundary site would decline to learn a word
+    /// nothing had actually vetted.
+    func testKnowsWordIsFalseWhenTheApostropheLeavesNothingToCheck() {
+        XCTAssertFalse(provider.knowsWord("chat'"))
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/LogEventTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/LogEventTests.swift
@@ -375,16 +375,32 @@ final class LogEventTests: XCTestCase {
         XCTAssertEqual(event.message, "stamped=12 droppedStamps=2 learnedCount=30")
     }
 
-    /// The privacy guarantee these four events rest on is that none of them can
-    /// carry a word at all: every associated value is an `Int`, so the formatted
-    /// line is digits and fixed keys and nothing else. A future parameter of type
+    func testUserDictionaryStaleDiscardedIsInfoKeyboard() {
+        let event = LogEvent.userDictionaryStaleDiscarded(removed: 4, learnedCount: 26, days: 300)
+        XCTAssertEqual(event.level, .info)
+        XCTAssertEqual(event.subsystem, .keyboard)
+        XCTAssertEqual(event.message, "removed=4 learnedCount=26 days=300")
+    }
+
+    func testUserDictionaryPrunedIsInfoKeyboard() {
+        let event = LogEvent.userDictionaryPruned(removed: 20, learnedCount: 2)
+        XCTAssertEqual(event.level, .info)
+        XCTAssertEqual(event.subsystem, .keyboard)
+        XCTAssertEqual(event.message, "removed=20 learnedCount=2")
+    }
+
+    /// The privacy guarantee these events rest on is that none of them can carry
+    /// a word at all: every associated value is an `Int`, so the formatted line
+    /// is digits and fixed keys and nothing else. A future parameter of type
     /// `String` would break this test before it could reach an export.
     func testUserDictionaryEventsCannotCarryText() {
         let events: [LogEvent] = [
             .userDictionaryWordLearned(learnedCount: 42),
             .userDictionaryEvicted(removed: 3, learnedCount: 1000, cap: 1000),
             .userDictionaryReset(clearedCount: 17),
-            .userDictionaryMigrated(stamped: 12, droppedStamps: 2, learnedCount: 30)
+            .userDictionaryMigrated(stamped: 12, droppedStamps: 2, learnedCount: 30),
+            .userDictionaryStaleDiscarded(removed: 4, learnedCount: 26, days: 300),
+            .userDictionaryPruned(removed: 20, learnedCount: 2)
         ]
         let allowed = CharacterSet(charactersIn: "0123456789= ")
             .union(CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"))

--- a/DictusCore/Tests/DictusCoreTests/UserDictionaryLoggingTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/UserDictionaryLoggingTests.swift
@@ -39,12 +39,14 @@ final class UserDictionaryLoggingTests: XCTestCase {
         }
         setDeveloperToggle(false)
         UserDictionary.shared.resetAll()
+        AppGroup.defaults.removeObject(forKey: UserDictionary.prunedTrieDuplicatesKey)
         clearLog()
     }
 
     override func tearDown() {
         setDeveloperToggle(false)
         UserDictionary.shared.resetAll()
+        AppGroup.defaults.removeObject(forKey: UserDictionary.prunedTrieDuplicatesKey)
         clearLog()
         // Leave nothing behind on the host: this file is a test artifact here,
         // unlike on device where it is the log the maintainer exports.
@@ -188,6 +190,33 @@ final class UserDictionaryLoggingTests: XCTestCase {
         assertLogNamesNoWord(["kubernetes", "bonjour", "zorglub"], log)
     }
 
+    /// The two removals #287 added report the same way: a count in every build,
+    /// the words only behind the Developer toggle.
+    func testTheStaleDiscardReportsHowManyEntriesItDroppedAndNotWhich() {
+        let old = Int(Date().timeIntervalSince1970) - 301 * 86_400
+        seedStore(words: ["oublie": 2, "zorglub": 3], lastUsed: ["oublie": old, "zorglub": Int(Date().timeIntervalSince1970)])
+
+        let log = logContents()
+        assertLogContains("userDictionaryStaleDiscarded removed=1 learnedCount=1 days=300", log)
+        assertLogNamesNoWord(["oublie", "zorglub"], log)
+    }
+
+    /// The line that lets an export answer "what did the migration take off me",
+    /// which is the only recourse a user has: #287 decision 6 ships no per-word
+    /// removal UI, so nothing else can name what disappeared.
+    func testThePruneReportsHowManyDuplicatesItRemovedAndNotWhich() {
+        seedStore(words: ["le": 40, "zorglub": 3], lastUsed: nil)
+        clearLog()
+
+        UserDictionary.shared.pruneTrieDuplicatesIfNeeded(
+            using: MockFrequencyProvider(frequencies: ["le": 5000])
+        )
+
+        let log = logContents()
+        assertLogContains("userDictionaryPruned removed=1 learnedCount=1", log)
+        assertLogNamesNoWord(["zorglub"], log)
+    }
+
     /// `reload()` runs on every keyboard appearance, so a store that is already
     /// stamped must report nothing at all — otherwise the line is noise on a path
     /// that runs constantly (#255).
@@ -231,6 +260,21 @@ final class UserDictionaryLoggingTests: XCTestCase {
         UserDictionary.shared.learn("nouveau")
         assertLogContains("USERDICT-EVICT words=[\"oubliable\"]", logContents())
 
+        // Discarded for going stale, and pruned as a duplicate of the base
+        // dictionary — the two removals #287 added.
+        UserDictionary.shared.resetAll()
+        let old = Int(Date().timeIntervalSince1970) - 301 * 86_400
+        clearLog()
+        seedStore(words: ["oublie": 2], lastUsed: ["oublie": old])
+        assertLogContains("USERDICT-STALE words=[\"oublie\"]", logContents())
+
+        AppGroup.defaults.removeObject(forKey: UserDictionary.prunedTrieDuplicatesKey)
+        seedStore(words: ["le": 40], lastUsed: nil)
+        clearLog()
+        UserDictionary.shared.pruneTrieDuplicatesIfNeeded(
+            using: MockFrequencyProvider(frequencies: ["le": 5000])
+        )
+        assertLogContains("USERDICT-PRUNE words=[\"le\"]", logContents())
 
         // Reset.
         UserDictionary.shared.resetAll()

--- a/DictusCore/Tests/DictusCoreTests/UserDictionaryLoggingTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/UserDictionaryLoggingTests.swift
@@ -204,17 +204,23 @@ final class UserDictionaryLoggingTests: XCTestCase {
     /// The line that lets an export answer "what did the migration take off me",
     /// which is the only recourse a user has: #287 decision 6 ships no per-word
     /// removal UI, so nothing else can name what disappeared.
+    /// WHY the duplicate here is "bonjour" and not the "le" the device trace
+    /// shows: the word this test names has to be one that cannot appear in the
+    /// log for any other reason, and "le" sits inside "learnedCount" in the very
+    /// line above. Asserting on it would fail on the log's own furniture, and a
+    /// word the prune does not remove — "zorglub" alone — would let a leak of the
+    /// removed word through unnoticed.
     func testThePruneReportsHowManyDuplicatesItRemovedAndNotWhich() {
-        seedStore(words: ["le": 40, "zorglub": 3], lastUsed: nil)
+        seedStore(words: ["bonjour": 40, "zorglub": 3], lastUsed: nil)
         clearLog()
 
         UserDictionary.shared.pruneTrieDuplicatesIfNeeded(
-            using: MockFrequencyProvider(frequencies: ["le": 5000])
+            using: MockFrequencyProvider(frequencies: ["bonjour": 5000])
         )
 
         let log = logContents()
         assertLogContains("userDictionaryPruned removed=1 learnedCount=1", log)
-        assertLogNamesNoWord(["zorglub"], log)
+        assertLogNamesNoWord(["bonjour", "zorglub"], log)
     }
 
     /// `reload()` runs on every keyboard appearance, so a store that is already

--- a/DictusCore/Tests/DictusCoreTests/UserDictionaryLoggingTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/UserDictionaryLoggingTests.swift
@@ -231,6 +231,7 @@ final class UserDictionaryLoggingTests: XCTestCase {
         UserDictionary.shared.learn("nouveau")
         assertLogContains("USERDICT-EVICT words=[\"oubliable\"]", logContents())
 
+
         // Reset.
         UserDictionary.shared.resetAll()
         UserDictionary.shared.learn("zorglub")

--- a/DictusCore/Tests/DictusCoreTests/UserDictionaryPruneGateTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/UserDictionaryPruneGateTests.swift
@@ -1,0 +1,70 @@
+// DictusCore/Tests/DictusCoreTests/UserDictionaryPruneGateTests.swift
+// Tests for the one precondition the user-dictionary prune runs under (#287).
+import XCTest
+@testable import DictusCore
+
+/// WHY these exist: three defects on this branch were all the same missing
+/// invariant — the prune asking a dictionary that was not the one the user was
+/// typing in — each found on a different call site. The rule is now stated in
+/// one place, and this is what holds it there. The keyboard extension has no
+/// test bundle, so a rule that lives in the extension is a rule nothing checks.
+final class UserDictionaryPruneGateTests: XCTestCase {
+
+    private func decide(
+        alreadyPruned: Bool = false,
+        mounted: String? = "fr",
+        active: String = "fr"
+    ) -> UserDictionaryPruneGate.Decision {
+        UserDictionaryPruneGate.decide(
+            alreadyPruned: alreadyPruned, mountedLanguage: mounted, activeLanguage: active
+        )
+    }
+
+    func testItRunsWhenTheMountedDictionaryIsTheActiveLanguage() {
+        XCTAssertEqual(decide(), .run)
+    }
+
+    func testItDoesNotRunTwice() {
+        XCTAssertEqual(decide(alreadyPruned: true), .alreadyDone)
+    }
+
+    /// The already-pruned answer wins over everything else: once the one shot is
+    /// spent there is nothing to report as a failure, and a mismatch at that
+    /// point is not a problem anyone needs to hear about.
+    func testAlreadyDoneOutranksAnyOtherReason() {
+        XCTAssertEqual(decide(alreadyPruned: true, mounted: nil), .alreadyDone)
+        XCTAssertEqual(decide(alreadyPruned: true, mounted: "de", active: "fr"), .alreadyDone)
+    }
+
+    /// Nothing mounted: no load has finished, or one is in flight and has already
+    /// torn down the dictionary it replaces. This is the state the keyboard is in
+    /// for much of a session, and answering it wrong is what kept the prune from
+    /// ever running.
+    func testItWaitsWhenNoDictionaryIsMounted() {
+        XCTAssertEqual(decide(mounted: nil), .notMounted)
+    }
+
+    /// The case that motivated the whole type: the language was changed from the
+    /// app while this keyboard process stayed alive, so the previous language's
+    /// trie is still mounted and would happily answer for every word. Pruning
+    /// there judges one language's vocabulary by another's — and spends the one
+    /// shot doing it, so the language the user actually selected never gets a
+    /// pass of its own.
+    func testItRefusesADictionaryFromAnotherLanguage() {
+        XCTAssertEqual(
+            decide(mounted: "fr", active: "de"),
+            .languageMismatch(mounted: "fr", active: "de")
+        )
+    }
+
+    /// The reasons reach an export, so they have to stay greppable and carry no
+    /// user content — language codes only.
+    func testReasonsAreLogSafeTokens() {
+        XCTAssertEqual(decide(mounted: nil).reason, "dictionary-not-mounted")
+        XCTAssertEqual(
+            decide(mounted: "fr", active: "de").reason,
+            "language-mismatch mounted=fr active=de"
+        )
+        XCTAssertEqual(decide(alreadyPruned: true).reason, "already-done")
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/UserDictionaryTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/UserDictionaryTests.swift
@@ -21,12 +21,16 @@ final class UserDictionaryTests: XCTestCase {
     /// edges makes each test independent of what ran before it.
     override func setUp() {
         super.setUp()
-        UserDictionary.shared.resetAll()
+        clearStore()
     }
 
     override func tearDown() {
-        UserDictionary.shared.resetAll()
+        clearStore()
         super.tearDown()
+    }
+
+    private func clearStore() {
+        UserDictionary.shared.resetAll()
     }
 
     // MARK: - Promotion from pending to learned
@@ -44,14 +48,50 @@ final class UserDictionaryTests: XCTestCase {
         XCTAssertEqual(UserDictionary.shared.allLearnedWords[word], UserDictionary.repetitionThreshold)
     }
 
-    func testRecordUsageBelowTheThresholdDoesNotLearnTheWord() throws {
-        try XCTSkipIf(
-            UserDictionary.repetitionThreshold < 2,
-            "Threshold is 1, so there is no below-threshold call to observe"
-        )
+    /// Un-skipped by #287: at a threshold of 1 there was no below-threshold call
+    /// to observe, which is the whole reason the counter was dead as a gate.
+    func testRecordUsageBelowTheThresholdDoesNotLearnTheWord() {
         let word = "zorglub"
         XCTAssertFalse(UserDictionary.shared.recordUsage(word))
         XCTAssertFalse(UserDictionary.shared.isLearned(word))
+    }
+
+    /// The observable rule the two sites are held to (#287 decisions 3 and 4):
+    /// the word-boundary path learns on the second occurrence, the undo path on
+    /// the first.
+    func testTypingTwiceLearnsAWordThatTypingOnceDoesNot() {
+        XCTAssertFalse(UserDictionary.shared.recordUsage("zorglub"))
+        XCTAssertFalse(UserDictionary.shared.isLearned("zorglub"))
+
+        XCTAssertTrue(UserDictionary.shared.recordUsage("zorglub"))
+        XCTAssertTrue(UserDictionary.shared.isLearned("zorglub"))
+    }
+
+    func testLearnRecordsAWordOnItsFirstOccurrence() {
+        XCTAssertTrue(UserDictionary.shared.learn("zorglub"), "The call creating the entry reports it")
+        XCTAssertTrue(UserDictionary.shared.isLearned("zorglub"))
+
+        XCTAssertFalse(
+            UserDictionary.shared.learn("zorglub"),
+            "A second call is a usage bump, not a new entry"
+        )
+        XCTAssertEqual(UserDictionary.shared.allLearnedWords["zorglub"], 2)
+    }
+
+    // MARK: - Bounding the probation pad (#287)
+
+    /// Raising the threshold above 1 is what brings `pendingWords` to life, and
+    /// what reaches it is mostly typos that never come back for a second
+    /// occurrence. Without a bound the pad would grow for the life of the install
+    /// and be re-serialised on every word boundary.
+    func testThePendingPadIsBounded() {
+        for index in 0...UserDictionary.maxPendingWords {
+            UserDictionary.shared.recordUsage("pending\(index)")
+        }
+
+        let pending = AppGroup.defaults.dictionary(forKey: UserDictionary.pendingKey) as? [String: Int] ?? [:]
+        XCTAssertLessThanOrEqual(pending.count, UserDictionary.maxPendingWords)
+        XCTAssertEqual(UserDictionary.shared.count, 0, "Nothing was typed twice, so nothing is learned")
     }
 
     // MARK: - Bumping an already-learned word
@@ -115,7 +155,8 @@ final class UserDictionaryTests: XCTestCase {
     private static let now = Int(Date().timeIntervalSince1970)
     private static let aMinuteAgo = now - 60
     private static let tenDaysAgo = now - 10 * 86_400
-    private static let threeHundredDaysAgo = now - 300 * 86_400
+    /// Old enough to lose an eviction, young enough to survive the stale discard.
+    private static let twoHundredDaysAgo = now - 200 * 86_400
 
     /// `count` filler words, named so they never collide with the words a test
     /// makes assertions about.
@@ -252,7 +293,7 @@ final class UserDictionaryTests: XCTestCase {
         words["legacy"] = 5
         words["ancient"] = 5
         var timestamps = stamp(words, at: Self.aMinuteAgo)
-        timestamps["ancient"] = Self.threeHundredDaysAgo
+        timestamps["ancient"] = Self.twoHundredDaysAgo
         timestamps.removeValue(forKey: "legacy")
         seedStore(words: words, lastUsed: timestamps)
 

--- a/DictusCore/Tests/DictusCoreTests/UserDictionaryTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/UserDictionaryTests.swift
@@ -476,6 +476,37 @@ final class UserDictionaryTests: XCTestCase {
         XCTAssertTrue(UserDictionary.shared.hasPrunedTrieDuplicates)
     }
 
+    /// Resetting the dictionary re-arms the prune, because the flag describes a
+    /// dictionary that no longer exists. It is also the only way a device that
+    /// has already pruned can show that the mechanism still works.
+    func testResettingTheDictionaryReArmsThePrune() {
+        seedForPrune()
+        UserDictionary.shared.pruneTrieDuplicatesIfNeeded(using: frenchWords)
+        XCTAssertTrue(UserDictionary.shared.hasPrunedTrieDuplicates)
+
+        UserDictionary.shared.resetAll()
+
+        XCTAssertFalse(UserDictionary.shared.hasPrunedTrieDuplicates)
+    }
+
+    /// Re-arming is safe, which is what makes it worth doing: everything learned
+    /// after a reset is absent from the base dictionary by construction — the
+    /// boundary site gates on exactly that, and a word restored by undo was never
+    /// in the dictionary to begin with — so the next prune has nothing to take.
+    func testThePruneAfterAResetHasNothingToTake() {
+        seedForPrune()
+        UserDictionary.shared.pruneTrieDuplicatesIfNeeded(using: frenchWords)
+        UserDictionary.shared.resetAll()
+
+        UserDictionary.shared.learn("zorglub")
+        UserDictionary.shared.recordUsage("kubernetes")
+        UserDictionary.shared.recordUsage("kubernetes")
+
+        XCTAssertEqual(UserDictionary.shared.pruneTrieDuplicatesIfNeeded(using: frenchWords), 0)
+        XCTAssertTrue(UserDictionary.shared.isLearned("zorglub"))
+        XCTAssertTrue(UserDictionary.shared.isLearned("kubernetes"))
+    }
+
     /// A word held in probation is the same class of entry and follows the same
     /// rule, so the prune must not leave one behind to be promoted into a
     /// duplicate on its next occurrence.

--- a/DictusCore/Tests/DictusCoreTests/UserDictionaryTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/UserDictionaryTests.swift
@@ -445,17 +445,35 @@ final class UserDictionaryTests: XCTestCase {
     }
 
     /// A provider that cannot answer is not asked, and the flag stays clear so
-    /// the prune waits for a load that can. The trie loads asynchronously, so
-    /// this is the state the keyboard is genuinely in for the first moments of
-    /// every session.
+    /// the prune waits for a load that can. The trie loads asynchronously and is
+    /// unloaded synchronously by the next load request, so this is the state the
+    /// keyboard is genuinely in for much of a session — it is what kept the prune
+    /// from ever running on device off the load completion alone.
     func testThePruneWaitsForADictionaryThatIsReady() {
         seedForPrune()
         let stillLoading = MockFrequencyProvider(isReady: false, frequencies: ["le": 5000])
 
         XCTAssertEqual(UserDictionary.shared.pruneTrieDuplicatesIfNeeded(using: stillLoading), 0)
         XCTAssertTrue(UserDictionary.shared.isLearned("le"))
+        XCTAssertFalse(
+            UserDictionary.shared.hasPrunedTrieDuplicates,
+            "A declined attempt must not consume the one shot"
+        )
 
         XCTAssertEqual(UserDictionary.shared.pruneTrieDuplicatesIfNeeded(using: frenchWords), 3)
+        XCTAssertTrue(UserDictionary.shared.hasPrunedTrieDuplicates)
+    }
+
+    /// The flag is what the keyboard reads to decide whether it still owes a
+    /// prune, so it has to report the same thing the guard inside acts on — and
+    /// it has to survive a dictionary that ends up empty, which is the fresh
+    /// install case.
+    func testAPruneWithNothingToRemoveStillConsumesTheOneShot() {
+        XCTAssertFalse(UserDictionary.shared.hasPrunedTrieDuplicates)
+
+        XCTAssertEqual(UserDictionary.shared.pruneTrieDuplicatesIfNeeded(using: frenchWords), 0)
+
+        XCTAssertTrue(UserDictionary.shared.hasPrunedTrieDuplicates)
     }
 
     /// A word held in probation is the same class of entry and follows the same

--- a/DictusCore/Tests/DictusCoreTests/UserDictionaryTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/UserDictionaryTests.swift
@@ -352,6 +352,23 @@ final class UserDictionaryTests: XCTestCase {
         XCTAssertTrue(UserDictionary.shared.isLearned("oublie"))
     }
 
+    /// The cutoff is inclusive: an entry stamped exactly `staleAfterDays` ago has
+    /// had the full period elapse.
+    ///
+    /// WHY the stamp is computed here rather than from the fixtures above: those
+    /// are captured once when the class loads, and the load being tested reads
+    /// its own clock, so a fixture would sit a few seconds *past* the cutoff and
+    /// the boundary would never actually be exercised. Taken as late as possible
+    /// the entry lands on the cutoff or a second past it — never inside it — so
+    /// this assertion is the right one either way, and it fails outright on a
+    /// strict comparison whenever the two clock reads land in the same second.
+    func testLoadingDiscardsAnEntryStampedExactlyAtTheCutoff() {
+        let cutoff = Int(Date().timeIntervalSince1970) - UserDictionary.staleAfterDays * 86_400
+        seedStore(words: ["oublie": 2], lastUsed: ["oublie": cutoff])
+
+        XCTAssertFalse(UserDictionary.shared.isLearned("oublie"))
+    }
+
     /// The interaction that would be silently destructive if the two load steps
     /// ran the other way round: a dictionary written before recency existed has
     /// no stamps at all, and #305 stamps it as of the update. Discarding first

--- a/DictusCore/Tests/DictusCoreTests/UserDictionaryTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/UserDictionaryTests.swift
@@ -29,8 +29,12 @@ final class UserDictionaryTests: XCTestCase {
         super.tearDown()
     }
 
+    /// The one-shot prune flag outlives the dictionary it describes, so a clean
+    /// slate has to clear it too — otherwise the first test to run a prune would
+    /// be the only one that could.
     private func clearStore() {
         UserDictionary.shared.resetAll()
+        AppGroup.defaults.removeObject(forKey: UserDictionary.prunedTrieDuplicatesKey)
     }
 
     // MARK: - Promotion from pending to learned
@@ -157,6 +161,7 @@ final class UserDictionaryTests: XCTestCase {
     private static let tenDaysAgo = now - 10 * 86_400
     /// Old enough to lose an eviction, young enough to survive the stale discard.
     private static let twoHundredDaysAgo = now - 200 * 86_400
+    private static let threeHundredAndOneDaysAgo = now - 301 * 86_400
 
     /// `count` filler words, named so they never collide with the words a test
     /// makes assertions about.
@@ -326,5 +331,129 @@ final class UserDictionaryTests: XCTestCase {
         )
 
         XCTAssertEqual(Set(persistedTimestamps.keys), ["zorglub"])
+    }
+
+    // MARK: - Discarding entries unused for 300 days (#287)
+
+    func testLoadingDiscardsAnEntryUnusedForLongerThanTheStalePeriod() {
+        seedStore(
+            words: ["zorglub": 3, "oublie": 2],
+            lastUsed: ["zorglub": Self.aMinuteAgo, "oublie": Self.threeHundredAndOneDaysAgo]
+        )
+
+        XCTAssertTrue(UserDictionary.shared.isLearned("zorglub"))
+        XCTAssertFalse(UserDictionary.shared.isLearned("oublie"))
+        XCTAssertNil(persistedTimestamps["oublie"], "The discarded entry takes its stamp with it")
+    }
+
+    func testLoadingKeepsAnEntryStillInsideTheStalePeriod() {
+        seedStore(words: ["oublie": 2], lastUsed: ["oublie": Self.twoHundredDaysAgo])
+
+        XCTAssertTrue(UserDictionary.shared.isLearned("oublie"))
+    }
+
+    /// The interaction that would be silently destructive if the two load steps
+    /// ran the other way round: a dictionary written before recency existed has
+    /// no stamps at all, and #305 stamps it as of the update. Discarding first
+    /// would read those entries as maximally old and delete every one of them on
+    /// the first launch after this ships.
+    func testALegacyStoreSurvivesItsFirstLoad() {
+        seedStore(words: ["kubernetes": 2, "zorglub": 3], lastUsed: nil)
+
+        XCTAssertTrue(UserDictionary.shared.isLearned("kubernetes"))
+        XCTAssertTrue(UserDictionary.shared.isLearned("zorglub"))
+    }
+
+    // MARK: - The one-shot prune of base-dictionary duplicates (#287)
+
+    /// The store as an existing install carries it: mostly words the base
+    /// dictionary already knows, plus the handful of personal ones the feature
+    /// exists for.
+    private func seedForPrune() {
+        seedStore(
+            words: ["le": 40, "chat": 12, "pomme": 8, "kubernetes": 2, "zorglub": 3],
+            lastUsed: nil
+        )
+    }
+
+    /// The base dictionary as the corrector sees it: "j'ai" is stored as "ai",
+    /// which is why the prune asks about the part after the apostrophe.
+    private var frenchWords: MockFrequencyProvider {
+        MockFrequencyProvider(frequencies: ["le": 5000, "chat": 900, "pomme": 400, "ai": 8000])
+    }
+
+    func testThePruneRemovesEntriesTheBaseDictionaryAlreadyKnows() {
+        seedForPrune()
+
+        let removed = UserDictionary.shared.pruneTrieDuplicatesIfNeeded(using: frenchWords)
+
+        XCTAssertEqual(removed, 3)
+        XCTAssertFalse(UserDictionary.shared.isLearned("le"))
+        XCTAssertFalse(UserDictionary.shared.isLearned("chat"))
+        XCTAssertFalse(UserDictionary.shared.isLearned("pomme"))
+        XCTAssertTrue(UserDictionary.shared.isLearned("kubernetes"), "Personal vocabulary is what survives")
+        XCTAssertTrue(UserDictionary.shared.isLearned("zorglub"))
+        XCTAssertEqual(Set(persistedTimestamps.keys), ["kubernetes", "zorglub"])
+    }
+
+    /// An entry is judged on the part the dictionary actually stores, the same
+    /// split `spellCheck` makes before its `already-valid` skip. Without this,
+    /// "j'ai" would sit in the dictionary forever: the prune would keep it and no
+    /// reader would ever look it up under that spelling.
+    func testThePruneJudgesAContractionOnThePartAfterTheApostrophe() {
+        seedStore(words: ["j'ai": 12, "zorglub": 3], lastUsed: nil)
+
+        UserDictionary.shared.pruneTrieDuplicatesIfNeeded(using: frenchWords)
+
+        XCTAssertFalse(UserDictionary.shared.isLearned("j'ai"))
+        XCTAssertTrue(UserDictionary.shared.isLearned("zorglub"))
+    }
+
+    /// It runs once and never again. This is what bounds the exposure for a user
+    /// who types in more than one language: the prune can only offer the active
+    /// language's dictionary, so a second run under a second language could
+    /// delete what the first language's user had just re-learned.
+    func testThePruneRunsOnlyOnce() {
+        seedForPrune()
+        UserDictionary.shared.pruneTrieDuplicatesIfNeeded(using: frenchWords)
+
+        UserDictionary.shared.learn("chat")
+        let removedAgain = UserDictionary.shared.pruneTrieDuplicatesIfNeeded(using: frenchWords)
+
+        XCTAssertEqual(removedAgain, 0)
+        XCTAssertTrue(
+            UserDictionary.shared.isLearned("chat"),
+            "A word deliberately learned after the prune is not taken away again"
+        )
+    }
+
+    /// A provider that cannot answer is not asked, and the flag stays clear so
+    /// the prune waits for a load that can. The trie loads asynchronously, so
+    /// this is the state the keyboard is genuinely in for the first moments of
+    /// every session.
+    func testThePruneWaitsForADictionaryThatIsReady() {
+        seedForPrune()
+        let stillLoading = MockFrequencyProvider(isReady: false, frequencies: ["le": 5000])
+
+        XCTAssertEqual(UserDictionary.shared.pruneTrieDuplicatesIfNeeded(using: stillLoading), 0)
+        XCTAssertTrue(UserDictionary.shared.isLearned("le"))
+
+        XCTAssertEqual(UserDictionary.shared.pruneTrieDuplicatesIfNeeded(using: frenchWords), 3)
+    }
+
+    /// A word held in probation is the same class of entry and follows the same
+    /// rule, so the prune must not leave one behind to be promoted into a
+    /// duplicate on its next occurrence.
+    func testThePruneAlsoClearsProbationEntriesTheDictionaryKnows() {
+        seedStore(words: ["zorglub": 3], lastUsed: nil)
+        UserDictionary.shared.recordUsage("pomme")
+
+        UserDictionary.shared.pruneTrieDuplicatesIfNeeded(using: frenchWords)
+        UserDictionary.shared.recordUsage("pomme")
+
+        XCTAssertFalse(
+            UserDictionary.shared.isLearned("pomme"),
+            "The second occurrence starts probation over instead of promoting a duplicate"
+        )
     }
 }

--- a/DictusKeyboard/DictusKeyboardBridge.swift
+++ b/DictusKeyboard/DictusKeyboardBridge.swift
@@ -438,7 +438,16 @@ final class DictusKeyboardBridge: NSObject,
         // boundary check (possibly phantom words, #191) must not be learned:
         // a learned word bypasses autocorrect everywhere afterwards, which is
         // how test typing in Safari's search bar broke "lai"/"Cest" in Messages.
-        var wordWasEvaluated = suggestionState?.hostPolicy.autocorrectAllowed ?? false
+        //
+        // The user's own autocorrect switch counts as such a case (#287 decision 8).
+        // With autocorrect off `spellCheck` never runs, so nothing vets the word:
+        // "bonjuor" typed twice would clear the trie filter below and become
+        // permanently immune. Reading only the host policy here — as this line did
+        // until #287 — made the comment above untrue in exactly that configuration.
+        var wordWasEvaluated: Bool = {
+            guard let state = suggestionState else { return false }
+            return state.autocorrectEnabled && state.hostPolicy.autocorrectAllowed
+        }()
 
         if let state = suggestionState, state.autocorrectEnabled,
            state.hostPolicy.autocorrectAllowed,
@@ -489,12 +498,21 @@ final class DictusKeyboardBridge: NSObject,
         // correct it (user typed it as-is). Track usage — at the repetition
         // threshold, learn it. Skipped when autocorrect never ran (see
         // wordWasEvaluated above): those words were not vetted by the pipeline.
-        if let state = suggestionState, !freshWord.isEmpty, wordWasEvaluated {
-            let word = freshWord
-            if UserDictionary.shared.recordUsage(word) {
-                // Word just crossed the learning threshold — notify prediction engine
-                state.learnWord(word)
-            }
+        //
+        // The dictionary check is the gate this site was missing (#287 decision 2).
+        // Passive typing states nothing about intent, so the only word worth
+        // recording here is one the base dictionary does not have: a word it does
+        // have is never autocorrected anyway, so an entry for it protects nothing
+        // while #288 would go on to feed it into speech recognition. Six ordinary
+        // French phrases used to leave 22 entries behind, 20 of them trie words.
+        //
+        // The check belongs here rather than inside UserDictionary because the undo
+        // site must NOT be subject to it — see `UserDictionary.recordUsage`.
+        if let state = suggestionState, !freshWord.isEmpty, wordWasEvaluated,
+           state.isUnknownToDictionary(freshWord),
+           UserDictionary.shared.recordUsage(freshWord) {
+            // Word just crossed the learning threshold — notify prediction engine
+            state.learnWord(freshWord)
         }
 
         // Normal space handling with double-space period detection

--- a/DictusKeyboard/KeyboardRootView.swift
+++ b/DictusKeyboard/KeyboardRootView.swift
@@ -538,7 +538,14 @@ struct KeyboardRootView: View {
 
         suggestionState.rejectedWords.insert(undo.originalWord.lowercased())
 
-        if UserDictionary.shared.recordUsage(undo.originalWord) {
+        // Learn on this single occurrence (#287 decision 4). `learn` and not
+        // `recordUsage`: rejecting a correction is the user saying "no, I meant
+        // this word", which is the strongest signal the keyboard ever gets, and
+        // it is the trigger Apple documents for its own keyboard dictionary. The
+        // repetition counter guards the word-boundary site, where the user has
+        // said nothing at all; applying it here would mean rejecting the same
+        // correction twice before the keyboard stopped making it.
+        if UserDictionary.shared.learn(undo.originalWord) {
             suggestionState.learnWord(undo.originalWord)
         }
     }

--- a/DictusKeyboard/KeyboardViewController.swift
+++ b/DictusKeyboard/KeyboardViewController.swift
@@ -507,6 +507,15 @@ class KeyboardViewController: UIInputViewController {
             giellaKeyboard?.page = .symbols1
         }
 
+        // The user dictionary's one-shot prune (#287), attempted BEFORE the load
+        // below and not after it. The engine is process-wide, so at this instant
+        // the previous appearance's dictionary is still mmap'd, we are on the main
+        // thread, and no load is in flight — the one moment in the cycle with no
+        // race in it. `setLanguage` on the next line unloads that dictionary
+        // synchronously, which is exactly what kept the prune from ever running
+        // off the load completion alone. Costs one boolean read once it has run.
+        suggestionState.pruneUserDictionaryIfPossible(trigger: "keyboard-appeared")
+
         // Refresh prediction language from App Group on every keyboard appearance.
         // WHY here not viewDidLoad: The user can change language in the app between
         // keyboard appearances. viewWillAppear fires each time, picking up the change.

--- a/DictusKeyboard/TextPrediction/AOSPTrieEngine.swift
+++ b/DictusKeyboard/TextPrediction/AOSPTrieEngine.swift
@@ -27,6 +27,20 @@ final class AOSPTrieEngine {
     /// Set by load(language:) so overrides and apostrophe handling can be language-aware.
     private var currentLanguage: String = "fr"
 
+    /// The language whose data is mmap'd **right now**, or nil when none is.
+    ///
+    /// WHY this is not `currentLanguage`: that one is the language most recently
+    /// *requested*, assigned synchronously when `load` is called, so it names a
+    /// dictionary that will not exist for another few hundred milliseconds. Any
+    /// decision about the data itself — see `UserDictionaryPruneGate` — has to
+    /// ask what is mounted, not what was ordered.
+    ///
+    /// Written on the main thread only: cleared in `load` at the same instant the
+    /// previous mmap is torn down, set in the load's main-thread completion. So a
+    /// non-nil value implies the bridge is loaded, and the pair cannot be
+    /// observed disagreeing from the main thread.
+    private(set) var mountedLanguage: String?
+
     /// The active language's data profile, or nil if `currentLanguage` is not a
     /// registered `SupportedLanguage`. All per-language data (overrides, accentMap,
     /// contractionPrefixes) is read from here so adding a language is a matter of
@@ -48,6 +62,9 @@ final class AOSPTrieEngine {
     func load(language: String, bundle: Bundle = .main, completion: ((Bool) -> Void)? = nil) {
         isLoading = true
         currentLanguage = language
+        // Cleared here, with the teardown it describes: from this line until the
+        // completion below, nothing is mounted.
+        mountedLanguage = nil
         bridge.unloadDictionary()
         wordCount = 0
 
@@ -79,6 +96,7 @@ final class AOSPTrieEngine {
             DispatchQueue.main.async {
                 if success {
                     self.wordCount = Int(self.bridge.wordCount())
+                    self.mountedLanguage = language
                     print("[AOSPTrieEngine] Loaded \(language)_spellcheck.dict (\(self.wordCount) words)")
                 } else {
                     print("[AOSPTrieEngine] Failed to load \(language)_spellcheck.dict")

--- a/DictusKeyboard/TextPrediction/AOSPTrieEngine.swift
+++ b/DictusKeyboard/TextPrediction/AOSPTrieEngine.swift
@@ -40,7 +40,12 @@ final class AOSPTrieEngine {
     ///
     /// WHY async: Prevents blocking the main thread during keyboard init.
     /// The keyboard appears instantly; spell correction becomes available after mmap load.
-    func load(language: String, bundle: Bundle = .main) {
+    ///
+    /// - Parameter completion: called on the main thread once the load has
+    ///   settled, with whether a dictionary is now available. Exists so a caller
+    ///   can run work that needs to ask the dictionary questions — there is no
+    ///   other moment at which `wordExists` starts telling the truth.
+    func load(language: String, bundle: Bundle = .main, completion: ((Bool) -> Void)? = nil) {
         isLoading = true
         currentLanguage = language
         bridge.unloadDictionary()
@@ -53,7 +58,10 @@ final class AOSPTrieEngine {
                 forResource: "\(language)_spellcheck", ofType: "dict"
             ) else {
                 print("[AOSPTrieEngine] Failed to find \(language)_spellcheck.dict")
-                DispatchQueue.main.async { self.isLoading = false }
+                DispatchQueue.main.async {
+                    self.isLoading = false
+                    completion?(false)
+                }
                 return
             }
 
@@ -76,6 +84,7 @@ final class AOSPTrieEngine {
                     print("[AOSPTrieEngine] Failed to load \(language)_spellcheck.dict")
                 }
                 self.isLoading = false
+                completion?(success)
             }
         }
     }

--- a/DictusKeyboard/TextPrediction/SuggestionState.swift
+++ b/DictusKeyboard/TextPrediction/SuggestionState.swift
@@ -344,6 +344,12 @@ class SuggestionState: ObservableObject {
         engine.isUnknownToDictionary(word)
     }
 
+    /// Attempts the user dictionary's one-shot prune (#287). Call from a moment
+    /// with a dictionary already mounted and no load pending — see the engine.
+    func pruneUserDictionaryIfPossible(trigger: String) {
+        engine.pruneUserDictionaryIfPossible(trigger: trigger)
+    }
+
     // MARK: - N-gram Predictions
 
     /// Updates suggestion bar with n-gram predicted next words.

--- a/DictusKeyboard/TextPrediction/SuggestionState.swift
+++ b/DictusKeyboard/TextPrediction/SuggestionState.swift
@@ -338,6 +338,12 @@ class SuggestionState: ObservableObject {
         engine.injectUserWord(word)
     }
 
+    /// Whether the active language's dictionary does not know this word (#287).
+    /// The word-boundary learning site asks before recording anything.
+    func isUnknownToDictionary(_ word: String) -> Bool {
+        engine.isUnknownToDictionary(word)
+    }
+
     // MARK: - N-gram Predictions
 
     /// Updates suggestion bar with n-gram predicted next words.

--- a/DictusKeyboard/TextPrediction/TextPredictionEngine.swift
+++ b/DictusKeyboard/TextPrediction/TextPredictionEngine.swift
@@ -37,13 +37,7 @@ class TextPredictionEngine {
     }
 
     private init() {
-        // Verify language is available in UITextChecker
-        let available = UITextChecker.availableLanguages
-        if !available.contains(where: { $0.hasPrefix(language) }) {
-            print("[TextPredictionEngine] Warning: '\(language)' not in available languages: \(available)")
-        }
-        frequencyDict.load(language: language)
-        aospTrieEngine.load(language: language)
+        loadDictionaries(for: language)
     }
 
     /// Updates the active language for completions and spell-checking.
@@ -54,12 +48,40 @@ class TextPredictionEngine {
     /// to stay within the keyboard extension's ~50MB memory budget.
     func setLanguage(_ lang: String) {
         language = lang
+        loadDictionaries(for: lang)
+    }
+
+    /// Loads both dictionaries for `lang` and runs the work that can only happen
+    /// once a dictionary is actually loaded.
+    private func loadDictionaries(for lang: String) {
+        // Verify language is available in UITextChecker
         let available = UITextChecker.availableLanguages
         if !available.contains(where: { $0.hasPrefix(lang) }) {
             print("[TextPredictionEngine] Warning: '\(lang)' not in available languages: \(available)")
         }
         frequencyDict.load(language: lang)
-        aospTrieEngine.load(language: lang)
+        aospTrieEngine.load(language: lang) { [weak self] loaded in
+            guard let self = self, loaded else { return }
+            // The user dictionary's one-shot prune (#287): the only place in the
+            // app that holds a loaded base dictionary is right here, and the
+            // prune has no way to ask its question before this point. It returns
+            // immediately once it has run, so paying the call on every language
+            // switch costs one boolean read.
+            UserDictionary.shared.pruneTrieDuplicatesIfNeeded(using: self.aospTrieEngine)
+        }
+    }
+
+    /// Whether `word` is genuinely new to the active language's dictionary —
+    /// the gate the word-boundary learning site needs (#287 decision 2).
+    ///
+    /// WHY false while the dictionary is still loading: the answer would be
+    /// "unknown" for every word typed in that window, and learning them all is
+    /// exactly the pollution this gate exists to stop. AOSP LatinIME takes the
+    /// same position for the same reason — it turns learning off entirely on a
+    /// slow InputConnection, because a word it cannot vet is a word it should
+    /// not keep. If we cannot ask, we do not learn.
+    func isUnknownToDictionary(_ word: String) -> Bool {
+        aospTrieEngine.isReady && !aospTrieEngine.knowsWord(word)
     }
 
     /// Returns up to 3 word completions for a partial word, ranked by frequency.

--- a/DictusKeyboard/TextPrediction/TextPredictionEngine.swift
+++ b/DictusKeyboard/TextPrediction/TextPredictionEngine.swift
@@ -40,6 +40,10 @@ class TextPredictionEngine {
     /// is still the newest one. See `loadDictionaries(for:)`.
     private var dictionaryLoadGeneration = 0
 
+    /// Whether this process has already reported that the prune was done in an
+    /// earlier session. See `reportPruneAlreadyDone()`.
+    private var hasReportedPruneAlreadyDone = false
+
     private init() {
         loadDictionaries(for: language)
     }
@@ -116,9 +120,10 @@ class TextPredictionEngine {
     /// done, a probe line says why, so an export can never again be ambiguous
     /// between "never called" and "called and declined".
     func pruneUserDictionaryIfPossible(trigger: String) {
-        // Once it has run there is nothing to attempt and nothing to report. This
-        // is what keeps the probe off a path that runs on every appearance.
-        guard !UserDictionary.shared.hasPrunedTrieDuplicates else { return }
+        guard !UserDictionary.shared.hasPrunedTrieDuplicates else {
+            reportPruneAlreadyDone()
+            return
+        }
 
         guard aospTrieEngine.isReady else {
             PersistentLog.log(.diagnosticProbe(
@@ -130,6 +135,30 @@ class TextPredictionEngine {
             return
         }
         UserDictionary.shared.pruneTrieDuplicatesIfNeeded(using: aospTrieEngine)
+    }
+
+    /// Says, once per keyboard process, that the prune has already been done.
+    ///
+    /// WHY this line has to exist. `userDictionaryPruned` is written once in the
+    /// life of an install, and `PersistentLog` is a 1 MB file trimmed from the
+    /// head — so an hour of ordinary use scrolls that line out of every later
+    /// export. Without a standing statement, "this install was cleaned long ago"
+    /// and "the prune is broken and never ran" are the same observation: silence.
+    /// The third device pass on #287 was spent on exactly that ambiguity.
+    ///
+    /// WHY once per process and not once per call: `viewWillAppear` runs on every
+    /// keyboard appearance, seventeen times in an hour of real use, and iOS keeps
+    /// several controllers alive. One line per process is enough to date the
+    /// state, and anything finer is the noise #255 was about.
+    private func reportPruneAlreadyDone() {
+        guard !hasReportedPruneAlreadyDone else { return }
+        hasReportedPruneAlreadyDone = true
+        PersistentLog.log(.diagnosticProbe(
+            component: "UserDictionaryPrune",
+            instanceID: "",
+            action: "alreadyDone",
+            details: "learnedCount=\(UserDictionary.shared.count)"
+        ))
     }
 
     /// Whether `word` is genuinely new to the active language's dictionary —

--- a/DictusKeyboard/TextPrediction/TextPredictionEngine.swift
+++ b/DictusKeyboard/TextPrediction/TextPredictionEngine.swift
@@ -36,6 +36,10 @@ class TextPredictionEngine {
         SupportedLanguage(rawValue: language)?.profile
     }
 
+    /// Counts dictionary load requests, so a load completion can tell whether it
+    /// is still the newest one. See `loadDictionaries(for:)`.
+    private var dictionaryLoadGeneration = 0
+
     private init() {
         loadDictionaries(for: language)
     }
@@ -59,6 +63,8 @@ class TextPredictionEngine {
         if !available.contains(where: { $0.hasPrefix(lang) }) {
             print("[TextPredictionEngine] Warning: '\(lang)' not in available languages: \(available)")
         }
+        dictionaryLoadGeneration += 1
+        let generation = dictionaryLoadGeneration
         frequencyDict.load(language: lang)
         aospTrieEngine.load(language: lang) { [weak self] loaded in
             guard let self = self, loaded else { return }
@@ -67,6 +73,20 @@ class TextPredictionEngine {
             // prune has no way to ask its question before this point. It returns
             // immediately once it has run, so paying the call on every language
             // switch costs one boolean read.
+            //
+            // WHY the generation check: loads are asynchronous, and a language
+            // switch during one leaves two in flight. The completions arrive in
+            // order, but nothing stops a later load from replacing the trie
+            // between an earlier completion being queued and it running — so a
+            // superseded completion can find a dictionary that is not the one it
+            // loaded, and is not the active language's either. The prune asks the
+            // live trie and sets a flag that is never retried, so pruning from
+            // there would delete one language's duplicates and permanently deny
+            // the active language its own pass. Only the newest load may prune.
+            //
+            // Skipping is free: the flag stays clear, so the next load — the one
+            // that superseded this one — prunes instead.
+            guard generation == self.dictionaryLoadGeneration else { return }
             UserDictionary.shared.pruneTrieDuplicatesIfNeeded(using: self.aospTrieEngine)
         }
     }

--- a/DictusKeyboard/TextPrediction/TextPredictionEngine.swift
+++ b/DictusKeyboard/TextPrediction/TextPredictionEngine.swift
@@ -87,8 +87,49 @@ class TextPredictionEngine {
             // Skipping is free: the flag stays clear, so the next load — the one
             // that superseded this one — prunes instead.
             guard generation == self.dictionaryLoadGeneration else { return }
-            UserDictionary.shared.pruneTrieDuplicatesIfNeeded(using: self.aospTrieEngine)
+            self.pruneUserDictionaryIfPossible(trigger: "dictionary-loaded")
         }
+    }
+
+    /// Attempts the user dictionary's one-shot prune, and says so when it cannot.
+    ///
+    /// WHY this needs two triggers and a report (#287). The load completion alone
+    /// was not enough, and the first device pass showed it: `userDictionaryPruned`
+    /// never appeared in the export at all. The cause is that
+    /// `AOSPTrieBridge.loadDictionaryAtPath` clears `_loaded` before it mmaps, and
+    /// `AOSPTrieEngine.load` calls `unloadDictionary()` synchronously on the main
+    /// thread before it queues anything — while `KeyboardViewController`
+    /// `viewWillAppear` issues a load on *every* keyboard appearance. A completion
+    /// posted with `DispatchQueue.main.async` therefore lands behind whatever main
+    /// is doing, which during a keyboard appearance includes further loads, each
+    /// of which has already blanked the flag. The completion then finds a
+    /// dictionary that reports itself unloaded, and the prune declines.
+    ///
+    /// Declining is correct — pruning against a dictionary that is not mounted
+    /// would ask every word and be told "not present", which prunes nothing but
+    /// would set the one-shot flag if it did not check. What was wrong is that it
+    /// was the *only* trigger, and a silent one.
+    ///
+    /// So: `viewWillAppear` calls this **before** it asks for a new load, which is
+    /// a moment with no race in it — on main, previous language's data still
+    /// mmap'd, nothing queued. And whenever the prune is still owed and cannot be
+    /// done, a probe line says why, so an export can never again be ambiguous
+    /// between "never called" and "called and declined".
+    func pruneUserDictionaryIfPossible(trigger: String) {
+        // Once it has run there is nothing to attempt and nothing to report. This
+        // is what keeps the probe off a path that runs on every appearance.
+        guard !UserDictionary.shared.hasPrunedTrieDuplicates else { return }
+
+        guard aospTrieEngine.isReady else {
+            PersistentLog.log(.diagnosticProbe(
+                component: "UserDictionaryPrune",
+                instanceID: "",
+                action: "skipped",
+                details: "trigger=\(trigger) reason=dictionary-not-ready"
+            ))
+            return
+        }
+        UserDictionary.shared.pruneTrieDuplicatesIfNeeded(using: aospTrieEngine)
     }
 
     /// Whether `word` is genuinely new to the active language's dictionary —

--- a/DictusKeyboard/TextPrediction/TextPredictionEngine.swift
+++ b/DictusKeyboard/TextPrediction/TextPredictionEngine.swift
@@ -36,10 +36,6 @@ class TextPredictionEngine {
         SupportedLanguage(rawValue: language)?.profile
     }
 
-    /// Counts dictionary load requests, so a load completion can tell whether it
-    /// is still the newest one. See `loadDictionaries(for:)`.
-    private var dictionaryLoadGeneration = 0
-
     /// Whether this process has already reported that the prune was done in an
     /// earlier session. See `reportPruneAlreadyDone()`.
     private var hasReportedPruneAlreadyDone = false
@@ -67,74 +63,58 @@ class TextPredictionEngine {
         if !available.contains(where: { $0.hasPrefix(lang) }) {
             print("[TextPredictionEngine] Warning: '\(lang)' not in available languages: \(available)")
         }
-        dictionaryLoadGeneration += 1
-        let generation = dictionaryLoadGeneration
         frequencyDict.load(language: lang)
-        aospTrieEngine.load(language: lang) { [weak self] loaded in
-            guard let self = self, loaded else { return }
-            // The user dictionary's one-shot prune (#287): the only place in the
-            // app that holds a loaded base dictionary is right here, and the
-            // prune has no way to ask its question before this point. It returns
-            // immediately once it has run, so paying the call on every language
-            // switch costs one boolean read.
-            //
-            // WHY the generation check: loads are asynchronous, and a language
-            // switch during one leaves two in flight. The completions arrive in
-            // order, but nothing stops a later load from replacing the trie
-            // between an earlier completion being queued and it running — so a
-            // superseded completion can find a dictionary that is not the one it
-            // loaded, and is not the active language's either. The prune asks the
-            // live trie and sets a flag that is never retried, so pruning from
-            // there would delete one language's duplicates and permanently deny
-            // the active language its own pass. Only the newest load may prune.
-            //
-            // Skipping is free: the flag stays clear, so the next load — the one
-            // that superseded this one — prunes instead.
-            guard generation == self.dictionaryLoadGeneration else { return }
-            self.pruneUserDictionaryIfPossible(trigger: "dictionary-loaded")
+        aospTrieEngine.load(language: lang) { [weak self] _ in
+            // The user dictionary's one-shot prune (#287). This is the first
+            // moment in a cold session at which anything can ask the dictionary a
+            // question, so it has to be one of the triggers — but it is not a
+            // privileged one. A completion can belong to a load that has since
+            // been superseded, and the trie it finds may be another language's
+            // entirely; the gate below is what decides, not the fact of being
+            // called from here.
+            self?.pruneUserDictionaryIfPossible(trigger: "dictionary-loaded")
         }
     }
 
     /// Attempts the user dictionary's one-shot prune, and says so when it cannot.
     ///
-    /// WHY this needs two triggers and a report (#287). The load completion alone
-    /// was not enough, and the first device pass showed it: `userDictionaryPruned`
-    /// never appeared in the export at all. The cause is that
-    /// `AOSPTrieBridge.loadDictionaryAtPath` clears `_loaded` before it mmaps, and
-    /// `AOSPTrieEngine.load` calls `unloadDictionary()` synchronously on the main
-    /// thread before it queues anything — while `KeyboardViewController`
-    /// `viewWillAppear` issues a load on *every* keyboard appearance. A completion
-    /// posted with `DispatchQueue.main.async` therefore lands behind whatever main
-    /// is doing, which during a keyboard appearance includes further loads, each
-    /// of which has already blanked the flag. The completion then finds a
-    /// dictionary that reports itself unloaded, and the prune declines.
+    /// WHY there are several triggers and no privileged one (#287). Two triggers
+    /// exist because neither is sufficient alone: the load completion is the only
+    /// moment a cold session can ask the dictionary anything, and it is
+    /// systematically starved once a session is warm — `viewWillAppear` issues a
+    /// load on every keyboard appearance, each tearing the mmap down
+    /// synchronously on the main thread before the previous completion, posted
+    /// with `DispatchQueue.main.async`, gets to run. That starvation is why the
+    /// prune never once ran on device. `viewWillAppear` therefore also attempts
+    /// it *before* asking for the next load, while the previous dictionary is
+    /// still mounted.
     ///
-    /// Declining is correct — pruning against a dictionary that is not mounted
-    /// would ask every word and be told "not present", which prunes nothing but
-    /// would set the one-shot flag if it did not check. What was wrong is that it
-    /// was the *only* trigger, and a silent one.
+    /// Neither is trusted, and that is the point. `UserDictionaryPruneGate` holds
+    /// the one precondition — the mounted dictionary is the active language's —
+    /// so a trigger cannot be wrong, only early. Adding another is safe.
     ///
-    /// So: `viewWillAppear` calls this **before** it asks for a new load, which is
-    /// a moment with no race in it — on main, previous language's data still
-    /// mmap'd, nothing queued. And whenever the prune is still owed and cannot be
-    /// done, a probe line says why, so an export can never again be ambiguous
-    /// between "never called" and "called and declined".
+    /// Whenever the prune is still owed and cannot be done, a probe says why, so
+    /// an export can never again be ambiguous between "never called", "called and
+    /// declined", and "done long ago".
     func pruneUserDictionaryIfPossible(trigger: String) {
-        guard !UserDictionary.shared.hasPrunedTrieDuplicates else {
+        let decision = UserDictionaryPruneGate.decide(
+            alreadyPruned: UserDictionary.shared.hasPrunedTrieDuplicates,
+            mountedLanguage: aospTrieEngine.mountedLanguage,
+            activeLanguage: SupportedLanguage.active.rawValue
+        )
+        switch decision {
+        case .run:
+            UserDictionary.shared.pruneTrieDuplicatesIfNeeded(using: aospTrieEngine)
+        case .alreadyDone:
             reportPruneAlreadyDone()
-            return
-        }
-
-        guard aospTrieEngine.isReady else {
+        case .notMounted, .languageMismatch:
             PersistentLog.log(.diagnosticProbe(
                 component: "UserDictionaryPrune",
                 instanceID: "",
                 action: "skipped",
-                details: "trigger=\(trigger) reason=dictionary-not-ready"
+                details: "trigger=\(trigger) reason=\(decision.reason)"
             ))
-            return
         }
-        UserDictionary.shared.pruneTrieDuplicatesIfNeeded(using: aospTrieEngine)
     }
 
     /// Says, once per keyboard process, that the prune has already been done.


### PR DESCRIPTION
Block A of #287, per the [grilling brief](https://github.com/getdictus/dictus-ios/issues/287#issuecomment-5250805961). Decisions 2, 3, 7, 8, 9. Block B (#346) is untouched.

## What this was for

The personal dictionary was learning **everything**. Type six ordinary French phrases and it kept 22 words, 20 of which were plain French the trie already knew — `le`, `chat`, `pomme`, `verte`. One App Group write per word boundary, for a dictionary that was mostly a duplicate of the dictionary sitting behind it.

That is not just untidy. A learned word is granted **permanent immunity from autocorrect**, invisibly, with no way for you to take it back except "Forget learned words". And #288 is going to feed this set into speech recognition — so it has to hold only genuinely personal words, not a copy of the French language.

Learning on rejection stays exactly as it was: the `Dictus` → `Rictus` → undo → immune chain is that path working correctly, and it is the trigger Apple documents for its own keyboard dictionary.

## To test by hand

A keyboard-extension change, so a green build is not a gate. Install on device, open Developer → **Autocorrect debug logs**, and keep the dictionary reset between passes — the two `USERDICT-RESET` lines bracket a session and name its inventory.

1. **Existing dictionaries get cleaned once.** Install over a build that already has a fat dictionary (do *not* reset first). Open the keyboard, then export the log. Expect `userDictionaryPruned removed=N learnedCount=M` and, with the toggle on, a `USERDICT-PRUNE words=[…]` line naming every word it dropped. What is left should be personal words only.
2. **Ordinary typing learns nothing.** Reset the dictionary. Type six ordinary French phrases (the ones from the 10 August measurement do fine: *le chat dort sur un tapis*, *elle a une pomme verte*, …). Reset again. The second `USERDICT-RESET` must read `words=[]`. Before this change it listed 22 words.
3. **An unknown word needs two occurrences.** Reset. Type `zorglub` once, space. Nothing in the log. Type `zorglub` a second time, space → `USERDICT-LEARN word="zorglub" count=2`.
4. **Rejection still learns on the first occurrence.** Reset. Type `Dictus`, space → it is autocorrected to `Rictus`. Undo it. Expect, in one window: `UNDO orig="Dictus" rejected="Rictus"`, then `USERDICT-LEARN word="dictus" count=1`. Type `Dictus` again → `AUTOCORRECT-SKIP word="Dictus" reason=user-learned`. **This chain is the one that must not have regressed.**
5. **Autocorrect off means no learning at all.** Reset. Turn autocorrect off in Settings. Type anything, including a word the trie does not know, twice. Reset again → `words=[]`.
6. **Nothing is learned during the first moments of a session.** Open the keyboard and type immediately, before the dictionary has loaded. Nothing should be learned in that window — the gate answers "cannot tell" and declines.
7. **Nothing else about typing changed.** Autocorrect, the suggestion bar, and accents behave as before. Only what gets *kept* changed.

Steps 2, 4 and 5 are the acceptance criteria that no test on this Mac can settle.

## What changed

| # | Decision | Where |
|---|---|---|
| 2 | Boundary site learns only words absent from the trie | `DictusKeyboardBridge.handleSpace`, via `SuggestionState.isUnknownToDictionary` |
| 3 | `repetitionThreshold` 1 → 2 | `UserDictionary` |
| 4 | Undo site unchanged: one occurrence | `KeyboardRootView.performUndo` now calls `learn` |
| 7 | Discard entries unused for 300 days | `UserDictionary.discardStaleEntries`, at load |
| 8 | Autocorrect disabled ⇒ no learning | `wordWasEvaluated` also requires `state.autocorrectEnabled` |
| 9 | Prune trie duplicates once, logged | `UserDictionary.pruneTrieDuplicatesIfNeeded` |

Three things are worth calling out beyond the brief.

**The shape the undo site keeps first-occurrence learning.** `learn()` already existed and its doc comment already said "e.g., after user rejects autocorrection" — the undo site was calling `recordUsage` when the function written for it was right there. It now calls `learn`, which returns whether it created the entry so the call site keeps its shape. No second threshold constant, no extra parameter, and the two sites no longer share a rule only one of them wants.

**One question, one place.** The gate and the prune both ask "does the base dictionary have this word", and both must ask it the way the corrector does: lowercased, and for a contraction only the part after the last apostrophe, since the trie stores `j'ai` as `ai`. That lives on `FrequencyProvider.knowsWord`. A gate that refused to learn `j'ai` while the prune kept it would leave entries no reader can ever reach.

**The gate fails closed.** The trie loads asynchronously, and `wordExists` answers false until it is up. Treating that as "unknown word, learn it" would pollute the dictionary for the first moments of every session, so `isUnknownToDictionary` requires the dictionary to be ready. AOSP takes the same position on a slow InputConnection: a word you cannot vet is a word you should not keep.

### One thing the brief did not name

Raising the threshold above 1 is what brings `pendingWords` back to life — and it had **no bound**. Everything reaching it is a word the trie does not know, which is mostly typos, and typos never come back for a second occurrence. Left alone it would grow for the life of the install, re-serialised on every word boundary. It now has a cap (500) and empties when it overflows: at a threshold of 2 every pending entry has been seen exactly once, so there is nothing to rank them by, and the alternative was a second timestamp map for entries that are not even vocabulary yet. Overflowing costs the words in flight one extra occurrence.

## The bilingual question (the brief asked for an answer here)

**Which trie is live:** unambiguously `SupportedLanguage.active`'s. #272 decoupled the *layout* from the dictionary language, not the dictionary from itself — `TextPredictionEngine.setLanguage` reads `SharedKeys.language`, and one trie is loaded at a time.

**What happens to a bilingual user's dictionary:** the prune removes entries the *active* trie knows. So an entry learned while typing language B is removed only if it also happens to be a valid word of language A. Not all of the other language's entries — the intersection.

**Why it ships rather than being deferred.** The brief's rule was "per-language or deferred", written before we knew whether such an entry comes back. It does, and this PR is what makes it come back:

- The prune is **one-shot**, flagged in App Group defaults. There is no delete/re-learn churn loop, which is the failure mode that would have made this genuinely destructive.
- Under language B the word is absent from B's trie, so the **boundary site re-learns it after two occurrences**, or the undo site re-learns it the first time the user rejects a correction on it. It is never pruned again.
- Worst case for that user: one autocorrection to undo, once, on a word they had taught. Not lasting data loss.

A truly per-language prune needs each entry to record the language it was learned in — a schema the store does not have and cannot have retroactively, and decision 9 explicitly rides on #305's timestamps rather than introducing one. Deferring instead would leave every existing install carrying a dictionary that #288 will later propagate into transcription, which is decision 1's whole rationale.

`USERDICT-PRUNE` names every word dropped, so if this does bite someone the export says exactly what it took.

## Acceptance

| Criterion | Status | Evidence |
|---|---|---|
| Six ordinary French phrases → zero new entries | **not verified here** | Device only. Manual step 2. The mechanism is unit-covered (`testThePruneRemovesEntriesTheBaseDictionaryAlreadyKnows`) but the keyboard target has no test bundle |
| Unknown word: once → nothing, twice → one entry | verified | `swift test`: `testTypingTwiceLearnsAWordThatTypingOnceDoesNot`, `testRecordUsageBelowTheThresholdDoesNotLearnTheWord` — both pass |
| Undo still learns on the first occurrence | partly | `testLearnRecordsAWordOnItsFirstOccurrence` passes; the `Dictus` → `Rictus` chain itself is device only. Manual step 4 |
| Autocorrect disabled → no learning at all | **not verified here** | Device only. Manual step 5 |
| Existing dictionary pruned on load, export names what was dropped | verified in core | `testThePruneRemovesEntriesTheBaseDictionaryAlreadyKnows`, `testThePruneRunsOnlyOnce`, `testThePruneWaitsForADictionaryThatIsReady`, `testThePruneReportsHowManyDuplicatesItRemovedAndNotWhich`, and the `USERDICT-PRUNE` assertion. On-device first-load behaviour: manual step 1 |
| `cd DictusCore && swift test`, incl. the un-skipped test | verified | `Executed 897 tests, with 0 failures`. `testRecordUsageBelowTheThresholdDoesNotLearnTheWord` now reports `passed`, not skipped |
| `swiftlint lint --strict` clean | verified | `Found 0 violations, 0 serious in 176 files` |

Also run: `xcodebuild build -scheme DictusApp` on iPhone 17 Pro Max (iOS 26.5) → `** BUILD SUCCEEDED **`, all three targets. The intermediate commit that touches the keyboard was built separately so no commit on this branch is broken.

## Out of scope, untouched

`injectUserWord`, `spellCheck`'s `isLearned` branch, every suggestion mode (block B / #346); per-word removal UI (decision 6 rejected it); #114; the undo site's behaviour. Version and build number are unchanged.

refs #287


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved personalized autocorrection by requiring repeated usage and excluding words already in the dictionary.
  * Added automatic cleanup of outdated and duplicate learned words.
  * Improved dictionary loading, language switching, and contraction handling.
* **Bug Fixes**
  * Corrected learning behavior when autocorrection is disabled, unavailable, or explicitly rejected.
  * Prevented learning decisions while dictionaries are still loading.
* **Diagnostics**
  * Added privacy-conscious debug logging for removed learned entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## After review — 26cf8e1

Device validation passed on 62f2dc3 (six French phrases → `words=[]`; `zorglub` learned on occurrence 2 only; the `UNDO` → `USERDICT-LEARN count=1` → `AUTOCORRECT-SKIP reason=user-learned` chain intact; autocorrect off → nothing learned). Three CodeRabbit findings were then settled; all three were valid, one of the two suggested fixes was not.

1. **Superseded dictionary load could run the prune (Major).** Real, and it is the bilingual concern arriving by a route the brief did not anticipate. `loadQueue` is serial so loads are ordered, but main is not synchronised against it: load A's completion is queued when A's queue work ends, then B's queue work replaces the trie on the same bridge, and whether A's completion runs before or after that is undefined. The prune asks the *live* trie, so a superseded completion could prune against whichever dictionary happened to be mounted — and the one-shot flag makes that unrecoverable. A load-generation counter now lets only the newest load prune; skipping is free, since the flag stays clear and the superseding load prunes instead.
2. **300-day cutoff was exclusive.** Now `<=`. The new boundary test computes its stamp against the same clock the load reads, which is the only way the boundary is reachable at all — the class-level fixtures are captured earlier and always land past it. Verified to fail on `<`, three runs out of three.
3. **The prune's privacy assertion checked only a survivor.** Valid. The suggested fix — adding `le` to `assertLogNamesNoWord` — would have failed: it is a substring search and `le` sits inside `learnedCount`, in the very line the same test asserts is present. The fixture's pruned word is now `bonjour`, which cannot appear in the log for any other reason, and both words are asserted absent.

**A second device pass is warranted on 26cf8e1.** Finding 1 is in the keyboard target. It cannot change typing or learning — the gate, the threshold and both call sites are untouched — but it changes when the prune fires, and the prune is the destructive part.

One practical note for re-testing step 1: the one-shot flag lives in App Group defaults and **"Forget learned words" does not clear it**, by design. Re-observing the prune needs a fresh install (deleting the app clears the container). Steps 2 to 7 re-test normally.

`swift test` → 898 passing. `swiftlint lint --strict` → 0 violations in 176 files. All three targets build.


---

## The prune never ran on device — 84c3bdf

Smoke on 26cf8e1 passed all three steps, but `userDictionaryPruned` was absent from both device exports. It is **case 2: called, and declining silently.** Not a plausibility argument — the mechanism is in the code:

- `AOSPTrieBridge.loadDictionaryAtPath` sets `_loaded = NO` before it mmaps, and `isLoaded` returns `_loaded`.
- `AOSPTrieEngine.load` calls `bridge.unloadDictionary()` — also `_loaded = NO` — **synchronously on the main thread**, before it queues any work.
- `KeyboardViewController.viewWillAppear` issues a load on **every** keyboard appearance, and the keyboard is recreated many times per session.
- The load completion is posted with `DispatchQueue.main.async`, so it lands *behind* whatever main is already doing — which during an appearance includes those further `load()` calls, each of which has already blanked the flag.

So the completion routinely runs against a dictionary that reports itself unloaded, `provider.isReady` is false, and `pruneTrieDuplicatesIfNeeded` returns 0. That guard is correct and must stay: pruning against an unmounted dictionary would be told "not present" for every word, remove nothing, and burn the one shot. The defect was that the load completion was the **only** trigger, and that missing it was indistinguishable from never being called.

Both halves are fixed:

1. **A trigger with no race in it.** `viewWillAppear` now attempts the prune *before* it asks for the next load. At that instant we are on main, the previous appearance's dictionary is still mmap'd (the engine is process-wide), and nothing is queued. `setLanguage` on the very next line is what unloads it. The load completion remains as the first-appearance path; the two cover each other.
2. **No more silence.** While a prune is still owed and cannot be done, a probe line records why: `diagnosticProbe component=UserDictionaryPrune action=skipped trigger=… reason=dictionary-not-ready`. Once the prune has run, both paths cost one boolean read and log nothing, so this cannot become noise on a path that runs on every appearance (#255).

**This needs a third device pass, and it is the one that closes the acceptance criterion.** The export must now show one of two things, and never neither:

- `userDictionaryPruned removed=N learnedCount=M` — and, with the Developer toggle on, `USERDICT-PRUNE words=[…]` naming what was dropped; or
- one or more `UserDictionaryPrune … action=skipped … reason=dictionary-not-ready` lines, which would mean the second trigger is also being starved and I have more to do.

Fresh install required — the one-shot flag lives in App Group defaults and "Forget learned words" does not clear it by design.

`swift test` → 899 passing. `swiftlint lint --strict` → 0 violations in 176 files. All three targets build.


---

## Why the prune is silent — a39c5db

Third pass, 84c3bdf, one hour of real use: six words learned, **every one preceded by its own `UNDO` line, all at `count=1`**, and nothing at all from the word-boundary site in an hour of ordinary French typing. Decisions 2, 3 and 8 hold under real conditions, which no scripted test had shown.

Neither `userDictionaryPruned` nor the `skipped` probe appears, which means the flag reads true. That is **case 1**, and it is provable rather than plausible:

- `dictus.userDictionary.prunedTrieDuplicates` has **exactly one writer**: `UserDictionary.swift:414`, inside `pruneTrieDuplicatesIfNeeded`, past the guard.
- The write and `PersistentLog.log(.userDictionaryPruned(…))` sit in the same straight-line block with **no branch, no early return and no throw between them**. `DictusApp` never calls the prune — it has no trie — so the keyboard extension is the only process that can set it.
- Therefore flag true ⟹ the prune completed ⟹ the line was written.
- `PersistentLog` caps the file at **1 MB and trims from the head** (`maxFileSize`, `trimmedTail`). The prune writes that line **once in the life of an install**, at the earliest keyboard appearance. An hour of real use with debug logging scrolls it out. The 13:54→14:06 gap is the same story from the other end.

Most likely it ran with an empty dictionary and logged `removed=0`: the smoke scripts reset the dictionary between passes, and a reset before the prune's first chance leaves it nothing to remove. Harmless, and it explains why no real removal has ever been demonstrated on that container.

**The defect is not the prune — it is that this state is unobservable.** "Cleaned long ago" and "never ran" were the same observation. Two changes:

1. **The already-done path now says so**, once per keyboard process: `diagnosticProbe component=UserDictionaryPrune action=alreadyDone details=learnedCount=N`. Not once per appearance — that is seventeen lines an hour and exactly the noise #255 was about.
2. **"Forget learned words" re-arms the prune.** The flag describes the stored dictionary, so destroying that dictionary leaves it describing nothing. Re-arming takes nothing from the user: everything learned after a reset is absent from the base dictionary by construction at both call sites, so the next prune has nothing it could take — pinned by `testThePruneAfterAResetHasNothingToTake`.

### Can a device be re-armed?

**For the mechanism, yes, on Pierre's current device:** tap "Forget learned words", reopen the keyboard, export. Expect `userDictionaryPruned removed=0 learnedCount=0`. That proves the trigger fires and logs — the ambiguity this pass was spent on — without reinstalling anything.

**For a real removal, no — not on a container that has already run this code**, and that is inherent rather than a gap in the fix. Demonstrating removal needs a dictionary full of duplicates *and* a clear flag, and after this change those two states cannot coexist: the prune fires on the appearance right after a reset, before anything can accumulate, and the boundary gate means nothing accumulates duplicates any more anyway. The only honest procedure is a container that predates this branch:

1. Delete the app (this, unlike a `devicectl` install, does wipe the App Group container).
2. Install a **`develop`** build and type ordinary French for a minute — pre-fix, it learns everything, which is the fat dictionary the migration exists for.
3. Install this branch and open the keyboard.
4. Export: `userDictionaryPruned removed=N learnedCount=M` with N large, and `USERDICT-PRUNE words=[…]` naming the ordinary French words it dropped.

That is the only run that can close "an existing dictionary containing trie duplicates is pruned on first load". It is worth doing once before merge, since the migration is destructive and one-shot.

`swift test` → 901 passing. `swiftlint lint --strict` → 0 violations in 176 files. All three targets build.


---

## One invariant instead of a fourth call site — 9012e2a

The a39c5db device pass closed the observability question: a reset re-armed the prune, `userDictionaryPruned removed=0 learnedCount=0` and `USERDICT-PRUNE words=[]` fired on the next appearance, and the appearance after logged `action=alreadyDone`. Both states are distinguishable in an export.

CodeRabbit then filed a Major against the pre-load call added in 84c3bdf, and it is **real**. `SettingsView.swift:215` calls `SupportedLanguage.activate` from the *app* process. The keyboard extension outlives that write, so on the next `viewWillAppear` the previous language's trie is still mmap'd, `isReady` is true for it, and the prune ran against it — spending the one shot, after which the language the user actually selected never got a pass.

That is the **third defect of the same shape** on this branch:

| fix | what it closed | what it moved |
|---|---|---|
| generation counter (26cf8e1) | a race between two loads | which load may prune |
| pre-load call (84c3bdf) | a prune that could never run | when the prune is attempted |
| — | | the moment it moved to is not language-safe |

Every one was a defensible call site, and every time a route was found where the choice does not hold. So the answer here is not a fourth site. The precondition was never "a dictionary is loaded". It is:

> **the dictionary I am about to ask is the one the user is typing in**

`UserDictionaryPruneGate` states exactly that, and lives in DictusCore — the only target with a test bundle, which matters because a rule that lives in the keyboard extension is a rule nothing checks. `AOSPTrieEngine` gains `mountedLanguage`, which names the data actually mmap'd: unlike `currentLanguage`, assigned when a load is *requested* and therefore naming a dictionary that will not exist for a few hundred milliseconds, it is cleared with the teardown and set in the load completion, main thread only. Call sites stop being trusted — a trigger can now be early, never wrong, so adding one is safe.

**The generation counter is removed**, because the invariant subsumes it and is stricter in both directions: a superseded completion whose trie matches the active language now prunes correctly, where the counter refused; one whose trie does not match is refused, where the counter allowed it.

Pinned by `UserDictionaryPruneGateTests` — including the app-changes-language case, `alreadyDone` outranking every other reason, and the log-safety of the reason tokens (language codes only, never user content).

### Does this need a fifth device pass?

**No, and a unit test is why.** The change is a guard tightening whose entire decision surface is now a pure function in DictusCore with direct coverage. Nothing in typing, learning, the threshold, the gate or either call site is touched. On a device that has already pruned, every path reaches `alreadyDone` exactly as it did on a39c5db, which was validated.

The one thing worth doing before merge remains the **removal** demonstration, unchanged from the previous section: delete the app, install `develop`, type French for a minute, install this branch, open the keyboard, expect `userDictionaryPruned removed=N` with N large plus `USERDICT-PRUNE words=[…]`. That is the only run that can close "an existing dictionary containing trie duplicates is pruned on first load", and it is worth one pass because the migration is destructive and one-shot.

`swift test` → 907 passing. `swiftlint lint --strict` → 0 violations in 177 files. All three targets build.
