### PR TITLE
Record the learned-word offering decision (refs #346)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -83,3 +83,17 @@ The accent relation covers every accented character of every language Dictus shi
 
 ### Long-press accents (`AccentedCharacters.mappings`)
 Pop-up accent variants shown when a key is long-pressed. Currently merged across languages (French + Spanish ñ + acute variants), keyed by base letter. To be migrated into `LanguageProfile.longPressAccents` so each language declares its own popups.
+
+## Suggestions and learning
+
+### Learned word
+An entry in `UserDictionary` (DictusCore), the per-user store in the App Group. **Distinct from a trie word**, which comes from the shipped `<lang>_spellcheck.dict`. The two sets never overlap by construction: since #287 a word is only learned when the trie does not already know it. Learned words carry no language tag — one store serves every language.
+
+### Undo site and boundary site
+The two places that learn. The **undo site** (`KeyboardRootView`) fires when the user rejects an applied autocorrection; it learns on the first occurrence, because rejecting a correction is an explicit statement. The **boundary site** (`DictusKeyboardBridge`) fires on any word the pipeline evaluated and did not correct; it learns only a word absent from the trie, seen twice, with autocorrect enabled. Their signal quality is not comparable and no rule should be shared between them without saying which one it is for (#287 decisions 2–4, 8).
+
+### The three levels a learned word can hold
+**L1 — offered**: the word can appear in the suggestion bar, where it is only ever applied by a tap. **L2 — immune**: the word is never rewritten by autocorrect (`spellCheck` returns `nil` for it). **L3 — authoritative**: the keyboard may rewrite *another* word into it. Dictus grants L1 (#346) and L2, and withholds L3, which belongs to #114. The separation is categorical rather than scored, which no keyboard in the field does (`docs/research/287-user-dictionary-learning.md` §5.4) — see ADR 0004 for why it is affordable here.
+
+### Suggestion mode (`SuggestionMode`)
+Which question the suggestion bar is answering. **`.completions`** — words starting with the partial word being typed; sourced from `UITextChecker`, ranked by `FrequencyDictionary`, merged with learned words since #346. **`.corrections`** — what `spellCheck` would apply on space, laid out `[typed | correction | alternative]`. **`.predictions`** — likely next words after a space, from the trie's n-grams, falling back to the language's most frequent words. **`.undoAvailable`** and **`.idle`** carry no candidates. Only `.corrections` previews something the space key will apply on its own; every other mode is tap-only.

--- a/docs/adr/0004-learned-words-are-offered-but-never-authoritative.md
+++ b/docs/adr/0004-learned-words-are-offered-but-never-authoritative.md
@@ -1,0 +1,32 @@
+# 0004 — Learned words are offered but never authoritative
+
+- **Date:** 2026-08-13
+- **Status:** Accepted
+- **Context:** Issue #346, decided in the grilling session of 2026-08-13. Implements decision 5 of the #287 session of 2026-08-11, which established the L1/L2/L3 vocabulary. Depends on #287 block A (PR #347), which is what makes the learned set small enough to be worth offering.
+
+## Decision
+
+A learned word is **offered** in the suggestion bar (L1) and **immune** to autocorrect (L2). It is never an **autocorrect target** (L3): the keyboard does not rewrite another word into it. L3 stays with #114.
+
+The offering is implemented by reading `UserDictionary` at query time and merging its prefix matches into `.completions`, in a pure function in DictusCore called from `TextPredictionEngine.suggestions(for:)`. At most one learned word appears, in the first slot, tie-broken by the `lastUsed` timestamp shipped in #305.
+
+## Why the categorical rule is affordable here
+
+`docs/research/287-user-dictionary-learning.md` §5.4 established that no keyboard in the field implements "suggestable but never an autocorrect target" as a category. Everywhere it is probabilistic, enforced by a unified scoring function that Dictus does not have. That reads as a reason to be careful, and it was — until the two code paths were traced.
+
+On space, only `spellCheck` can apply anything (`DictusKeyboardBridge.handleSpace`). Every suggestion mode other than `.corrections` is tap-only. So a candidate that reaches the bar through `.completions` and never through `spellCheck` is structurally incapable of being auto-applied. The categorical rule is not a gate anyone has to write and defend — it is a property of keeping the two sources apart.
+
+This is the load-bearing fact of the whole decision, and it is the thing to re-check before any change that lets a learned word reach `spellCheck`, the trie, or `.corrections`.
+
+## Considered options
+
+**Inject learned words into the trie** (`injectUserWord`, the hook that already existed and did nothing). Rejected: a trie entry is by construction an autocorrect target, so this ships L3 as a side effect of shipping L1. Separately, trie frequencies are log-normalized (#326), so "insert at a low frequency" does not behave the way the number suggests. The hook is deleted rather than left in place, since a function named after the feature that does not implement it is what made #287 look solved.
+
+**Call `UITextChecker.learnWord(_:)`** and let the system checker return learned words for free. The cheapest option by a distance, and rejected on ownership: a word pushed into that store cannot be listed, cleared, or migrated by us. #287 decision 6 made "Reset learned words" the only exit from the dictionary, and this route creates an exit-less second copy. The research could not establish whether that store is device-global or extension-local (§"What could not be established", point 2), so the blast radius is unknown in principle, not merely unmeasured.
+
+## Consequences
+
+- **No language filter.** The store has no language tag, so a word learned in German is offered while typing French. Accepted: the cost is one slot on a prefix the user typed, and L2 immunity already crosses languages invisibly. Tagging is a schema change that #103 (iCloud KVS) builds its merge strategy against; if it becomes necessary, #288 will make it necessary first.
+- **A fully typed learned word leaves the bar empty** until space is pressed. There is nothing longer to complete, and echoing the word back costs a slot for a tap that changes nothing. Predictions after the space are unaffected.
+- **Autocorrect disabled still offers previously learned words.** #287 decision 8 blocks *learning* in that configuration because nothing vets a new word there; an existing entry was vetted when it was learned, and the bar imposes nothing.
+- **Casing is reconstructed from the typed prefix**, not stored. `UserDictionary` lowercases its keys, and the same rule already governs the accent path in `spellCheck`.


### PR DESCRIPTION
Docs only. No code, no target touched.

The 2026-08-13 grilling on #346 settled how a learned word reaches the suggestion bar. The decision comment on the issue is the spec; this PR records the two things that outlive it.

**ADR 0004** — why "offered (L1) but never authoritative (L3)" is affordable in Dictus when `docs/research/287-user-dictionary-learning.md` §5.4 found no keyboard in the field implementing that rule as a category. Short version: on space only `spellCheck` can apply anything, so a candidate that reaches the bar through `.completions` alone is structurally incapable of being auto-applied. It also keeps the two rejected routes — trie injection and `UITextChecker.learnWord` — with the reasons, so neither gets re-proposed.

**CONTEXT.md** — four terms the decision runs on that existed only in issue comments: *learned word*, *undo site and boundary site*, *the three levels*, *suggestion mode*.

Closing note: `Closes #346` is deliberately absent. The issue stays open for the implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUUyDpuVjZnLoXMdB2Ynn4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a glossary explaining learned words, learning sites, learning levels, and suggestion modes.
  - Documented how learned words appear as suggestions while remaining protected from autocorrection.
  - Clarified result ordering, language behavior, fully typed words, disabled autocorrect, and casing considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->