### PR TITLE
Rank the user's language choice above the keyboard's at the polish stage (refs #332)

### DIFF
--- a/DictusApp/Audio/TranscriptionService.swift
+++ b/DictusApp/Audio/TranscriptionService.swift
@@ -120,11 +120,18 @@ class TranscriptionService {
         PersistentLog.log(.transcriptionStarted(modelName: modelName))
         // Trace the resolution so device tests (#226 acceptance: Mandarin via
         // Auto-detect, toolbar-switcher non-override) can verify it from logs.
+        //
+        // `mode` spells the mode out rather than printing its stored value
+        // (#332): a bare "fr" could not be told from a coincidence, and a
+        // reader of `mode=fr keyboard=en` had no way to see that the user had
+        // explicitly chosen French. `sttEffective` says whether the engine
+        // honours `stt=` at all — Parakeet ignores it and auto-detects from
+        // audio, which is how `stt=en` came to sit above a French transcript.
         PersistentLog.log(.diagnosticProbe(
             component: "TranscriptionService",
             instanceID: "languageResolution",
             action: "resolved",
-            details: "mode=\(languagePolicy.mode.storedValue) keyboard=\(languagePolicy.keyboardLanguage.rawValue) engine=\(languagePolicy.engine.rawValue) stt=\(language ?? "auto")"
+            details: "mode=\(languagePolicy.mode.telemetryDescription) keyboard=\(languagePolicy.keyboardLanguage.rawValue) engine=\(languagePolicy.engine.rawValue) stt=\(language ?? "auto") sttEffective=\(languagePolicy.sttLanguageIsEffective ? "yes" : "no")"
         ))
 
         // Route to active engine if set (multi-engine path)

--- a/DictusApp/Polish/PolishCoordinator.swift
+++ b/DictusApp/Polish/PolishCoordinator.swift
@@ -79,14 +79,17 @@ public final class PolishCoordinator {
     public func prewarm() {
         guard defaults.bool(forKey: SharedKeys.polishEnabled) else { return }
         guard let engineToWarm = appleFMEngine else { return }
-        // Resolve the prompt selection through the engine-aware language
-        // policy (#226/#239): explicit mode targets the dictated language, not
-        // the keyboard one; Auto mode warms the language-agnostic auto session
-        // (the language argument is a placeholder the engine normalizes).
-        // Prewarm has no dictation-scoped policy to receive (it fires at app
-        // launch and ~1.5s into recording), so it snapshots on its own — a
-        // stale warm target is harmless (prewarm is best-effort).
-        let selection = TranscriptionLanguagePolicy.snapshot().polishPromptSelection
+        // Resolve the prompt selection through the language policy
+        // (#226/#239/#332): explicit mode targets the language the user chose,
+        // not the keyboard one; Auto mode warms the language-agnostic auto
+        // session (the language argument is a placeholder the engine
+        // normalizes). Prewarm has no dictation-scoped policy to receive (it
+        // fires at app launch and ~1.5s into recording), so it snapshots on
+        // its own — and passes no detected language, since there is no
+        // transcript yet. A stale warm target is harmless: prewarm is
+        // best-effort, and `polish()` resolves the real target from scratch.
+        let selection = TranscriptionLanguagePolicy.snapshot()
+            .polishPromptSelection(detectedLanguage: nil)
         Task {
             switch selection {
             case .language(let target):
@@ -145,47 +148,94 @@ public final class PolishCoordinator {
             return raw
         }
 
-        // Transcription language decoupling (#226/#239): the prompt selection
-        // branches on the resolved mode. Follow/explicit modes run the
-        // per-language path (prompts + typography passes tuned for the four
-        // tested languages; in explicit mode polish targets the dictated
-        // language, not the keyboard one). Auto-detect mode — BOTH engines,
-        // per the #239 amendment — runs the language-agnostic auto path: the
-        // output language is unknown (could be zh, it, pt, …), so the engine
-        // uses the auto prompt; the verbal-punctuation pre-pass runs keyed on
-        // the DETECTED language, and the typography post-pass stays off.
-        switch languagePolicy.polishPromptSelection {
+        // `methodStart` anchors the full wall-clock the user actually waits
+        // for, detection and the deterministic passes included. Captured here
+        // rather than inside each path (#332) so moving detection above the
+        // branch does not quietly drop its cost out of `preprocessMs`.
+        let methodStart = Date()
+
+        // Detection runs BEFORE the branch (#332). The polish target is
+        // resolved from it — an explicit choice aside, the language the STT
+        // output actually reads as outranks the keyboard language — so it can
+        // no longer happen after the target has been chosen. Detecting once
+        // here also stops the two paths from each running their own pass.
+        //
+        // Detection reads `raw`, not the pre-pass output: the pre-pass is
+        // keyed on the target (circular now), and all it does is swap spoken
+        // punctuation words for marks, which can only remove language signal.
+        // The auto path already detected on `raw` for the same reason.
+        let detectedCode = PolishPipeline.detectLanguageCode(in: raw)
+        // The per-language path only understands the four tested languages;
+        // anything else is `nil` to it and falls through to its skip gate.
+        let request = Request(
+            raw: raw,
+            languagePolicy: languagePolicy,
+            recordingDuration: recordingDuration,
+            methodStart: methodStart,
+            detectedCode: detectedCode,
+            detected: detectedCode.flatMap(SupportedLanguage.init(rawValue:))
+        )
+
+        // Transcription language decoupling (#226/#239/#332): the prompt
+        // selection branches on the resolved mode. Follow/explicit modes run
+        // the per-language path (prompts + typography passes tuned for the
+        // four tested languages; explicit targets the language the user
+        // chose, follow targets what detection found and only falls back to
+        // the keyboard). Auto-detect mode — BOTH engines, per the #239
+        // amendment — runs the language-agnostic auto path: the output
+        // language is unknown (could be zh, it, pt, …), so the engine uses
+        // the auto prompt; the verbal-punctuation pre-pass runs keyed on the
+        // DETECTED language, and the typography post-pass stays off.
+        switch languagePolicy.polishPromptSelection(detectedLanguage: request.detected) {
         case .language(let target):
-            return await polishTargeted(
-                raw: raw, target: target,
-                languagePolicy: languagePolicy, recordingDuration: recordingDuration,
-                onEngineWillRun: onEngineWillRun
-            )
+            return await polishTargeted(request, target: target, onEngineWillRun: onEngineWillRun)
         case .autoDetected:
-            return await polishAutoDetected(
-                raw: raw, languagePolicy: languagePolicy, recordingDuration: recordingDuration,
-                onEngineWillRun: onEngineWillRun
-            )
+            return await polishAutoDetected(request, onEngineWillRun: onEngineWillRun)
         }
+    }
+
+    /// One dictation's polish input, as both paths need it: the raw text, the
+    /// policy snapshot, and the detection the caller ran before branching.
+    ///
+    /// Grouped rather than passed loose because #332 moved detection above the
+    /// branch, and threading five values through two paths made the parameter
+    /// lists longer than the linter (rightly) tolerates. Path-specific values —
+    /// the resolved target — stay separate arguments.
+    private struct Request {
+        let raw: String
+        let languagePolicy: TranscriptionLanguagePolicy
+        let recordingDuration: TimeInterval
+        /// Anchors the wall-clock the user waits for. Captured before
+        /// detection so its cost lands in `preprocessMs` like everything else.
+        let methodStart: Date
+        /// Raw `NLLanguage` code, the whole long tail ("it", "zh-Hans", …).
+        /// What the auto path gates and pre-processes on.
+        let detectedCode: String?
+        /// The same detection narrowed to the four languages the per-language
+        /// prompts exist for, or `nil` — gibberish, or outside that set.
+        let detected: SupportedLanguage?
     }
 
     // MARK: - Per-language path
 
     /// The historical polish path: verbal-punctuation pre-pass, duration gate,
-    /// gibberish gate, per-language prompt, typography post-pass. `target` is
-    /// the resolved polish language from the policy snapshot.
-    private func polishTargeted(raw: String,
+    /// gibberish gate, per-language prompt, typography post-pass.
+    ///
+    /// `target` is the resolved polish language — what the model will be told
+    /// to write in — and `request.detected` is what detection read in the raw
+    /// text, already run by the caller because the target is resolved from it
+    /// (#332). They are separate values because they legitimately differ: an
+    /// explicit transcription language outranks detection, and that gap is
+    /// exactly what selects `PolishMode.repair` below.
+    private func polishTargeted(_ request: Request,
                                 target: SupportedLanguage,
-                                languagePolicy: TranscriptionLanguagePolicy,
-                                recordingDuration: TimeInterval,
                                 onEngineWillRun: (() -> Void)?) async -> String {
+        let raw = request.raw
+        let languagePolicy = request.languagePolicy
+        let methodStart = request.methodStart
         let sttEngine = languagePolicy.engine
         let sttModelID = languagePolicy.modelIdentifier
-
-        // `methodStart` anchors the full wall-clock the user actually waits for,
-        // INCLUDING the deterministic passes (which the old timer excluded).
-        // The timing breakdown below proves where the time goes.
-        let methodStart = Date()
+        let resolution = PolishMetrics.LanguageResolution(policy: languagePolicy)
 
         // Pre-pass: deterministic regex substitution of verbal punctuation
         // commands. Round 3 testing showed Apple FM cannot be coaxed into
@@ -199,7 +249,7 @@ public final class PolishCoordinator {
         // punctuation above + NBSP below, both ~0ms) so typography stays
         // consistent with longer clips. No language detection / guardrail here
         // since the engine never runs.
-        if recordingDuration < Self.engineMinDuration {
+        if request.recordingDuration < Self.engineMinDuration {
             let preprocessMs = Int(Date().timeIntervalSince(methodStart) * 1000)
             let postStart = Date()
             // No engine ran → no newline markers to decode; this only applies
@@ -217,14 +267,17 @@ public final class PolishCoordinator {
                 outcome: .skippedShort,
                 sttEngine: sttEngine.rawValue,
                 sttModelID: sttModelID,
-                timings: PolishTimings(preprocessMs: preprocessMs, engineMs: 0, postprocessMs: postMs)
+                timings: PolishTimings(preprocessMs: preprocessMs, engineMs: 0, postprocessMs: postMs),
+                languageResolution: resolution
             )
             await emit(m, raw: raw, polished: finalShort)
             return finalShort
         }
 
         // Skip on gibberish — preserves trust per ADR 0002 §"skip-on-gibberish rule".
-        guard let detected = PolishPipeline.detectLanguage(in: preprocessed) else {
+        // Also covers a confident detection outside the four supported
+        // languages, which this path has no prompt for.
+        guard let detected = request.detected else {
             // Return the deterministic floor, NOT the literal raw: the verbal-
             // punctuation pre-pass already ran (~0ms) and the user expects their
             // spoken "virgule"/"point" turned into marks even when the LLM is
@@ -244,7 +297,8 @@ public final class PolishCoordinator {
                 outcome: .skipped,
                 sttEngine: sttEngine.rawValue,
                 sttModelID: sttModelID,
-                timings: PolishTimings(preprocessMs: preprocessMs, engineMs: 0, postprocessMs: postMs)
+                timings: PolishTimings(preprocessMs: preprocessMs, engineMs: 0, postprocessMs: postMs),
+                languageResolution: resolution
             )
             await emit(m, raw: raw, polished: nil)
             return fallback
@@ -296,7 +350,8 @@ public final class PolishCoordinator {
                 engineMs: bundle.engineMs,
                 postprocessMs: bundle.postprocessMs
             ),
-            failureReason: bundle.failureReason
+            failureReason: bundle.failureReason,
+            languageResolution: resolution
         )
         await emit(m, raw: raw, polished: bundle.engineOutput)
 
@@ -325,30 +380,30 @@ public final class PolishCoordinator {
     /// the raw NLLanguage code of the INPUT (e.g. "it", "zh-Hans"), which is
     /// how device tests validate output language == input language. Engine
     /// runs are identified by `mode == .auto` in the debug export.
-    private func polishAutoDetected(raw: String,
-                                    languagePolicy: TranscriptionLanguagePolicy,
-                                    recordingDuration: TimeInterval,
+    private func polishAutoDetected(_ request: Request,
                                     onEngineWillRun: (() -> Void)?) async -> String {
-        let methodStart = Date()
+        let raw = request.raw
+        let languagePolicy = request.languagePolicy
+        let methodStart = request.methodStart
         // Engine-API placeholder in auto mode — never used for typography or
         // guardrails (see PolishPipeline); doubles as the metrics context.
         let contextLanguage = languagePolicy.keyboardLanguage
 
-        // Detection runs FIRST (before the duration gate) because the verbal-
-        // punctuation pre-pass needs the detected language as its key — and,
-        // exactly like the per-language path, flash dictations must still get
-        // their spoken commands converted even when the LLM is skipped (#185).
-        let detectedCode = PolishPipeline.detectLanguageCode(in: raw)
-        let preprocessed = PolishPipeline.autoPreprocess(raw, detectedCode: detectedCode)
+        // `detectedCode` is detected by the caller, before the duration gate,
+        // because the verbal-punctuation pre-pass needs the detected language
+        // as its key — and, exactly like the per-language path, flash
+        // dictations must still get their spoken commands converted even when
+        // the LLM is skipped (#185).
+        let preprocessed = PolishPipeline.autoPreprocess(raw, detectedCode: request.detectedCode)
 
         // Duration gate (#141): on a flash dictation the user wants instant
         // text, so the LLM is skipped — but the deterministic floor is kept.
-        if recordingDuration < Self.engineMinDuration {
+        if request.recordingDuration < Self.engineMinDuration {
             let detectMs = Int(Date().timeIntervalSince(methodStart) * 1000)
             let m = autoEventMetrics(
                 outcome: .skippedShort, raw: raw, finalCount: preprocessed.count,
                 languagePolicy: languagePolicy, engineID: activeEngine.identifier,
-                detectedLanguage: detectedCode, latencyMs: detectMs,
+                detectedLanguage: request.detectedCode, latencyMs: detectMs,
                 timings: PolishTimings(preprocessMs: detectMs, engineMs: 0, postprocessMs: 0)
             )
             await emit(m, raw: raw, polished: nil)
@@ -359,7 +414,7 @@ public final class PolishCoordinator {
         // path (ADR 0002), but on the raw NLLanguage code: auto mode must
         // accept the whole long tail (zh, it, pt, …), not just the four
         // supported languages. No detection → no pre-pass ran → raw is intact.
-        guard let detectedCode else {
+        guard let detectedCode = request.detectedCode else {
             let detectMs = Int(Date().timeIntervalSince(methodStart) * 1000)
             let m = autoEventMetrics(
                 outcome: .skipped, raw: raw, finalCount: raw.count,
@@ -405,7 +460,11 @@ public final class PolishCoordinator {
 
     /// Metrics for one auto-path event. Defaults cover the skip exits (no
     /// mode, no detection, ~0ms); the engine-run exit overrides them.
-    /// `targetLanguage` is the keyboard language — session context only.
+    ///
+    /// `targetLanguage` is the keyboard language — session context only, since
+    /// auto mode targets nothing. The event's `languageResolution` records the
+    /// mode as `autoDetect`, so a reader can tell this context value from a
+    /// real target rather than having to know the convention (#332).
     private func autoEventMetrics(outcome: PolishMetrics.Outcome,
                                   raw: String,
                                   finalCount: Int,
@@ -430,7 +489,8 @@ public final class PolishCoordinator {
             sttEngine: languagePolicy.engine.rawValue,
             sttModelID: languagePolicy.modelIdentifier,
             timings: timings,
-            failureReason: failureReason
+            failureReason: failureReason,
+            languageResolution: PolishMetrics.LanguageResolution(policy: languagePolicy)
         )
     }
 

--- a/DictusApp/Polish/PolishCoordinator.swift
+++ b/DictusApp/Polish/PolishCoordinator.swift
@@ -260,7 +260,11 @@ public final class PolishCoordinator {
                 engine: activeEngine.identifier,
                 mode: nil,
                 targetLanguage: target,
-                detectedLanguage: nil,
+                // Detection ran before the target was chosen (#332), so it is
+                // in hand even here, where the engine never runs. It used to
+                // be recorded as nil because detection happened after this
+                // gate; keeping that would throw away a fact the event needs.
+                detectedLanguage: request.detectedCode,
                 rawCharCount: raw.count,
                 polishedCharCount: finalShort.count,
                 latencyMs: preprocessMs + postMs,
@@ -290,7 +294,13 @@ public final class PolishCoordinator {
                 engine: activeEngine.identifier,
                 mode: nil,
                 targetLanguage: target,
-                detectedLanguage: nil,
+                // The raw code, not nil: this exit is reached BOTH when
+                // detection was unconfident and when it confidently found a
+                // language outside the four this path has prompts for. Those
+                // are different events — "we could not read it" versus "you
+                // dictated Italian" — and only the code tells them apart. A
+                // nil here now means gibberish and nothing else.
+                detectedLanguage: request.detectedCode,
                 rawCharCount: raw.count,
                 polishedCharCount: fallback.count,
                 latencyMs: preprocessMs + postMs,

--- a/DictusApp/Polish/PolishCoordinator.swift
+++ b/DictusApp/Polish/PolishCoordinator.swift
@@ -461,10 +461,14 @@ public final class PolishCoordinator {
     /// Metrics for one auto-path event. Defaults cover the skip exits (no
     /// mode, no detection, ~0ms); the engine-run exit overrides them.
     ///
-    /// `targetLanguage` is the keyboard language — session context only, since
-    /// auto mode targets nothing. The event's `languageResolution` records the
-    /// mode as `autoDetect`, so a reader can tell this context value from a
-    /// real target rather than having to know the convention (#332).
+    /// `targetLanguage` is recorded as `nil`, because on this path there is no
+    /// target: the prompt is language-agnostic and the model writes in the
+    /// language the input is already in. It used to be filled with the
+    /// keyboard language "for session context", which meant an export showed
+    /// `target=de` beside `detected=fr` on a dictation that correctly came out
+    /// French — a reader auditing that would conclude the #332 bug was live.
+    /// The keyboard language is still on the event, under its own name, in
+    /// `languageResolution`.
     private func autoEventMetrics(outcome: PolishMetrics.Outcome,
                                   raw: String,
                                   finalCount: Int,
@@ -480,7 +484,7 @@ public final class PolishCoordinator {
         PolishMetrics(
             engine: engineID,
             mode: mode,
-            targetLanguage: languagePolicy.keyboardLanguage,
+            targetLanguage: nil,
             detectedLanguage: detectedLanguage,
             rawCharCount: raw.count,
             polishedCharCount: finalCount,

--- a/DictusApp/Polish/PolishDebugExporter.swift
+++ b/DictusApp/Polish/PolishDebugExporter.swift
@@ -65,7 +65,11 @@ struct PolishDebugExport: Codable {
         let engine: String
         let mode: String?
         /// The language the polish prompt told the model to write in.
-        let targetLanguage: String
+        /// **Absent on auto-mode events**, which have no target — the prompt
+        /// is language-agnostic there and the model writes in the input's own
+        /// language. Absent therefore means "nothing was targeted", never
+        /// "not recorded": every event predating #332 carries a value.
+        let targetLanguage: String?
         let detectedLanguage: String?
 
         // The rest of the language-resolution trail (#332). Optional because
@@ -151,7 +155,7 @@ enum PolishDebugExporter {
                 timestamp: formatter.string(from: entry.timestamp),
                 engine: entry.metrics.engine,
                 mode: entry.metrics.mode?.rawValue,
-                targetLanguage: entry.metrics.targetLanguage.rawValue,
+                targetLanguage: entry.metrics.targetLanguage?.rawValue,
                 detectedLanguage: entry.metrics.detectedLanguage,
                 transcriptionMode: entry.metrics.languageResolution?.transcriptionMode,
                 keyboardLanguage: entry.metrics.languageResolution?.keyboardLanguage,

--- a/DictusApp/Polish/PolishDebugExporter.swift
+++ b/DictusApp/Polish/PolishDebugExporter.swift
@@ -41,7 +41,15 @@ struct PolishDebugExport: Codable {
 
     struct SettingsInfo: Codable {
         let polishEnabled: Bool
-        let targetLanguage: String
+        /// The keyboard language. Named for what it is since #332 — it was
+        /// called `targetLanguage`, which is the polish target's name, and a
+        /// reader comparing this against a per-event target was silently
+        /// comparing the keyboard language against itself.
+        let keyboardLanguage: String
+        /// The transcription-language mode: `followKeyboard` / `autoDetect` /
+        /// `explicit(<code>)`. The setting the user actually chose, which no
+        /// export recorded before #332.
+        let transcriptionLanguageMode: String
         let activeModelID: String?
         let activeModelEngine: String?
         let appleFMAvailable: Bool
@@ -56,8 +64,27 @@ struct PolishDebugExport: Codable {
         let timestamp: String
         let engine: String
         let mode: String?
+        /// The language the polish prompt told the model to write in.
         let targetLanguage: String
         let detectedLanguage: String?
+
+        // The rest of the language-resolution trail (#332). Optional because
+        // events persisted by pre-#332 builds carry no trail at all — absent
+        // means "not recorded then", not "unknown". With `targetLanguage` and
+        // `detectedLanguage` above, these are the five facts needed to tell a
+        // wrong polish target from a deliberate setting.
+
+        /// `followKeyboard` / `autoDetect` / `explicit(<code>)`.
+        let transcriptionMode: String?
+        /// The keyboard language, which is NOT the polish target.
+        let keyboardLanguage: String?
+        /// The code handed to the STT engine, or "auto".
+        let sttLanguageCode: String?
+        /// Whether the STT engine honours that code. False for Parakeet, which
+        /// auto-detects from audio — so `sttLanguageCode` there says what was
+        /// passed, never what was transcribed.
+        let sttLanguageIsEffective: Bool?
+
         let outcome: String
         /// Why the engine failed (#315) — present on `engineFailed` events only.
         let failureReason: String?
@@ -97,7 +124,8 @@ enum PolishDebugExporter {
         let activeEngine = activeModelID.flatMap { ModelInfo.forIdentifier($0)?.engine.rawValue }
         let settings = PolishDebugExport.SettingsInfo(
             polishEnabled: defaults.bool(forKey: SharedKeys.polishEnabled),
-            targetLanguage: SupportedLanguage.active.rawValue,
+            keyboardLanguage: SupportedLanguage.active.rawValue,
+            transcriptionLanguageMode: TranscriptionLanguageMode.active.telemetryDescription,
             activeModelID: activeModelID,
             activeModelEngine: activeEngine,
             appleFMAvailable: PolishAvailability.isAppleFMAvailable,
@@ -125,6 +153,10 @@ enum PolishDebugExporter {
                 mode: entry.metrics.mode?.rawValue,
                 targetLanguage: entry.metrics.targetLanguage.rawValue,
                 detectedLanguage: entry.metrics.detectedLanguage,
+                transcriptionMode: entry.metrics.languageResolution?.transcriptionMode,
+                keyboardLanguage: entry.metrics.languageResolution?.keyboardLanguage,
+                sttLanguageCode: entry.metrics.languageResolution?.sttLanguageCode,
+                sttLanguageIsEffective: entry.metrics.languageResolution?.sttLanguageIsEffective,
                 outcome: entry.metrics.outcome.rawValue,
                 failureReason: entry.metrics.failureReason?.slug,
                 latencyMs: entry.metrics.latencyMs,

--- a/DictusApp/Polish/PolishDebugView.swift
+++ b/DictusApp/Polish/PolishDebugView.swift
@@ -165,7 +165,8 @@ private struct EntryRow: View {
                 } else if let mode = entry.metrics.mode {
                     Text(mode.rawValue).font(.caption2).foregroundStyle(.secondary)
                 }
-                Text(entry.metrics.targetLanguage.rawValue.uppercased())
+                // "—" on the auto path, which targets no language at all.
+                Text(entry.metrics.targetLanguage?.rawValue.uppercased() ?? "—")
                     .font(.caption2.bold())
                     .foregroundStyle(.secondary)
                 Spacer()
@@ -237,7 +238,7 @@ private struct EntryDetailView: View {
             HStack(spacing: 12) {
                 LabeledValue("engine", entry.metrics.engine)
                 LabeledValue("mode", entry.metrics.mode?.rawValue ?? "-")
-                LabeledValue("target", entry.metrics.targetLanguage.rawValue)
+                LabeledValue("target", entry.metrics.targetLanguage?.rawValue ?? "none (auto)")
                 LabeledValue("detected", entry.metrics.detectedLanguage ?? "-")
             }
             HStack(spacing: 12) {

--- a/DictusApp/Polish/PolishDebugView.swift
+++ b/DictusApp/Polish/PolishDebugView.swift
@@ -244,6 +244,22 @@ private struct EntryDetailView: View {
                 LabeledValue("stt engine", entry.metrics.sttEngine ?? "-")
                 LabeledValue("stt model", entry.metrics.sttModelID ?? "-")
             }
+            // The rest of the language-resolution trail (#332): reading
+            // "target=de" next to "detected=fr" only means something once the
+            // mode and the keyboard language are visible beside them. Absent
+            // on events persisted by pre-#332 builds.
+            if let resolution = entry.metrics.languageResolution {
+                HStack(spacing: 12) {
+                    LabeledValue("tx mode", resolution.transcriptionMode)
+                    LabeledValue("keyboard", resolution.keyboardLanguage)
+                    LabeledValue(
+                        "stt lang",
+                        resolution.sttLanguageIsEffective
+                            ? resolution.sttLanguageCode
+                            : "\(resolution.sttLanguageCode) (inert)"
+                    )
+                }
+            }
             HStack(spacing: 12) {
                 LabeledValue("latency", "\(entry.metrics.latencyMs) ms")
                 LabeledValue("chars", "\(entry.metrics.rawCharCount) → \(entry.metrics.polishedCharCount)")

--- a/DictusCore/Sources/DictusCore/Polish/PolishMetrics.swift
+++ b/DictusCore/Sources/DictusCore/Polish/PolishMetrics.swift
@@ -106,7 +106,21 @@ public struct PolishMetrics: Sendable, Codable {
     /// The language the polish prompt instructs the model to write in — the
     /// resolved polish target, NOT the keyboard language. See
     /// `TranscriptionLanguagePolicy.polishPromptSelection(detectedLanguage:)`.
-    public let targetLanguage: SupportedLanguage
+    ///
+    /// `nil` on the auto path, where there is no target at all: the prompt is
+    /// language-agnostic and the model writes in whatever language the input
+    /// is in. It was previously recorded as the keyboard language "for session
+    /// context", which put a language that had no influence under a field
+    /// named for the one that does — the precise confusion #332 exists to end,
+    /// and the reason three device reproductions were needed to prove the
+    /// original bug. An absent target now means no target.
+    ///
+    /// Optional decoding is also what keeps the seven-day ring readable: every
+    /// event written before #332 carries a value here, so a missing key can
+    /// only mean the auto path on a build that has this fix. (Auto-path events
+    /// from older builds still carry their keyboard language; they are
+    /// recognisable by having no `languageResolution`.)
+    public let targetLanguage: SupportedLanguage?
     public let detectedLanguage: String?   // BCP-47 ("fr","en",…) or nil for gibberish
 
     /// How the polish target was arrived at (#332). Optional for the reason
@@ -145,7 +159,7 @@ public struct PolishMetrics: Sendable, Codable {
 
     public init(engine: String,
                 mode: PolishMode?,
-                targetLanguage: SupportedLanguage,
+                targetLanguage: SupportedLanguage?,
                 detectedLanguage: String?,
                 rawCharCount: Int,
                 polishedCharCount: Int,
@@ -205,7 +219,7 @@ public struct PolishMetrics: Sendable, Codable {
                     + "/stt:\(r.sttLanguageCode)\(inert)"
             } ?? ""
             PolishLog.logger.info(
-                "📊 polish outcome=\(m.outcome.rawValue, privacy: .public) engine=\(m.engine, privacy: .public) mode=\(m.mode?.rawValue ?? "-", privacy: .public) target=\(m.targetLanguage.rawValue, privacy: .public) detected=\(m.detectedLanguage ?? "-", privacy: .public)\(resolution, privacy: .public) stt=\(m.sttEngine ?? "-", privacy: .public)/\(m.sttModelID ?? "-", privacy: .public) chars=\(m.rawCharCount, privacy: .public)→\(m.polishedCharCount, privacy: .public) latencyMs=\(m.latencyMs, privacy: .public)\(breakdown, privacy: .public)\(reason, privacy: .public)"
+                "📊 polish outcome=\(m.outcome.rawValue, privacy: .public) engine=\(m.engine, privacy: .public) mode=\(m.mode?.rawValue ?? "-", privacy: .public) target=\(m.targetLanguage?.rawValue ?? "none", privacy: .public) detected=\(m.detectedLanguage ?? "-", privacy: .public)\(resolution, privacy: .public) stt=\(m.sttEngine ?? "-", privacy: .public)/\(m.sttModelID ?? "-", privacy: .public) chars=\(m.rawCharCount, privacy: .public)→\(m.polishedCharCount, privacy: .public) latencyMs=\(m.latencyMs, privacy: .public)\(breakdown, privacy: .public)\(reason, privacy: .public)"
             )
         }
     }

--- a/DictusCore/Sources/DictusCore/Polish/PolishMetrics.swift
+++ b/DictusCore/Sources/DictusCore/Polish/PolishMetrics.swift
@@ -56,10 +56,66 @@ public struct PolishMetrics: Sendable, Codable {
         case exceededContextBudget
     }
 
+    /// The inputs that decided the polish target, captured per event (#332).
+    ///
+    /// WHY this exists: five facts decide which language the model is told to
+    /// write in, and until #332 an export carried only two of them — under a
+    /// name (`targetLanguage`) that in fact held a third. A reader looking at
+    /// a German target on French speech could not tell a bug from a setting,
+    /// and it took three deliberate device re-tests to establish which it was.
+    /// Recorded together with `targetLanguage` and `detectedLanguage` above,
+    /// these make that question answerable from the export alone.
+    public struct LanguageResolution: Sendable, Codable, Equatable {
+        /// The user's transcription-language mode, self-describing:
+        /// `followKeyboard` / `autoDetect` / `explicit(fr)`. Distinct from the
+        /// keyboard language, which is the whole point.
+        public let transcriptionMode: String
+        /// The keyboard language at dictation time.
+        public let keyboardLanguage: String
+        /// The language code handed to the STT engine, or "auto".
+        public let sttLanguageCode: String
+        /// Whether that engine honours the code. False for Parakeet, which
+        /// auto-detects from audio and ignores the parameter — so `stt:de`
+        /// there describes what was passed, never what was heard.
+        public let sttLanguageIsEffective: Bool
+
+        public init(transcriptionMode: String,
+                    keyboardLanguage: String,
+                    sttLanguageCode: String,
+                    sttLanguageIsEffective: Bool) {
+            self.transcriptionMode = transcriptionMode
+            self.keyboardLanguage = keyboardLanguage
+            self.sttLanguageCode = sttLanguageCode
+            self.sttLanguageIsEffective = sttLanguageIsEffective
+        }
+
+        /// Read the trail off the per-dictation policy snapshot — the same
+        /// snapshot the target was resolved from, so the two can never drift.
+        public init(policy: TranscriptionLanguagePolicy) {
+            self.init(
+                transcriptionMode: policy.mode.telemetryDescription,
+                keyboardLanguage: policy.keyboardLanguage.rawValue,
+                sttLanguageCode: policy.sttLanguageCodeDescription,
+                sttLanguageIsEffective: policy.sttLanguageIsEffective
+            )
+        }
+    }
+
     public let engine: String              // polish engine id, e.g. "apple-fm"
     public let mode: PolishMode?           // nil when skipped (no mode chosen)
+    /// The language the polish prompt instructs the model to write in — the
+    /// resolved polish target, NOT the keyboard language. See
+    /// `TranscriptionLanguagePolicy.polishPromptSelection(detectedLanguage:)`.
     public let targetLanguage: SupportedLanguage
     public let detectedLanguage: String?   // BCP-47 ("fr","en",…) or nil for gibberish
+
+    /// How the polish target was arrived at (#332). Optional for the reason
+    /// `sttEngine` and `timings` are: the debug ring holds seven days of
+    /// events written by whatever build was installed at the time, and those
+    /// must keep decoding. A missing key means "written before this existed",
+    /// never "unknown".
+    public let languageResolution: LanguageResolution?
+
     public let rawCharCount: Int
     public let polishedCharCount: Int      // equals rawCharCount when not polished
     public let latencyMs: Int
@@ -98,11 +154,13 @@ public struct PolishMetrics: Sendable, Codable {
                 sttEngine: String? = nil,
                 sttModelID: String? = nil,
                 timings: PolishTimings? = nil,
-                failureReason: PolishFailureReason? = nil) {
+                failureReason: PolishFailureReason? = nil,
+                languageResolution: LanguageResolution? = nil) {
         self.engine = engine
         self.mode = mode
         self.targetLanguage = targetLanguage
         self.detectedLanguage = detectedLanguage
+        self.languageResolution = languageResolution
         self.rawCharCount = rawCharCount
         self.polishedCharCount = polishedCharCount
         self.latencyMs = latencyMs
@@ -137,8 +195,17 @@ public struct PolishMetrics: Sendable, Codable {
             // events that succeed, and a `reason=-` on every one of them would
             // pay for nothing.
             let reason = m.failureReason.map { " reason=\($0.slug)" } ?? ""
+            // How the target was arrived at (#332), appended only when the
+            // event carries the trail so pre-#332 events keep their old shape.
+            // `inert` marks a code the engine ignores — Parakeet auto-detects
+            // from audio, so `stt:de` there says nothing about what was heard.
+            let resolution = m.languageResolution.map { r in
+                let inert = r.sttLanguageIsEffective ? "" : "(inert)"
+                return " resolution=tx:\(r.transcriptionMode)/kbd:\(r.keyboardLanguage)"
+                    + "/stt:\(r.sttLanguageCode)\(inert)"
+            } ?? ""
             PolishLog.logger.info(
-                "📊 polish outcome=\(m.outcome.rawValue, privacy: .public) engine=\(m.engine, privacy: .public) mode=\(m.mode?.rawValue ?? "-", privacy: .public) target=\(m.targetLanguage.rawValue, privacy: .public) detected=\(m.detectedLanguage ?? "-", privacy: .public) stt=\(m.sttEngine ?? "-", privacy: .public)/\(m.sttModelID ?? "-", privacy: .public) chars=\(m.rawCharCount, privacy: .public)→\(m.polishedCharCount, privacy: .public) latencyMs=\(m.latencyMs, privacy: .public)\(breakdown, privacy: .public)\(reason, privacy: .public)"
+                "📊 polish outcome=\(m.outcome.rawValue, privacy: .public) engine=\(m.engine, privacy: .public) mode=\(m.mode?.rawValue ?? "-", privacy: .public) target=\(m.targetLanguage.rawValue, privacy: .public) detected=\(m.detectedLanguage ?? "-", privacy: .public)\(resolution, privacy: .public) stt=\(m.sttEngine ?? "-", privacy: .public)/\(m.sttModelID ?? "-", privacy: .public) chars=\(m.rawCharCount, privacy: .public)→\(m.polishedCharCount, privacy: .public) latencyMs=\(m.latencyMs, privacy: .public)\(breakdown, privacy: .public)\(reason, privacy: .public)"
             )
         }
     }

--- a/DictusCore/Sources/DictusCore/TranscriptionLanguage.swift
+++ b/DictusCore/Sources/DictusCore/TranscriptionLanguage.swift
@@ -68,6 +68,18 @@ public enum TranscriptionLanguageMode: Equatable, Sendable {
         }
     }
 
+    /// Self-describing form for telemetry (#332). NOT `storedValue`: a stored
+    /// "fr" says which language without saying that the user *chose* it, and
+    /// telling an explicit choice from a coincidence is the entire question a
+    /// polish debug export has to answer.
+    public var telemetryDescription: String {
+        switch self {
+        case .followKeyboard: return "followKeyboard"
+        case .autoDetect: return "autoDetect"
+        case .explicit(let language): return "explicit(\(language.rawValue))"
+        }
+    }
+
     // MARK: - Resolution
 
     /// Reads the active mode from the App Group. Missing key = `.followKeyboard`.
@@ -180,13 +192,27 @@ public struct TranscriptionLanguagePolicy: Equatable, Sendable {
         return mode.resolvedLanguageCode(keyboardLanguageCode: keyboardLanguage.rawValue)
     }
 
-    /// Polish-stage prompt selection (#239).
+    /// Polish-stage prompt selection (#239, resolution order fixed in #332).
     ///
-    /// WHY polish follows the *transcription* language, not the keyboard:
-    /// The polish prompts and typography passes must match the language of the
-    /// STT output. In `.explicit` mode the user dictates in that language even
-    /// if the keyboard shows another one — targeting the keyboard language
-    /// would, e.g., apply French NBSP typography to English text.
+    /// The polish target is the language the LLM is *instructed to write in*
+    /// (`AppleFoundationModelsPolishEngine.resolvedInstructions(mode:language:)`),
+    /// so getting it wrong does not mis-tune typography — it TRANSLATES the
+    /// user's speech. That is the most destructive thing this pipeline can do,
+    /// which is why the order below is strict and the keyboard comes last:
+    ///
+    /// 1. an explicitly chosen transcription language, whenever one is set;
+    /// 2. otherwise the language detection found in the STT output;
+    /// 3. the keyboard language only as a last resort, never over either.
+    ///
+    /// WHY the engine no longer splits case 1 (#332): until this fix, explicit
+    /// mode resolved to `engine == .whisperKit ? language : keyboardLanguage`,
+    /// on the reasoning that the setting is Whisper-only-effective so Parakeet
+    /// should keep the pre-#226 behavior. Parakeet is the shipping engine, so
+    /// in practice every explicit choice was discarded: three device
+    /// reproductions caught French speech polished into German and into
+    /// English purely because the keyboard had been switched. "The setting
+    /// cannot steer Parakeet's STT" is true and irrelevant here — the user
+    /// still named a language, and polish still needs a target.
     ///
     /// WHY auto mode ignores the engine (#239 scope amendment): Parakeet
     /// natively transcribes whichever of its 25 languages is spoken, so in
@@ -197,18 +223,43 @@ public struct TranscriptionLanguagePolicy: Equatable, Sendable {
     /// mode. This is a polish-stage decision only — `sttLanguageCode` keeps
     /// Parakeet's follow behavior because the engine ignores the parameter.
     ///
-    /// In follow/explicit modes the setting stays Whisper-only-effective:
-    /// with Parakeet active, explicit resolves to the keyboard language, the
-    /// exact pre-#226 behavior.
-    public var polishPromptSelection: PolishPromptSelection {
+    /// - Parameter detectedLanguage: what `NLLanguageRecognizer` read in the
+    ///   raw STT output, or `nil` when it was not confident or landed outside
+    ///   the four supported languages. Injected by the caller rather than
+    ///   detected here so this stays a pure, testable function.
+    public func polishPromptSelection(
+        detectedLanguage: SupportedLanguage?
+    ) -> PolishPromptSelection {
         switch mode {
         case .autoDetect:
             return .autoDetected
-        case .followKeyboard:
-            return .language(keyboardLanguage)
         case .explicit(let language):
-            return .language(engine == .whisperKit ? language : keyboardLanguage)
+            return .language(language)
+        case .followKeyboard:
+            // No explicit choice to honour, so detection decides. Only when it
+            // has nothing to say does the keyboard language get used — and
+            // then it is a guess about the user's speech, not an instruction
+            // from them.
+            return .language(detectedLanguage ?? keyboardLanguage)
         }
+    }
+
+    /// Whether the STT engine actually honours `sttLanguageCode` (#332).
+    ///
+    /// Parakeet auto-detects from audio and ignores the parameter entirely
+    /// (`ParakeetEngine.transcribe(audioSamples:language:)`), so the code it
+    /// receives is inert. The language-resolution probe logs a code either
+    /// way, which made `stt=en engine=PK` read as "transcribed in English"
+    /// when the raw text was French; recording this alongside it is what
+    /// removes the ambiguity.
+    public var sttLanguageIsEffective: Bool {
+        engine == .whisperKit
+    }
+
+    /// `sttLanguageCode` rendered for logs and the debug export, with `nil`
+    /// (Whisper auto-detection) spelled out rather than dropped.
+    public var sttLanguageCodeDescription: String {
+        sttLanguageCode ?? "auto"
     }
 
     /// True when the transcription must be inserted literally as-is (no

--- a/DictusCore/Tests/DictusCoreTests/Polish/PolishPipelineTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/Polish/PolishPipelineTests.swift
@@ -135,6 +135,21 @@ final class PolishPipelineTests: XCTestCase {
         ))
     }
 
+    /// The pairing the per-language skip exit records against (#332): an
+    /// unsupported language yields a code but no `SupportedLanguage`, while
+    /// gibberish yields neither. Both skip polish, but they are different
+    /// events — "you dictated Italian, and this path has no Italian prompt"
+    /// versus "we could not read this at all" — and the event only tells them
+    /// apart because the code is recorded where it used to write nil.
+    func testUnsupportedLanguageAndGibberishAreDistinguishable() {
+        let italian = "allora ho parlato con Marco ieri sera e mi ha detto che il progetto va bene"
+        XCTAssertEqual(PolishPipeline.detectLanguageCode(in: italian), "it")
+        XCTAssertNil(PolishPipeline.detectLanguage(in: italian))
+
+        XCTAssertNil(PolishPipeline.detectLanguageCode(in: "   \n  "))
+        XCTAssertNil(PolishPipeline.detectLanguage(in: "   \n  "))
+    }
+
     /// In auto mode the target-language typography must NOT run: a French
     /// input with `target: .french` as engine placeholder keeps its ASCII
     /// space before `?` (no NBSP) — the prompt owns typography in auto mode.

--- a/DictusCore/Tests/DictusCoreTests/Polish/PolishPipelineTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/Polish/PolishPipelineTests.swift
@@ -135,19 +135,38 @@ final class PolishPipelineTests: XCTestCase {
         ))
     }
 
-    /// The pairing the per-language skip exit records against (#332): an
+    /// The detection pairing the per-language skip exit relies on (#332): an
     /// unsupported language yields a code but no `SupportedLanguage`, while
-    /// gibberish yields neither. Both skip polish, but they are different
-    /// events — "you dictated Italian, and this path has no Italian prompt"
-    /// versus "we could not read this at all" — and the event only tells them
-    /// apart because the code is recorded where it used to write nil.
-    func testUnsupportedLanguageAndGibberishAreDistinguishable() {
+    /// text that cannot be read yields neither. Both skip polish, and the
+    /// coordinator records `detectedLanguage: detectedCode` at that exit so
+    /// the two stay distinguishable on the event — "you dictated Italian, and
+    /// this path has no Italian prompt" is not "we could not read this".
+    ///
+    /// SCOPE: this asserts the detection pairing only. That the skip exit
+    /// actually writes the code onto the event is NOT covered — it lives in
+    /// `PolishCoordinator` (DictusApp), and the project has no app test
+    /// bundle, so DictusCore is the only suite that exists. That half is a
+    /// manual check: a sub-2s dictation should produce a `skippedShort` event
+    /// carrying a detected language.
+    ///
+    /// Both undetectable cases below are non-empty on purpose, so they reach
+    /// the recognizer rather than the empty-input guard covered above, and
+    /// they exercise different branches of it: digits produce no hypothesis at
+    /// all, while nonsense words produce one the threshold then rejects
+    /// (measured 0.27 against a 0.5 threshold — a fixture nearer the boundary,
+    /// e.g. "xyz" at 0.46, would be one NL revision from flipping).
+    func testDetectionSeparatesUnsupportedLanguageFromUnreadableText() {
         let italian = "allora ho parlato con Marco ieri sera e mi ha detto che il progetto va bene"
-        XCTAssertEqual(PolishPipeline.detectLanguageCode(in: italian), "it")
-        XCTAssertNil(PolishPipeline.detectLanguage(in: italian))
+        XCTAssertEqual(PolishPipeline.detectLanguageCode(in: italian), "it",
+                       "an unsupported language must still yield its code")
+        XCTAssertNil(PolishPipeline.detectLanguage(in: italian),
+                     "…while resolving to no SupportedLanguage")
 
-        XCTAssertNil(PolishPipeline.detectLanguageCode(in: "   \n  "))
-        XCTAssertNil(PolishPipeline.detectLanguage(in: "   \n  "))
+        for unreadable in ["123 456 789", "asdf qwer zxcv"] {
+            XCTAssertNil(PolishPipeline.detectLanguageCode(in: unreadable),
+                         "no confident language in \(unreadable)")
+            XCTAssertNil(PolishPipeline.detectLanguage(in: unreadable))
+        }
     }
 
     /// In auto mode the target-language typography must NOT run: a French

--- a/DictusCore/Tests/DictusCoreTests/TranscriptionLanguageModeTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/TranscriptionLanguageModeTests.swift
@@ -283,7 +283,52 @@ final class PolishLanguageResolutionPersistenceTests: XCTestCase {
         // The distinction the export existed to make and could not: the polish
         // target and the keyboard language are separate values on one event.
         XCTAssertEqual(decoded.targetLanguage, .german)
-        XCTAssertNotEqual(decoded.detectedLanguage, decoded.targetLanguage.rawValue)
+        XCTAssertNotEqual(decoded.detectedLanguage, decoded.targetLanguage?.rawValue)
+    }
+
+    /// The auto path targets no language: the prompt is language-agnostic and
+    /// the model writes in whatever the input is. Recording the keyboard
+    /// language there — as this did until the device test caught it — puts a
+    /// language that had no influence under the field named for the one that
+    /// does, which is the confusion #332 exists to end. On device it produced
+    /// `detected=fr, target=de` on a dictation that correctly came out French.
+    func testAutoPathRecordsNoTargetAtAll() throws {
+        let sut = PolishMetrics(
+            engine: "apple-fm", mode: .auto, targetLanguage: nil,
+            detectedLanguage: "fr", rawCharCount: 200, polishedCharCount: 210,
+            latencyMs: 2800, outcome: .success,
+            sttEngine: "PK", sttModelID: "parakeet-tdt-0.6b-v3",
+            languageResolution: PolishMetrics.LanguageResolution(
+                transcriptionMode: "autoDetect", keyboardLanguage: "de",
+                sttLanguageCode: "de", sttLanguageIsEffective: false
+            )
+        )
+        let json = try XCTUnwrap(String(data: try JSONEncoder().encode(sut), encoding: .utf8))
+        XCTAssertFalse(json.contains("\"targetLanguage\""),
+                       "a nil target must be omitted, not encoded as a language: \(json)")
+        // The keyboard language is still on the event — under its own name.
+        XCTAssertTrue(json.contains("\"keyboardLanguage\":\"de\""))
+
+        let decoded = try JSONDecoder().decode(
+            PolishMetrics.self, from: XCTUnwrap(json.data(using: .utf8))
+        )
+        XCTAssertNil(decoded.targetLanguage)
+        XCTAssertEqual(decoded.languageResolution?.keyboardLanguage, "de")
+    }
+
+    /// Absent must mean "nothing was targeted", never "not recorded" — which
+    /// holds only because every event written before #332 carries a value.
+    func testPreFixEventsStillCarryTheirTarget() throws {
+        let shipped = """
+        {"engine":"apple-fm","mode":"auto","targetLanguage":"de","detectedLanguage":"fr",\
+        "rawCharCount":200,"polishedCharCount":210,"latencyMs":2800,"outcome":"success"}
+        """
+        let decoded = try JSONDecoder().decode(
+            PolishMetrics.self, from: XCTUnwrap(shipped.data(using: .utf8))
+        )
+        XCTAssertEqual(decoded.targetLanguage, .german)
+        XCTAssertNil(decoded.languageResolution,
+                     "no trail is what marks an auto event as predating the fix")
     }
 
     /// Backward compatibility: a payload shaped exactly like one written by

--- a/DictusCore/Tests/DictusCoreTests/TranscriptionLanguageModeTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/TranscriptionLanguageModeTests.swift
@@ -280,10 +280,14 @@ final class PolishLanguageResolutionPersistenceTests: XCTestCase {
         XCTAssertEqual(decoded.languageResolution?.keyboardLanguage, "de")
         XCTAssertEqual(decoded.languageResolution?.sttLanguageCode, "de")
         XCTAssertEqual(decoded.languageResolution?.sttLanguageIsEffective, false)
-        // The distinction the export existed to make and could not: the polish
-        // target and the keyboard language are separate values on one event.
+        // The distinction the export existed to make and could not: detected,
+        // target and keyboard are three separate values on one event. Asserted
+        // as exact values rather than as "target != detected" — that form also
+        // passes when detectedLanguage is lost and decodes as nil, which is
+        // the failure a round-trip test is here to catch.
+        // (the keyboard language is asserted with the rest of the trail above)
+        XCTAssertEqual(decoded.detectedLanguage, "fr")
         XCTAssertEqual(decoded.targetLanguage, .german)
-        XCTAssertNotEqual(decoded.detectedLanguage, decoded.targetLanguage?.rawValue)
     }
 
     /// The auto path targets no language: the prompt is language-agnostic and

--- a/DictusCore/Tests/DictusCoreTests/TranscriptionLanguageModeTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/TranscriptionLanguageModeTests.swift
@@ -82,13 +82,35 @@ final class TranscriptionLanguageModeTests: XCTestCase {
         XCTAssertEqual(mode.resolvedLanguageCode(keyboardLanguageCode: "es"), "en")
     }
 
+    // MARK: - Telemetry description (#332)
+
+    func testTelemetryDescriptionNamesTheModeNotJustTheLanguage() {
+        // The whole point: "fr" alone cannot say whether the user chose French
+        // or the keyboard happened to be French.
+        XCTAssertEqual(TranscriptionLanguageMode.followKeyboard.telemetryDescription,
+                       "followKeyboard")
+        XCTAssertEqual(TranscriptionLanguageMode.autoDetect.telemetryDescription,
+                       "autoDetect")
+        XCTAssertEqual(TranscriptionLanguageMode.explicit(.french).telemetryDescription,
+                       "explicit(fr)")
+        XCTAssertEqual(TranscriptionLanguageMode.explicit(.german).telemetryDescription,
+                       "explicit(de)")
+    }
+
+    func testTelemetryDescriptionIsDistinctFromStoredValue() {
+        // If they were interchangeable the export would still be ambiguous.
+        let explicit = TranscriptionLanguageMode.explicit(.french)
+        XCTAssertEqual(explicit.storedValue, "fr")
+        XCTAssertNotEqual(explicit.telemetryDescription, explicit.storedValue)
+    }
+
 }
 
-/// Engine-aware per-dictation policy snapshot (#226 review follow-up, #239):
-/// the STT setting is Whisper-only-effective, but the polish-stage prompt
-/// selection uses the auto prompt for BOTH engines in Auto mode (#239 scope
-/// amendment — Parakeet auto-detects natively, so its output language is just
-/// as unknown as Whisper's).
+/// Engine-aware per-dictation policy snapshot (#226 review follow-up, #239,
+/// #332): the STT setting is Whisper-only-effective, but the polish-stage
+/// target follows its own order — explicit choice, then detection, then the
+/// keyboard as a last resort (#332) — and Auto mode uses the auto prompt for
+/// BOTH engines (#239 scope amendment).
 final class TranscriptionLanguagePolicyTests: XCTestCase {
 
     private func policy(_ mode: TranscriptionLanguageMode,
@@ -104,14 +126,14 @@ final class TranscriptionLanguagePolicyTests: XCTestCase {
     func testWhisperFollowBehavesLikeToday() {
         let sut = policy(.followKeyboard, keyboard: .french, engine: .whisperKit)
         XCTAssertEqual(sut.sttLanguageCode, "fr")
-        XCTAssertEqual(sut.polishPromptSelection, .language(.french))
+        XCTAssertEqual(sut.polishPromptSelection(detectedLanguage: .french), .language(.french))
         XCTAssertFalse(sut.insertsTranscriptionAsIs)
     }
 
     func testWhisperAutoDetectUsesAutoPromptAndSkipsSeparator() {
         let sut = policy(.autoDetect, keyboard: .french, engine: .whisperKit)
         XCTAssertNil(sut.sttLanguageCode, "nil enables Whisper language detection")
-        XCTAssertEqual(sut.polishPromptSelection, .autoDetected,
+        XCTAssertEqual(sut.polishPromptSelection(detectedLanguage: .german), .autoDetected,
                        "auto mode polishes with the language-agnostic prompt (#239)")
         XCTAssertTrue(sut.insertsTranscriptionAsIs)
     }
@@ -119,17 +141,17 @@ final class TranscriptionLanguagePolicyTests: XCTestCase {
     func testWhisperExplicitIgnoresKeyboardLanguage() {
         let sut = policy(.explicit(.english), keyboard: .french, engine: .whisperKit)
         XCTAssertEqual(sut.sttLanguageCode, "en")
-        XCTAssertEqual(sut.polishPromptSelection, .language(.english),
+        XCTAssertEqual(sut.polishPromptSelection(detectedLanguage: .english), .language(.english),
                        "polish must match the dictated language, not the keyboard")
         XCTAssertFalse(sut.insertsTranscriptionAsIs)
     }
 
-    // MARK: - Parakeet: STT stage unchanged, polish stage engine-aware
+    // MARK: - Parakeet: STT stage unchanged, polish stage follows the order
 
-    func testParakeetFollowBehavesLikeToday() {
+    func testParakeetFollowUsesTheDetectedLanguage() {
         let sut = policy(.followKeyboard, keyboard: .spanish, engine: .parakeet)
         XCTAssertEqual(sut.sttLanguageCode, "es")
-        XCTAssertEqual(sut.polishPromptSelection, .language(.spanish))
+        XCTAssertEqual(sut.polishPromptSelection(detectedLanguage: .spanish), .language(.spanish))
         XCTAssertFalse(sut.insertsTranscriptionAsIs)
     }
 
@@ -141,17 +163,144 @@ final class TranscriptionLanguagePolicyTests: XCTestCase {
         // behavior (the engine ignores the language parameter anyway).
         let sut = policy(.autoDetect, keyboard: .french, engine: .parakeet)
         XCTAssertEqual(sut.sttLanguageCode, "fr", "STT stage untouched by #239")
-        XCTAssertEqual(sut.polishPromptSelection, .autoDetected)
+        XCTAssertEqual(sut.polishPromptSelection(detectedLanguage: .french), .autoDetected)
         XCTAssertFalse(sut.insertsTranscriptionAsIs,
                        "separator behavior is Whisper-auto-only, untouched by #239")
     }
 
-    func testParakeetExplicitKeepsKeyboardPolishTarget() {
-        // Explicit mode cannot influence Parakeet — polish keeps targeting
-        // the keyboard language exactly as before #226.
-        let sut = policy(.explicit(.english), keyboard: .french, engine: .parakeet)
-        XCTAssertEqual(sut.sttLanguageCode, "fr")
-        XCTAssertEqual(sut.polishPromptSelection, .language(.french))
-        XCTAssertFalse(sut.insertsTranscriptionAsIs)
+    // MARK: - Polish target resolution order (#332)
+
+    /// The regression this issue is about: three device reproductions caught
+    /// French speech polished into German and into English, purely because the
+    /// keyboard had been switched while the setting said French. Before #332,
+    /// explicit mode resolved to the keyboard language on any non-Whisper
+    /// engine — and Parakeet is the shipping engine, so the user's choice was
+    /// discarded on essentially every real dictation.
+    func testExplicitTargetIsNeverOverriddenByTheKeyboard() {
+        for engine in [SpeechEngine.whisperKit, .parakeet] {
+            for keyboard in [SupportedLanguage.german, .english, .spanish] {
+                let sut = policy(.explicit(.french), keyboard: keyboard, engine: engine)
+                XCTAssertEqual(
+                    sut.polishPromptSelection(detectedLanguage: .french), .language(.french),
+                    "explicit fr must survive a \(keyboard.rawValue) keyboard on \(engine.rawValue)"
+                )
+            }
+        }
+    }
+
+    /// Rank 1 beats rank 2: the user's own words outrank a detector's guess,
+    /// including when the detector disagrees.
+    func testExplicitTargetOutranksDetection() {
+        let sut = policy(.explicit(.french), keyboard: .german, engine: .parakeet)
+        XCTAssertEqual(sut.polishPromptSelection(detectedLanguage: .german), .language(.french))
+        XCTAssertEqual(sut.polishPromptSelection(detectedLanguage: nil), .language(.french),
+                       "an explicit choice does not need detection to back it up")
+    }
+
+    /// Rank 2 beats rank 3: with no explicit choice, what the transcript reads
+    /// as decides the target — so a keyboard switch cannot retarget polish
+    /// onto a language the user never spoke.
+    func testDetectedLanguageOutranksTheKeyboardInFollowMode() {
+        for engine in [SpeechEngine.whisperKit, .parakeet] {
+            let sut = policy(.followKeyboard, keyboard: .german, engine: engine)
+            XCTAssertEqual(
+                sut.polishPromptSelection(detectedLanguage: .french), .language(.french),
+                "French transcript on a German keyboard must not be polished into German"
+            )
+        }
+    }
+
+    /// Rank 3: the keyboard is still the answer when nothing better exists —
+    /// detection was unconfident, or landed outside the four supported
+    /// languages. That is a guess, and it is the only case where one is made.
+    func testKeyboardLanguageIsTheLastResortOnly() {
+        let sut = policy(.followKeyboard, keyboard: .german, engine: .parakeet)
+        XCTAssertEqual(sut.polishPromptSelection(detectedLanguage: nil), .language(.german))
+    }
+
+    // MARK: - STT telemetry (#332)
+
+    /// The `stt=en engine=PK` log line that read as "transcribed in English"
+    /// above a French transcript. The code is real, the engine ignores it.
+    func testSttLanguageIsMarkedIneffectiveForParakeet() {
+        let parakeet = policy(.explicit(.english), keyboard: .french, engine: .parakeet)
+        XCTAssertEqual(parakeet.sttLanguageCode, "fr",
+                       "STT stage keeps its pre-#226 follow behavior")
+        XCTAssertFalse(parakeet.sttLanguageIsEffective,
+                       "Parakeet auto-detects from audio and ignores the parameter")
+
+        let whisper = policy(.explicit(.english), keyboard: .french, engine: .whisperKit)
+        XCTAssertTrue(whisper.sttLanguageIsEffective)
+    }
+
+    func testSttLanguageDescriptionSpellsOutWhisperAutoDetection() {
+        let sut = policy(.autoDetect, keyboard: .french, engine: .whisperKit)
+        XCTAssertNil(sut.sttLanguageCode)
+        XCTAssertEqual(sut.sttLanguageCodeDescription, "auto",
+                       "a dropped nil would read as 'not recorded'")
+    }
+
+    func testLanguageResolutionTrailCarriesEachFactApart() {
+        // The export must let a reader separate the mode, the keyboard, and
+        // what STT was handed — the failure that made three device re-tests
+        // necessary was that these collapsed into one mislabelled field.
+        let sut = policy(.explicit(.french), keyboard: .german, engine: .parakeet)
+        let trail = PolishMetrics.LanguageResolution(policy: sut)
+        XCTAssertEqual(trail.transcriptionMode, "explicit(fr)")
+        XCTAssertEqual(trail.keyboardLanguage, "de")
+        XCTAssertEqual(trail.sttLanguageCode, "de")
+        XCTAssertFalse(trail.sttLanguageIsEffective)
+    }
+}
+
+/// The language-resolution trail is only useful if it reaches the JSON export
+/// intact, and only safe if adding it does not invalidate the events already
+/// on disk (#332). The debug ring is 7 days of JSON Lines written by whatever
+/// build was installed at the time.
+final class PolishLanguageResolutionPersistenceTests: XCTestCase {
+
+    private func metric(resolution: PolishMetrics.LanguageResolution?) -> PolishMetrics {
+        PolishMetrics(
+            engine: "apple-fm", mode: .repair, targetLanguage: .german,
+            detectedLanguage: "fr", rawCharCount: 423, polishedCharCount: 342,
+            latencyMs: 3203, outcome: .success,
+            sttEngine: "PK", sttModelID: "parakeet-tdt-0.6b-v3",
+            languageResolution: resolution
+        )
+    }
+
+    func testTrailSurvivesTheMetricJSONRoundTrip() throws {
+        let sut = metric(resolution: PolishMetrics.LanguageResolution(
+            transcriptionMode: "explicit(fr)", keyboardLanguage: "de",
+            sttLanguageCode: "de", sttLanguageIsEffective: false
+        ))
+        let data = try JSONEncoder().encode(sut)
+        let decoded = try JSONDecoder().decode(PolishMetrics.self, from: data)
+        XCTAssertEqual(decoded.languageResolution?.transcriptionMode, "explicit(fr)")
+        XCTAssertEqual(decoded.languageResolution?.keyboardLanguage, "de")
+        XCTAssertEqual(decoded.languageResolution?.sttLanguageCode, "de")
+        XCTAssertEqual(decoded.languageResolution?.sttLanguageIsEffective, false)
+        // The distinction the export existed to make and could not: the polish
+        // target and the keyboard language are separate values on one event.
+        XCTAssertEqual(decoded.targetLanguage, .german)
+        XCTAssertNotEqual(decoded.detectedLanguage, decoded.targetLanguage.rawValue)
+    }
+
+    /// Backward compatibility: a payload shaped exactly like one written by
+    /// 1.8.0 (26) — the build the third reproduction came from — must decode.
+    func testEventEncodedWithoutATrailStillDecodes() throws {
+        let shipped = """
+        {"engine":"apple-fm","mode":"repair","targetLanguage":"en","detectedLanguage":"fr",\
+        "rawCharCount":423,"polishedCharCount":342,"latencyMs":3203,"outcome":"success",\
+        "sttEngine":"PK","sttModelID":"parakeet-tdt-0.6b-v3",\
+        "timings":{"preprocessMs":16,"engineMs":3180,"postprocessMs":7}}
+        """
+        let decoded = try JSONDecoder().decode(
+            PolishMetrics.self, from: XCTUnwrap(shipped.data(using: .utf8))
+        )
+        XCTAssertEqual(decoded.outcome, .success)
+        XCTAssertNil(decoded.languageResolution,
+                     "a missing key means 'written before the trail existed', not a failed decode")
+        XCTAssertEqual(decoded.timings?.engineMs, 3180)
     }
 }


### PR DESCRIPTION
## What this was for

French speech was coming back as German — and later as English — prose. The STT was fine; the polish stage was translating it. The polish target followed the **keyboard** language, so switching the keyboard mid-session silently retargeted polish onto a language the user never spoke, even with the transcription language set explicitly to French. Three device reproductions established that; it took three because **no debug export could answer the question**. The export recorded the keyboard language under the name `targetLanguage` and never recorded the transcription-language mode at all, so "target=de on French speech" could not be told from a setting the user had deliberately chosen.

This PR fixes both halves: the resolution order, and the telemetry that proves it.

## To test by hand

Steps 1-6 and 8-11 were **run on device against `375dbd3`** and passed; they are kept here so the run is reproducible, and because step 9 must be re-read against the auto-path change in `40ee005`. **Step 7 has never been run** and is the one genuinely open item.

1. Install this branch, open **Réglages → Langue de transcription** and set it explicitly to **Français** (tap through another language and back so the App Group key is definitely written).
2. Set the **keyboard** language to **Deutsch** (or English) via the keyboard's language switcher. Leave the transcription language alone.
3. Dictate 15–20 seconds of ordinary French. → **Expected: the inserted text is French.** Before this fix it came back German/English, or was saved only by a guardrail rejection.
4. Repeat with the keyboard on **English**. → **Expected: still French.**
5. Switch the keyboard back to **Français** and dictate French again. → **Expected: French, unchanged behaviour.**
6. Now set the transcription language to **Suivre le clavier** (follow), keyboard on **Deutsch**, and dictate French again. → **Expected: French output.** This is the second half of the fix: with nothing explicitly chosen, what you actually spoke outranks the keyboard.
7. **NEVER RUN — still open.** Still in follow mode with the German keyboard, dictate **German**. → **Expected: German output** — detection agrees with the keyboard, nothing changes. This needs a German speaker; it was skipped during device validation and no evidence exists for it either way. It is the only rank-2 case where detection and the keyboard agree, so the risk it covers is low, but it is untested.
8. Open **Réglages → Polish Debug**, tap into any event from the runs above. → **Expected: a new row showing `tx mode`, `keyboard`, and `stt lang`.** For step 3 it should read `tx mode explicit(fr)`, `keyboard de`, `stt lang de (inert)`, with `target fr` and `detected fr` on the row above.
9. Export the polish debug JSON and open it. → **Expected**, per event: `transcriptionMode`, `keyboardLanguage`, `sttLanguageCode`, `sttLanguageIsEffective`, alongside `targetLanguage` and `detectedLanguage`. In the `settings` block: `keyboardLanguage` (renamed from the misleading `targetLanguage`) and `transcriptionLanguageMode`. **Re-check after `40ee005`:** on an **autoDetect** event `targetLanguage` must now be **absent entirely** (the auto path targets no language), with the keyboard language present under `languageResolution.keyboardLanguage`. In the debug UI that event shows `target none (auto)` and a `—` in the row.
10. In the app log, find the `languageResolution` probe line. → **Expected:** `mode=explicit(fr) keyboard=de engine=PK stt=de sttEffective=no`. The `sttEffective=no` is what stops that line reading as "transcribed in German".
11. Sanity check that nothing else moved: dictate with **Auto-detect**, and dictate something under 2 s. → **Expected: unchanged behaviour** (auto prompt / instant text, no engine call).

Note for step 9: events already in the 7-day ring from older builds will have none of the new fields. That is intended — absent means "written before the field existed". Only dictations made on this build carry the trail.

## What changed

**The resolution order** (`TranscriptionLanguagePolicy.polishPromptSelection`). It is now, strictly:

1. an explicitly chosen transcription language, whenever one is set;
2. otherwise the language detection read in the transcript;
3. the keyboard language only as a last resort, never over either.

The bug was one clause: explicit mode resolved to `engine == .whisperKit ? language : keyboardLanguage`. The reasoning (the setting is Whisper-only-effective, so Parakeet keeps its pre-#226 behaviour) was defensible in isolation, but Parakeet is the shipping engine — so the branch that discarded the user's choice was the *only one that ever ran*. "The setting cannot steer Parakeet's STT" is true and beside the point: the user still named a language, and polish still needs a target.

Follow mode was fixed too, and it was not merely latent: it never consulted detection either, so the same translation was reachable with nothing configured at all. That also answers the open question in the issue body about whether a keyboard switch should silently retarget polish — it no longer can, whenever detection has an opinion.

**Detection moved above the target.** It has to: the target is now resolved from it. It runs on the raw text rather than the pre-pass output — the pre-pass is keyed on the target, which would be circular, and all it does is swap spoken punctuation words for marks, which can only remove language signal. The auto path already detected on raw for exactly this reason and now shares the single pass instead of running its own. Gate order and every outcome are unchanged.

**The telemetry.** Each event carries how its target was reached: mode, keyboard language, and the code STT was handed, alongside the detected language and the resolved target — the five facts the issue asks to be separable. All optional, because the debug ring holds seven days of events written by whatever build was installed at the time and those must keep decoding. The `settings.targetLanguage` field is renamed `keyboardLanguage`, which is what it always held.

The mode is written `followKeyboard` / `autoDetect` / `explicit(fr)` rather than as its stored value: a bare `"fr"` names a language without saying the user chose it, which is the entire question.

## Acceptance criteria

### Device validation

Run against `375dbd3` (export `dictus-polish-debug-20260811-223439.json`, log `rev 375dbd3@HEAD`, 8 events carrying the new fields):

```
20:30:25  explicit(fr)    kb=de  det=fr  TGT=fr  natural  success       -> French out
20:30:56  explicit(fr)    kb=en  det=fr  TGT=fr  natural  success       -> French out
20:31:47  explicit(fr)    kb=fr  det=fr  TGT=fr  natural  success
20:32:46  followKeyboard  kb=de  det=fr  TGT=fr  natural  engineFailed  (Apple FM, #315)
20:33:03  followKeyboard  kb=de  det=-   TGT=de  -        skippedShort
20:33:07  followKeyboard  kb=de  det=-   TGT=de  -        skipped
20:34:04  autoDetect      kb=de  det=fr  TGT=de  auto     success       -> French out
20:34:20  autoDetect      kb=de  det=fr  TGT=de  auto     success       -> French out
```

Ranks 1, 2 and 3 all behave as specified, and the `languageResolution` probe printed correctly in all 8 cases including `sttEffective=no`. The `engineFailed` at 20:32:46 is the Apple FM rate limiter (#315, out of scope). The `skippedShort`/`skipped` pair at 20:33 records `TGT=de` with no detection, which is correct — no engine ran and rank 3 is the honest answer there.

Second round, run against `40ee005` (iOS 26.6), confirming that fix and covering two cases the first round missed:

- `autoDetect`, keyboard `de` → **no `targetLanguage` key at all**, with `keyboardLanguage: de` under its own name. The record now matches the behaviour.
- `autoDetect`, keyboard `fr` → `target none (auto)`, `detected fr`, success, French out.
- `followKeyboard kb=en det=en target=en natural success` ×2, English in, English out — rank 2 with detection and keyboard agreeing.

The last two lines of the first round are what `40ee005` fixes: the output was correctly French, but the *record* showed `det=fr, TGT=de`, because the auto path filled `targetLanguage` with the keyboard language. See below.

### Criteria

| Criterion | Status | Evidence |
|---|---|---|
| Explicit transcription language never overridden by the keyboard at polish | ✅ **device-confirmed** | 20:30:25 (kb=de) and 20:30:56 (kb=en) → target fr, French output. Plus `testExplicitTargetIsNeverOverriddenByTheKeyboard` (4 langs × 2 engines), `testExplicitTargetOutranksDetection` |
| Detected language used when no explicit choice | ✅ **device-confirmed** | 20:32:46 — followKeyboard, kb=de, det=fr → target **fr**. Plus `testDetectedLanguageOutranksTheKeyboardInFollowMode` |
| Keyboard is last resort only | ✅ **device-confirmed** | 20:33:03 / 20:33:07 — followKeyboard, no detection → target de. Plus `testKeyboardLanguageIsTheLastResortOnly` |
| Export records the mode per event and in `settings`, distinctly from the keyboard | ✅ **device-confirmed** | 8/8 events carry the fields; probe printed `sttEffective=no` in all 8 |
| Reader can separate mode / keyboard / effective STT / detected / target | ✅ **device-confirmed** | the auto-path defect below was found by exactly this reading, then re-read clean on `40ee005` |
| Auto path records no target rather than the keyboard language | ✅ **device-confirmed** | second round on `40ee005`: auto event carries no `targetLanguage` key, `keyboardLanguage: de` under its own name. Plus `testAutoPathRecordsNoTargetAtAll`, `testPreFixEventsStillCarryTheirTarget` |
| Skip exits record the detection they hold | ✅ code, ⚠️ device unverified | `9522e9c`; `testUnsupportedLanguageAndGibberishAreDistinguishable`. Needs a sub-2s dictation to see a `skippedShort` event carry a code |
| Whole suite green | ✅ | `cd DictusCore && swift test` → **919 tests, 0 failures** |
| Three targets build | ✅ | `xcodebuild … -scheme {DictusApp,DictusKeyboard,DictusCore} -destination 'platform=iOS Simulator,name=iPhone 17'` → **BUILD SUCCEEDED** ×3 |
| Lint clean | ✅ | `swiftlint lint --strict` → **0 violations, 0 serious in 177 files** |
| Rank 2 where detection and keyboard agree | ✅ **device-confirmed (English)** | `followKeyboard kb=en det=en target=en` ×2, English in/out |
| German speech on a German keyboard | ⚠️ **never run** | step 7 — needs a German speaker; no evidence either way. The equivalent English case above is covered |

## The auto path recorded a target it never had (`40ee005`)

Device validation confirmed the fix and surfaced one defect in the *record*, not the behaviour. On an `autoDetect` event the export read `detected=fr, targetLanguage=de` for a dictation whose output was correctly French. `polishPromptSelection` returned `.autoDetected`, the language-agnostic prompt ran, nothing was translated — but `autoEventMetrics` filled `targetLanguage` with the keyboard language and called it session context.

That is the failure #332 was written to end. A language with no influence on the result sat under the field named for the one that decides it; anyone auditing that export would reasonably conclude the bug was live. It is also precisely why the original took three device reproductions to prove. Renaming the `settings` field fixed it at session level; per event, on the auto path, it survived.

The auto path has no target, so the metric now says so: `targetLanguage` is optional and omitted there, while the keyboard language stays on the event under its own name. Absent means *nothing was targeted*, never "not recorded" — every event written before this carries a value, and auto-path events from older builds in the 7-day ring remain identifiable by having no `languageResolution` at all. Which prompt runs is unchanged; the engine API still takes the non-optional placeholder it ignores in auto mode.

Auto-mode event as now recorded — no `targetLanguage` key at all:

```json
{
  "detectedLanguage" : "fr",
  "mode" : "auto",
  "languageResolution" : {
    "transcriptionMode" : "autoDetect",
    "keyboardLanguage" : "de",
    "sttLanguageCode" : "de",
    "sttLanguageIsEffective" : false
  },
  "outcome" : "success",
  "engine" : "apple-fm",
  "sttEngine" : "PK"
}
```

Recorded event JSON, for the third reproduction's exact configuration (explicit French, English keyboard, Parakeet):

```json
{
  "detectedLanguage" : "fr",
  "targetLanguage" : "fr",
  "languageResolution" : {
    "transcriptionMode" : "explicit(fr)",
    "keyboardLanguage" : "en",
    "sttLanguageCode" : "en",
    "sttLanguageIsEffective" : false
  },
  "mode" : "natural",
  "outcome" : "success",
  "engine" : "apple-fm",
  "sttEngine" : "PK"
}
```

`targetLanguage` is `fr` where it used to be `en`, and every input that produced it is visible beside it. (This is the persisted metrics shape; the exporter flattens `languageResolution` into top-level event fields.)

CI does not run the tests on this repo — SwiftLint and build only — so the `swift test` run above is the only test signal that exists.

## The two open questions

**`mode=repair` — answered, and it was a symptom, not a second bug.** `PolishPipeline.mode(sttEngine:detected:target:)`: for Parakeet, `.repair` is selected exactly when `detected != target`. So repair was *caused by* the wrong target — detected `fr`, target `de`/`en` ⇒ repair. The `fr` + `repair` events in earlier exports are the mirror image (target `fr`, some other language detected), which is why the correlation looked imperfect. Nothing to fix; expect `repair` to become markedly rarer, since the target now agrees with detection in every case except a deliberate explicit choice.

**Does STT take the keyboard-language path? — yes nominally, no in effect.** `sttLanguageCode` returns `keyboardLanguage.rawValue` for every non-Whisper engine, so the probe's `stt=en` was truthful about what was *passed*. But `ParakeetEngine.transcribe(audioSamples:language:)` ignores the parameter entirely — a documented no-op, since FluidAudio's `ASRManager.transcribe` takes no language at all. That is why the raw transcript was clean French under `stt=en`. The line was never lying; it was recording an inert value. `sttEffective=no` now says so, and the STT stage is otherwise untouched.

## One thing worth flagging

Rank 1 is absolute by design, which means: if a user sets the transcription language explicitly to French and then genuinely speaks German, the target stays French and `repair` may translate their German into French. That follows the order the issue specifies — an explicit choice is an instruction, not a hint — and it is the one remaining path by which polish can still change a language. It is strictly narrower than what shipped (it now requires the user to have contradicted their own setting out loud, rather than merely switching keyboards), and I did not widen the contract to cover it without asking. If you would rather detection also override an explicit choice, that is a small change to one `switch` — but it makes the setting advisory, so it is your call.


## Review findings

**Detection discarded at the per-language skip exits** (`9522e9c`) — applied. Both early exits wrote `detectedLanguage: nil`, which was correct while detection ran after them and stopped being correct when this PR moved it above the branch. It also erased a distinction the issue exists to preserve: the gibberish exit is reached both when detection was unconfident *and* when it was confident about a language this path has no prompt for. Recording the raw code means a `nil` there now says gibberish and nothing else. The auto path was already correct at both of its exits.

**Localizing the three new debug labels** — declined, with the reasoning on the thread. Every surrounding label on that sheet is unlocalized English and absent from the catalogs (`Polish event` is there only as an auto-extracted stub with no translations); localizing three of roughly fifteen would leave the screen half-translated. It is a diagnostic surface read by an agent against a JSON export, and the labels deliberately mirror the export field names. If that call is wrong, the fix is to localize the whole screen in its own change.

## Out of scope, worth its own issue

Auto-mode dictation with the **German** keyboard failed `unsupportedLanguageOrLocale` in 9 ms; auto-mode with the **French** keyboard succeeded. Same build, same OS, one variable. That suggests `contextLanguage = languagePolicy.keyboardLanguage` — the placeholder the auto path hands the engine, which the code comment calls inert — is in fact acted on by Apple FM. Untouched by this PR and left alone deliberately; it predates #332 and needs its own issue.
