### PR TITLE
Number row fallout: no digit row on iPad, popups sized from the letter rows (refs #336, #337)

### DIFF
--- a/DictusApp/Localizable.xcstrings
+++ b/DictusApp/Localizable.xcstrings
@@ -2250,13 +2250,13 @@
         }
       }
     },
-    "The number row is shown in portrait only." : {
-      "comment" : "Settings footer explaining that the digit row is deliberately dropped in landscape (issue #331).",
+    "The number row is shown on iPhone in portrait only." : {
+      "comment" : "Settings footer explaining where the digit row is drawn: dropped in landscape (issue #331) and on iPad (issue #336).",
       "localizations" : {
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La rangée de chiffres s'affiche uniquement en mode portrait."
+            "value" : "La rangée de chiffres s'affiche uniquement sur iPhone, en mode portrait."
           }
         }
       }

--- a/DictusApp/Views/SettingsView.swift
+++ b/DictusApp/Views/SettingsView.swift
@@ -273,10 +273,18 @@ struct SettingsView: View {
                 Text("Keyboard")
             } footer: {
                 // Only shown once the row is on: the keyboard drops it in landscape by
-                // design (#331), and without a word here that reads as a bug to the person
-                // who just turned it on.
+                // design (#331) and on iPad by design (#336), and without a word here either
+                // one reads as a bug to the person who just turned it on.
+                //
+                // WHY one sentence covering both rather than a device-aware one, and why the
+                // toggle stays visible on an iPad where it now does nothing: this target has
+                // no device detection at all — `DeviceContext` and DeviceKit are linked to the
+                // keyboard, not here, and `UIDevice.userInterfaceIdiom` reports `.phone` in
+                // compatibility mode, which is the only way an iPad reaches this app. A second
+                // copy of device detection in a second target, for a device class Dictus does
+                // not target, costs more than a sentence that is simply true on both.
                 if numberRowEnabled {
-                    Text("The number row is shown in portrait only.")
+                    Text("The number row is shown on iPhone in portrait only.")
                 }
                 if !liveActivityEnabled {
                     Text("Dynamic Island and Lock Screen notification are disabled.")

--- a/DictusKeyboard/KeyboardLayouts.swift
+++ b/DictusKeyboard/KeyboardLayouts.swift
@@ -43,10 +43,35 @@ enum KeyboardLayouts {
     /// subtraction instead just reinstates the 20% shrink under another name. Landscape has
     /// no version of this that passes, so it keeps four rows and today's height.
     ///
+    /// WHY iPad never draws it either (#336): the height provider's reference row count is
+    /// already 5 on a large iPad, so asking it for 5 rows returns the base height unchanged —
+    /// the grid does not grow and `sizeForItemAt` divides the same height by five instead of
+    /// four, taking cells from 82 pt to 65.6 pt. That is the 20% shrink #331 rejected, arriving
+    /// through the back door. Excluding the context is the fix that keeps the vendored layout
+    /// maths untouched.
+    ///
+    /// WHY all iPads and not just `isLargeIPad`, the only class that shrinks: on a mini or
+    /// medium iPad the provider's reference count is 4, the grid does grow, and the row would
+    /// be safe there. It goes anyway. That split is `screenInches >= 12` against DeviceKit's
+    /// diagonal table, with 13.0 substituted whenever the diagonal is missing — a fragile thing
+    /// to hang a feature on for a device class Dictus does not target. The app ships
+    /// iPhone-only and reaches an iPad through compatibility mode.
+    ///
+    /// An iPad whose identifier DeviceKit does not recognise reads as neither, and the height
+    /// provider falls through to its iPhone values, where a five-row request does grow the
+    /// grid. The unrecognised case is the safe one either way.
+    ///
+    /// WHY `isPad` and not `isIPhoneAppRunningOnIPad(traitCollection:)`, which is what the
+    /// height provider uses: this predicate must stay context-free. Its whole job is to give
+    /// the two readers below one answer, and a parameter is a way for them to be handed
+    /// different ones. On an iPhone-only app `isPad` is already true exactly when the app is
+    /// running on an iPad in compatibility mode.
+    ///
     /// WHY the orientation half is here and not in `NumberRowPreference`: `DeviceContext`
     /// lives in this target (it depends on DeviceKit and UIScreen); DictusCore cannot see it.
     static var drawsDigitRow: Bool {
-        NumberRowPreference.isEnabled && !DeviceContext.current.isLandscape
+        let device = DeviceContext.current
+        return NumberRowPreference.isEnabled && !device.isLandscape && !device.isPad
     }
 
     /// The digit row, prepended to every letter page when `drawsDigitRow` is true.

--- a/DictusKeyboard/KeyboardViewController.swift
+++ b/DictusKeyboard/KeyboardViewController.swift
@@ -872,10 +872,11 @@ class KeyboardViewController: UIInputViewController {
         // got before this line existed, with no divide-and-multiply in between.
         //
         // The provider's `rowCount > 4 && isLandscape` subtraction is unreachable from here:
-        // `drawsDigitRow` is false in landscape, by decision. On a large iPad the provider's
-        // normal row count is already 5, so this asks for the 5-row height it budgets for —
-        // the grid does not grow there and cells go 82 pt to 65.6 pt, still well above the
-        // 54 pt every iPhone lives on. Left alone deliberately; the app ships iPhone-only.
+        // `drawsDigitRow` is false in landscape, by decision. Its large-iPad branch — where the
+        // normal row count is already 5, so asking for 5 rows returns the base height and the
+        // cells shrink instead of the grid growing — is unreachable for the same reason since
+        // #336: `drawsDigitRow` is false on any iPad, so this passes nil there and the provider
+        // early-returns the height it has always returned.
         let keyGridHeight = KeyboardHeightProvider.height(
             for: deviceContext,
             traitCollection: traitCollection,

--- a/DictusKeyboard/Vendored/Models/KeyDefinition.swift
+++ b/DictusKeyboard/Vendored/Models/KeyDefinition.swift
@@ -161,12 +161,19 @@ public enum KeyType: Codable, Hashable {
 
     /// True for an input key carrying a single digit. Dictus addition (#336).
     ///
-    /// WHY this exists at all: before the optional number row (#331) no letter page carried a
-    /// digit, so "which page am I on" answered every question about what a key draws. The
-    /// injected digit row broke that, and two places now have to tell a digit from a letter —
-    /// the popup width divisor (`GiellaKeyboardView.popupSizingRow`, #337) and the label font
-    /// (`KeyView.configureKeyLabel`, #336). One property so they cannot drift into asking
-    /// subtly different questions.
+    /// READ THIS BEFORE DERIVING ANY STYLING FROM `KeyboardPage`. Before the optional number
+    /// row (#331), an `.input` key on a letter page was always a letter, so "which page am I
+    /// on" answered every question about what a key draws: `.normal` meant lowercase, and
+    /// anything else meant a capital-height glyph. #331 injects a row of `.input` keys that
+    /// are not letters and do not follow the shift state, and every decision resting on that
+    /// assumption silently became wrong for ten keys.
+    ///
+    /// Four sites have been caught by it so far, each found separately and each after
+    /// shipping: the long-press popup width divisor (`GiellaKeyboardView.popupSizingRow`,
+    /// #337), the label font (`KeyView.configureKeyLabel`, #336), and the label's vertical
+    /// nudge at both of its call sites (`KeyView.labelYOffset(on:)`, #336). The pattern, not
+    /// the individual bugs, is the thing to remember: if a piece of styling asks what page an
+    /// `.input` key is on, it has to ask this property first.
     var isDigit: Bool {
         guard case .input(let character, _) = self else { return false }
         // count == 1 first: `contains` is a substring test, so "12" would pass on its own.

--- a/DictusKeyboard/Vendored/Models/KeyDefinition.swift
+++ b/DictusKeyboard/Vendored/Models/KeyDefinition.swift
@@ -158,6 +158,20 @@ public enum KeyType: Codable, Hashable {
             return false
         }
     }
+
+    /// True for an input key carrying a single digit. Dictus addition (#336).
+    ///
+    /// WHY this exists at all: before the optional number row (#331) no letter page carried a
+    /// digit, so "which page am I on" answered every question about what a key draws. The
+    /// injected digit row broke that, and two places now have to tell a digit from a letter —
+    /// the popup width divisor (`GiellaKeyboardView.popupSizingRow`, #337) and the label font
+    /// (`KeyView.configureKeyLabel`, #336). One property so they cannot drift into asking
+    /// subtly different questions.
+    var isDigit: Bool {
+        guard case .input(let character, _) = self else { return false }
+        // count == 1 first: `contains` is a substring test, so "12" would pass on its own.
+        return character.count == 1 && "1234567890".contains(character)
+    }
 }
 
 public struct KeyDefinition: Codable {

--- a/DictusKeyboard/Vendored/Views/KeyView.swift
+++ b/DictusKeyboard/Vendored/Views/KeyView.swift
@@ -84,6 +84,21 @@ final class KeyView: UIView {
         }
     }
 
+    /// Vertical nudge applied to a key's label, in points.
+    ///
+    /// The normal page raises an input key's label by 2 pt; every other page leaves it
+    /// centred. A digit takes 0.0 on every page (#336) — see `KeyType.isDigit` for why an
+    /// `.input` key on a letter page can no longer be assumed to be a letter.
+    ///
+    /// Dictus change: this rule was spelled out identically at both call sites below. One
+    /// copy, so the digit exception cannot be applied to one and forgotten at the other.
+    private func labelYOffset(on page: KeyboardPage) -> CGFloat {
+        guard case .normal = page, key.type.isInputKey, !key.type.isDigit else {
+            return 0.0
+        }
+        return -2.0
+    }
+
     private func configureKeyLabel(_ label: UILabel, page: KeyboardPage, text: String) {
         label.textColor = theme.textColor
         label.numberOfLines = 0
@@ -103,17 +118,13 @@ final class KeyView: UIView {
             case .shifted, .capslock, .symbols1, .symbols2:
                 label.font = theme.capitalKeyFont
             default:
-                // A digit takes the capital font here too (#336). Picking the font from the
-                // page was always right before the number row (#331): no letter page carried a
-                // digit, so "not a shifted page" meant "a lowercase letter". The injected row
-                // broke that and the same ten keys rendered 25 pt on the normal page against
-                // 22 pt on the shifted one, which is visible.
+                // A digit takes the capital font here too (#336, see `KeyType.isDigit`).
                 //
-                // WHY the capital font is the right one and not the larger: `lowerKey` is
-                // 25 pt against `capitalKey` 22 pt on iPhone (`Theme.fonts`) because lowercase
-                // has a lower x-height and needs the extra point size to read at the same
-                // optical size. A digit is a cap-height glyph like an uppercase letter, so the
-                // compensation does not apply to it and only makes it oversized.
+                // WHY the capital font and not the larger one: `lowerKey` is 25 pt against
+                // `capitalKey` 22 pt on iPhone (`Theme.fonts`) because lowercase has a lower
+                // x-height and needs the extra point size to read at the same optical size. A
+                // digit is a cap-height glyph, so the compensation does not apply to it and
+                // only makes it oversized.
                 //
                 // The arm above is untouched, so `symbols1` and `symbols2` — whose first row
                 // genuinely is digits — render exactly as they did. This lands the injected
@@ -182,12 +193,7 @@ final class KeyView: UIView {
         label.centerXAnchor.constraint(equalTo: labelContainer.centerXAnchor).enable()
         label.widthAnchor.constraint(equalTo: labelContainer.widthAnchor).enable()
 
-        let yConstant: CGFloat
-        if case .normal = page, case KeyType.input(_, _) = self.key.type {
-            yConstant = -2.0
-        } else {
-            yConstant = 0.0
-        }
+        let yConstant = labelYOffset(on: page)
 
         if let alternateLabel = self.alternateLabel {
             swipeLayoutConstraint = alternateLabel.topAnchor
@@ -218,12 +224,7 @@ final class KeyView: UIView {
         labelContainer.addSubview(label)
         addSubview(labelContainer)
 
-        let yConstant: CGFloat
-        if case .normal = page, case KeyType.input(_, _) = self.key.type {
-            yConstant = -2.0
-        } else {
-            yConstant = 0.0
-        }
+        let yConstant = labelYOffset(on: page)
 
         label.centerXAnchor.constraint(equalTo: labelContainer.centerXAnchor).enable()
         label.centerYAnchor.constraint(equalTo: labelContainer.centerYAnchor, constant: yConstant).enable()

--- a/DictusKeyboard/Vendored/Views/KeyView.swift
+++ b/DictusKeyboard/Vendored/Views/KeyView.swift
@@ -103,7 +103,22 @@ final class KeyView: UIView {
             case .shifted, .capslock, .symbols1, .symbols2:
                 label.font = theme.capitalKeyFont
             default:
-                label.font = theme.lowerKeyFont
+                // A digit takes the capital font here too (#336). Picking the font from the
+                // page was always right before the number row (#331): no letter page carried a
+                // digit, so "not a shifted page" meant "a lowercase letter". The injected row
+                // broke that and the same ten keys rendered 25 pt on the normal page against
+                // 22 pt on the shifted one, which is visible.
+                //
+                // WHY the capital font is the right one and not the larger: `lowerKey` is
+                // 25 pt against `capitalKey` 22 pt on iPhone (`Theme.fonts`) because lowercase
+                // has a lower x-height and needs the extra point size to read at the same
+                // optical size. A digit is a cap-height glyph like an uppercase letter, so the
+                // compensation does not apply to it and only makes it oversized.
+                //
+                // The arm above is untouched, so `symbols1` and `symbols2` — whose first row
+                // genuinely is digits — render exactly as they did. This lands the injected
+                // row on the same font those pages have always used for the same glyphs.
+                label.font = key.type.isDigit ? theme.capitalKeyFont : theme.lowerKeyFont
             }
         } else {
             if text.count > 6 {

--- a/DictusKeyboard/Vendored/Views/KeyboardView.swift
+++ b/DictusKeyboard/Vendored/Views/KeyboardView.swift
@@ -66,6 +66,38 @@ final internal class GiellaKeyboardView: UIView,
         }
     }
 
+    /// The row a long-press popup sizes its keys against: the first of the current page's
+    /// letter rows.
+    ///
+    /// WHY not `currentPage.first`, which is what this was (#337): with the number row on
+    /// (#331) the first row of a letter page is the ten digits, and QWERTZ is the one layout
+    /// whose letter rows do not carry ten keys — ü closes the top row, ö and ä the home row
+    /// (#151). Sizing off the first row therefore moved the divisor 11 → 10 the moment the
+    /// setting was turned on, and every QWERTZ popup key got ~10% wider. The digit row is not
+    /// representative of the keyboard the popup belongs to; the letter rows are.
+    ///
+    /// WHY not the pressed key's own row, the other candidate in #337: it would size the popup
+    /// by an accident of which row was tapped, and QWERTZ rows 1-2 and row 3 do not agree.
+    ///
+    /// WHY the row is recognised by its contents rather than by asking
+    /// `KeyboardLayouts.drawsDigitRow`: that flag is read at long-press time and the page was
+    /// built earlier, so the two can disagree while a rebuild is pending. The contents cannot.
+    ///
+    /// The symbols pages are excluded because their leading digits are their own — `symbols1`
+    /// carries `1234567890` as its real first row and never gets the injected one.
+    private var popupSizingRow: [KeyDefinition]? {
+        let rows = currentPage
+        switch page {
+        case .normal, .shifted, .capslock:
+            guard let first = rows.first, first.isDigitRow else {
+                return rows.first
+            }
+            return rows.dropFirst().first
+        case .symbols1, .symbols2:
+            return rows.first
+        }
+    }
+
     public var page: KeyboardPage = .normal {
         didSet {
             update()
@@ -465,7 +497,7 @@ final internal class GiellaKeyboardView: UIView,
             break
         }
 
-        let width = bounds.size.width / CGFloat(currentPage.first?.count ?? 10)
+        let width = bounds.size.width / CGFloat(popupSizingRow?.count ?? 10)
         // Reduce height to 60% so first-row popups stay within keyboard bounds (#69).
         var height = ((bounds.size.height / CGFloat(currentPage.count)) - theme.popupCornerRadius * 2) * 0.6
         height = max(24.0, height)
@@ -1008,6 +1040,23 @@ final internal class GiellaKeyboardView: UIView,
 
         required init?(coder _: NSCoder) {
             fatalError("init(coder:) has not been implemented")
+        }
+    }
+}
+
+private extension Array where Element == KeyDefinition {
+    /// True for the digit row the number-row setting prepends to a letter page (#331).
+    ///
+    /// Ten plain input keys, every one of them a single digit. No letter page has a row of its
+    /// own that answers this, so the test cannot mistake one — see `popupSizingRow`, its only
+    /// caller. Kept in this file rather than on the vendored `KeyDefinition` model so the whole
+    /// deviation from giellakbd-ios sits next to the code that needs it.
+    var isDigitRow: Bool {
+        guard !isEmpty else { return false }
+        return allSatisfy { key in
+            guard case .input(let character, _) = key.type else { return false }
+            // count == 1 first: `contains` is a substring test, so "12" would pass on its own.
+            return character.count == 1 && "1234567890".contains(character)
         }
     }
 }

--- a/DictusKeyboard/Vendored/Views/KeyboardView.swift
+++ b/DictusKeyboard/Vendored/Views/KeyboardView.swift
@@ -1047,17 +1047,12 @@ final internal class GiellaKeyboardView: UIView,
 private extension Array where Element == KeyDefinition {
     /// True for the digit row the number-row setting prepends to a letter page (#331).
     ///
-    /// Ten plain input keys, every one of them a single digit. No letter page has a row of its
-    /// own that answers this, so the test cannot mistake one — see `popupSizingRow`, its only
-    /// caller. Kept in this file rather than on the vendored `KeyDefinition` model so the whole
-    /// deviation from giellakbd-ios sits next to the code that needs it.
+    /// Ten plain input keys, every one of them a digit. No letter page has a row of its own
+    /// that answers this, so the test cannot mistake one — see `popupSizingRow`, its only
+    /// caller. `KeyType.isDigit` is the shared atom: `KeyView` asks the same question of a
+    /// single key when it picks that key's font (#336).
     var isDigitRow: Bool {
-        guard !isEmpty else { return false }
-        return allSatisfy { key in
-            guard case .input(let character, _) = key.type else { return false }
-            // count == 1 first: `contains` is a substring test, so "12" would pass on its own.
-            return character.count == 1 && "1234567890".contains(character)
-        }
+        !isEmpty && allSatisfy { $0.type.isDigit }
     }
 }
 


### PR DESCRIPTION
Fixes the two pieces of #331 fallout that were accepted knowingly when the number row shipped. Same origin, same file pair, one PR.

## What this was for

The optional number row (#331) was shipped with two known defects, both written down at the time rather than fixed:

- **#336** — the row was supposed to be paid for with extra keyboard height, never with smaller keys. That holds on iPhone. On an iPad in compatibility mode it does the opposite: the grid stays the same size and the letter keys shrink from 82 pt to 65.6 pt. That is exactly the trade #331 measured and rejected, arriving from the other side.
- **#337** — with the row on, QWERTZ long-press popups render about 10% wider than with it off, because the popup width was derived from the first row of the page and the digit row is not the row it should be sized against.
- **A third defect of the same family**, found on device while testing this PR: the digit row renders 25 pt on the lowercase page and 22 pt on the shifted page. Same ten keys, two sizes. The label font is picked from the page, which was always right before a letter page could carry a digit.

Neither is a usability failure — hence `priority:low` on both — and the triage of 2026-08-13 settled which fix to take for each. This PR takes those two decisions and nothing else.

## To test by hand

Validated on device by the maintainer on 2026-08-13: the QWERTZ popup width with the row on and off, and AZERTY / QWERTY unchanged. Those steps are struck below rather than removed, so a reviewer can see what was covered.

Everything else is unobserved. The digit font change in particular: **nobody has seen the corrected rendering**, only the two screenshots that show the defect.

1. Number row **on**, portrait, any layout. Capture the keyboard on the lowercase page, tap shift, capture again. Compare the two digit rows side by side. → the digits must be the **same size and at the same height** on both pages. The size half was validated on device on `af631f8`; the height half is `5541896` and has not been seen by anyone. Before this PR: 25 pt against 22 pt, and 2 pt higher on the lowercase page.
2. Same two captures, letters this time. → unchanged from today, in size and in position. Lowercase letters still render larger than uppercase ones and still sit 2 pt higher on the lowercase page; only the digits moved.
3. Switch to the symbols page (`123`). → its digit row must look exactly as it always has. Only the `default` arm of the font switch changed, so this page is untouched by construction, but it is the cheapest confirmation.
4. **Tap and hold a digit, and watch the preview bubble that pops above your finger.** It is *not* fixed and it is not in this PR: the bubble's own label font is chosen from the page in `GiellaKeyboardView.showOverlay`, the same assumption again, so a digit's preview is about 3 pt larger on the lowercase page than on the shifted one. Reported rather than shipped, because the maintainer decides what goes in here. See "A fifth site" below.
5. In Settings, turn the number row **on**. On an iPhone in portrait, the digit row still appears above the letters and the letter keys are the size they were. → the regression check for #331.
6. Still in Settings, toggle on, read the footer under the Keyboard section. → "La rangée de chiffres s'affiche uniquement sur iPhone, en mode portrait." Turn the toggle off. → the footer disappears, as before.
7. Rotate to landscape with the row on. → no digit row, four rows, today's height. Unchanged.
8. ~~QWERTZ long-press popup width, row on against row off.~~ **Validated on device**: identical.
9. ~~AZERTY and QWERTY popups unchanged.~~ **Validated on device**: unchanged.
10. Long-press a key that opens a **two-row** popup (e.g. `e` on AZERTY). → still two rows, same shape as before.
11. **iPad: closed as unverifiable, not as passed.** The maintainer has an iPad but cannot build to it, and a simulator cannot stand in: `docs/agents/simulator.md` §7 records four failed attempts to enable the Dictus keyboard in any simulator. Registering the extension is not enabling it, and there is no touch injection. #336's acceptance criterion therefore stays unobserved. The mitigating fact, which is real: on iPad the fix makes `drawsDigitRow` false, which returns `computeKeyboardHeight()` to the `rowCount: nil` early-return path that shipped for months before #331 existed. It is a return to known-good behaviour rather than new behaviour.

### A fifth site, found and not fixed

`DictusKeyboard/Vendored/Views/KeyboardView.swift:381`, inside `showOverlay(forKeyAtIndexPath:)`:

```swift
switch page {
case .normal:
    keyLabel.font = theme.popupLowerKeyFont
default:
    keyLabel.font = theme.popupCapitalKeyFont
}
```

Same assumption, fifth occurrence. It is **live, not dead**: the caller at line 577 is `if case .input = activeKey.key.type, !shouldUseiPadLayout`, which is the magnified preview bubble shown on every plain touch of an input key on iPhone, not only on a long press. Tapping a digit therefore draws it at `popupLowerKeyFont` on the lowercase page and `popupCapitalKeyFont` on the shifted one — `lowerKey + 10/16` against `capitalKey + 10/16`, so the same 3 pt gap, magnified.

The fix would be the same one line as the label font. It is not in this PR: the instruction was to report a fifth site rather than ship it, and this is that report.

## What changed

**#336 — `DictusKeyboard/KeyboardLayouts.swift`**

`drawsDigitRow` now excludes iPad the same way it already excluded landscape:

```swift
let device = DeviceContext.current
return NumberRowPreference.isEnabled && !device.isLandscape && !device.isPad
```

Option 1 from the issue, as decided in triage. Nothing in the vendored height maths is touched, and the declared height constraint is not touched — `computeKeyboardHeight()` passes `rowCount: nil` on iPad, which is the early-return path the provider took before #331 existed. The comment there that said the iPad shrink was "left alone deliberately" is now false and was updated.

All iPads, not only the large ones that actually shrink. On a mini or medium iPad the provider's reference row count is 4, so the grid does grow and the row is safe there; it goes anyway, because the large/small split is a lookup against DeviceKit's diagonal table for a device class the app does not target. Reasoning is in the code comment.

**#336 — `DictusApp/Views/SettingsView.swift` and `DictusApp/Localizable.xcstrings`**

The Settings footer read "The number row is shown in portrait only." On an iPad that sentence became false: the row is not shown in portrait either, and the toggle above it does nothing there. It now reads "The number row is shown on iPhone in portrait only.", which is true on both device classes. The string was replaced deliberately in the catalogue, French translation included; the build produced no `stale` churn and the trailing newline is intact.

The toggle stays visible on iPad rather than being hidden or disabled. The app target has no device detection: DeviceKit and `DeviceContext` are linked to the keyboard, not here, and `UIDevice.userInterfaceIdiom` reports `.phone` in compatibility mode, which is the only way an iPad reaches Dictus. A second copy of device detection in a second target, for a device class the app does not target, costs more than one sentence that is simply true on both.

**#337 — `DictusKeyboard/Vendored/Views/KeyboardView.swift`**

`longpressKeySize()` takes its width divisor from `popupSizingRow` instead of `currentPage.first` — the first of the page's letter rows, i.e. the page's own first row unless it is the injected digit row. The second fix from the issue body, as decided in triage; sizing from the pressed key's own row was rejected there.

The digit row is recognised by its contents (all `.input` keys carrying a single digit) rather than by reading `KeyboardLayouts.drawsDigitRow`. That flag is read at long-press time against a page built earlier, so the two can disagree while a rebuild is pending; the page's own contents cannot. The symbols pages are excluded explicitly: `symbols1` carries `1234567890` as its real first row and never receives the injected one.

**Digit label font — `DictusKeyboard/Vendored/Views/KeyView.swift`, `DictusKeyboard/Vendored/Models/KeyDefinition.swift`**

`configureKeyLabel` picked the label font from the page. Only the `default` arm changes: a digit now takes `capitalKeyFont` there, a letter still takes `lowerKeyFont`. The shifted / capslock / symbols arm is byte-identical, so `symbols1` and `symbols2` render exactly as before.

22 pt is the right value for a typographic reason as well as by eye: `lowerKey` is 25 pt against `capitalKey` 22 pt on iPhone because lowercase has a lower x-height and needs the extra point size to read at the same optical size. A digit is a cap-height glyph, so the compensation does not apply and only makes it oversized. The injected row now matches the digits `symbols1` has drawn for months.

`KeyType.isDigit` is the shared predicate. `isDigitRow`, written for #337, now asks it of every key in a row instead of carrying its own copy of the test.

**Digit label vertical offset — `DictusKeyboard/Vendored/Views/KeyView.swift`**

`yConstant` raises an input key's label 2 pt on the normal page and leaves it centred everywhere else: the same assumption as the font, one layer down. A digit now takes 0.0 on every page, which is what it already took on `.shifted` and on the symbols pages. Letters keep the -2.0.

The rule was written out identically at both call sites (`input(string:alt:page:)` and `text(_:page:)`); it is now one `labelYOffset(on:)`, so the digit exception cannot be applied to one and forgotten at the other. Worth recording: the second call site's input arm was already dead — `text(_:page:)` is only reached for spacebar, return, symbols and shift-symbols keys, never for an `.input` key. Factoring keeps the two in step regardless of that.

`KeyType.isDigit` now carries the pattern rather than the individual bugs: #331 injects `.input` keys that are not letters, so any styling derived from `KeyboardPage` has to ask it first. Four sites have been caught by that assumption so far, each one after shipping.

`configureAltKeyLabel` has the same page-derived switch and is **not** affected, for two independent reasons: digit keys carry no alternate (`inputRow` passes `alternate: nil`, and that function is only reached inside `if let alternateString = alt`), and the switch sits inside a `shouldUseiPadLayout && device.isLargeIPad` branch the digit row no longer reaches at all. Left as it is.

## Acceptance criteria

**#336**

| Criterion | Status | Evidence |
| --- | --- | --- |
| iPad in compatibility mode, row enabled: letter cells the size they are today | Met by construction, **not observed** | `drawsDigitRow` false on iPad ⇒ `computeKeyboardHeight()` passes `rowCount: nil` ⇒ `KeyboardHeightProvider.height` early-returns before the `normalRowCount` division ⇒ 328 pt portrait ⇒ `sizeForItemAt` divides by 4 rows ⇒ 82 pt, the value the issue records as today's. This is arithmetic, not a screenshot. |
| iPhone behaviour from #331 unchanged, verified by the existing tests | Met | `cd DictusCore && swift test` → **920 tests, 0 failures**. The #331-specific ones, all passing: `NumberRowPreferenceTests` (8 tests), `KeyboardProximityTests.testTheCostTableIsIdenticalWithTheNumberRowOnAndOff`, `KeyboardProximityTests.testTheBottomLetterRowKeepsItsPositionsWithTheNumberRowOn`, `QWERTZLayoutTests` (11), `QWERTYLayoutTests` (6). On iPhone `isPad` is false, so the predicate is unchanged there. |

**#337**

| Criterion | Status | Evidence |
| --- | --- | --- |
| QWERTZ popups the same width with the row on and off | Met, **validated on device** 2026-08-13 | Divisor before: 11 (row off) → 10 (row on). After: 11 in both cases, since the digit row is skipped and `qwertzPage` row 1 is 11 keys (`QWERTZLayoutTests.testRowsOneAndTwoCarryElevenKeys`). The difference is a divisor read from code, never a rendered popup — the issue notes the same. |
| AZERTY and QWERTY popups unchanged | Met, **validated on device** 2026-08-13 | Both keep divisor 10 in all four combinations: their row 1 is 10 keys, and the digit row is 10 keys, so skipping it changes nothing. |
| No change to popup height or to the two-row popup path | Met | The diff touches one line inside `longpressKeySize()`; the height expression (`currentPage.count`) and every `popupLongpressKeysPerRow` branch are untouched. Height is correct as-is: with the row on the grid also grows 5/4 on iPhone, so height ÷ row count is unchanged. |

**Digit label font (no issue of its own, found while testing this PR)**

| Criterion | Status | Evidence |
| --- | --- | --- |
| The digit row is the same size on the lowercase and shifted pages | Met, **validated on device** 2026-08-14 | Both pages now resolve to `theme.capitalKeyFont` for a digit: the shifted arm already did, the default arm does through `key.type.isDigit`. Nobody has seen the corrected rendering. |
| The digit row sits at the same height on both pages | Met by construction, **not observed** | `labelYOffset(on:)` returns 0.0 for a digit on every page, the value `.shifted` and the symbols pages already used. |
| Letters unchanged on both pages | Met | The default arm still returns `lowerKeyFont` for anything that is not a digit, the shifted arm is untouched, and `labelYOffset(on:)` still returns -2.0 for a letter on the normal page. |
| `symbols1` / `symbols2` unchanged | Met | The font diff touches only the `default` arm, which those pages never take, and they already took 0.0 for the offset. |

## Checks

| Check | Result |
| --- | --- |
| `xcodebuild build -scheme DictusApp -derivedDataPath build/DerivedData` (builds DictusApp, DictusKeyboard, DictusWidgets, DictusCore) | `** BUILD SUCCEEDED **` |
| `cd DictusCore && swift test` | 920 tests, 0 failures |
| `swiftlint lint --strict` | 0 violations in 177 files |
| `Localizable.xcstrings` | one string replaced deliberately, EN + FR; no `stale` extraction state, trailing newline intact, no build churn committed |
| Version / build numbers | untouched |

CI does not run the tests, so the `swift test` line above is the only coverage this change gets before review.

refs #336
refs #337


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled the number row on iPad devices and in landscape orientation.
  * Preserved existing keyboard height behavior on iPad.
  * Improved long-press popup sizing when a number row appears above letter keys.
  * Improved digit key labeling and vertical alignment.
* **Documentation**
  * Clarified that the number row is available only on iPhone in portrait orientation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->