### PR TITLE
Spike: the keyboard extension IS served while the app is refused (refs #357)

### DIFF
--- a/Dictus.xcodeproj/project.pbxproj
+++ b/Dictus.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		AA000006 /* DictationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10000A /* DictationView.swift */; };
 		AA000007 /* KeyboardState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10000B /* KeyboardState.swift */; };
 		AA0000F7 /* KeyboardLifecycleProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1000F6 /* KeyboardLifecycleProbe.swift */; };
+		AA357002 /* AppleFMExtensionProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA357001 /* AppleFMExtensionProbe.swift */; };
 		AA000008 /* MicButtonDisabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10000C /* MicButtonDisabled.swift */; };
 		AA000010 /* DictusCore in Frameworks */ = {isa = PBXBuildFile; productRef = AA900010 /* DictusCore */; };
 		AA000011 /* DictusCore in Frameworks */ = {isa = PBXBuildFile; productRef = AA900011 /* DictusCore */; };
@@ -188,6 +189,7 @@
 		AA10000A /* DictationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationView.swift; sourceTree = "<group>"; };
 		AA10000B /* KeyboardState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardState.swift; sourceTree = "<group>"; };
 		AA1000F6 /* KeyboardLifecycleProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardLifecycleProbe.swift; sourceTree = "<group>"; };
+		AA357001 /* AppleFMExtensionProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleFMExtensionProbe.swift; sourceTree = "<group>"; };
 		AA10000C /* MicButtonDisabled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicButtonDisabled.swift; sourceTree = "<group>"; };
 		AA100030 /* InputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputView.swift; sourceTree = "<group>"; };
 		AA100035 /* FullAccessBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullAccessBanner.swift; sourceTree = "<group>"; };
@@ -392,6 +394,7 @@
 				AA100004 /* KeyboardRootView.swift */,
 				AA10000B /* KeyboardState.swift */,
 				AA1000F6 /* KeyboardLifecycleProbe.swift */,
+				AA357001 /* AppleFMExtensionProbe.swift */,
 				AA100030 /* InputView.swift */,
 				CC100030 /* KeyboardMetrics.swift */,
 				CC100050 /* KeySoundPolicy.swift */,
@@ -994,6 +997,7 @@
 				AA000004 /* KeyboardRootView.swift in Sources */,
 				AA000007 /* KeyboardState.swift in Sources */,
 				AA0000F7 /* KeyboardLifecycleProbe.swift in Sources */,
+				AA357002 /* AppleFMExtensionProbe.swift in Sources */,
 				AA000008 /* MicButtonDisabled.swift in Sources */,
 				AA000030 /* InputView.swift in Sources */,
 				AA000035 /* FullAccessBanner.swift in Sources */,

--- a/DictusApp/Polish/PolishDebugView.swift
+++ b/DictusApp/Polish/PolishDebugView.swift
@@ -60,8 +60,9 @@ struct PolishDebugView: View {
             } header: {
                 Text("#357 spike")
             } footer: {
-                Text("Fires ONE Apple FM call inside the keyboard extension, "
-                     + "the next time the keyboard appears, then disarms itself. "
+                Text("Fires a burst of 10 Apple FM calls inside the keyboard "
+                     + "extension, the next time the keyboard appears, then "
+                     + "disarms itself. Takes about a minute, keyboard open. "
                      + "Results land in the persistent log as diagnosticProbe / "
                      + "AppleFMExtensionProbe. Arm this only once the app is "
                      + "already being refused, otherwise the result proves nothing.")

--- a/DictusApp/Polish/PolishDebugView.swift
+++ b/DictusApp/Polish/PolishDebugView.swift
@@ -15,6 +15,9 @@ struct PolishDebugView: View {
     @State private var exportURL: URL?
     @State private var exportError: String?
     @State private var isExporting = false
+    /// #357 spike, throwaway. Arms ONE Apple FM probe run inside the keyboard
+    /// extension; see `DictusKeyboard/AppleFMExtensionProbe.swift`.
+    @State private var probeArmed = false
 
     var body: some View {
         List {
@@ -47,6 +50,23 @@ struct PolishDebugView: View {
                             .onTapGesture { selectedEntry = entry }
                     }
                 }
+            }
+            // #357 spike, throwaway. Delete with the spike.
+            Section {
+                Toggle("Arm keyboard Apple FM probe", isOn: $probeArmed)
+                    .onChange(of: probeArmed) { _, armed in
+                        AppGroup.defaults.set(armed, forKey: SharedKeys.appleFMExtensionProbeArmed)
+                    }
+            } header: {
+                Text("#357 spike")
+            } footer: {
+                Text("Fires ONE Apple FM call inside the keyboard extension, "
+                     + "the next time the keyboard appears, then disarms itself. "
+                     + "Results land in the persistent log as diagnosticProbe / "
+                     + "AppleFMExtensionProbe. Arm this only once the app is "
+                     + "already being refused, otherwise the result proves nothing.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
             }
         }
         .navigationTitle("Polish debug")
@@ -117,6 +137,10 @@ struct PolishDebugView: View {
     private func refresh() async {
         entries = await PolishCoordinator.shared.metricsSnapshot()
         storedCount = await PolishCoordinator.shared.metricsStoredCount()
+        // #357 spike: read the flag back rather than trusting local state. The
+        // extension clears it when it fires, so a toggle that stays on would
+        // claim a run is still pending after it has already happened.
+        probeArmed = AppGroup.defaults.bool(forKey: SharedKeys.appleFMExtensionProbeArmed)
     }
 }
 

--- a/DictusCore/Sources/DictusCore/SharedKeys.swift
+++ b/DictusCore/Sources/DictusCore/SharedKeys.swift
@@ -153,4 +153,18 @@ public enum SharedKeys {
     public static let historyEnabled = "dictus.historyEnabled"
     /// Bool: per-feature toggle for Vocabulary, default true (registered by ProStatusManager)
     public static let vocabularyEnabled = "dictus.vocabularyEnabled"
+
+    // MARK: - #357 spike (throwaway)
+    /// Bool: arms exactly ONE Apple Foundation Models probe run inside the
+    /// keyboard extension. Written by the hidden polish debug screen, read and
+    /// immediately cleared by `AppleFMExtensionProbe` in DictusKeyboard.
+    ///
+    /// WHY it lives here rather than next to the probe: the two processes that
+    /// have to agree on this string cannot see each other's targets, and a
+    /// literal duplicated across a process boundary is the kind of typo that
+    /// costs a device session to find. Absent — which is the shipped state —
+    /// it reads false and the probe never runs.
+    ///
+    /// Delete with the spike.
+    public static let appleFMExtensionProbeArmed = "dictus.debug.appleFMExtensionProbeArmed"
 }

--- a/DictusKeyboard/AppleFMExtensionProbe.swift
+++ b/DictusKeyboard/AppleFMExtensionProbe.swift
@@ -37,6 +37,36 @@ enum AppleFMExtensionProbe {
     /// an exported log pulls the whole run out.
     private static let component = "AppleFMExtensionProbe"
 
+    /// How many generations one armed run issues, back to back, in a single
+    /// extension process.
+    ///
+    /// WHY a burst and not a single call — this is the point the experiment
+    /// turns on. #315 established that the budget is **per process** and that
+    /// only a fresh process resets it. The keyboard extension is a *different
+    /// process* from DictusApp, so ONE successful call from it has two
+    /// explanations that a single result cannot separate:
+    ///
+    /// 1. the extension counts as foreground and is never limited — the
+    ///    hypothesis this spike is testing; or
+    /// 2. the extension is simply a fresh process whose background budget has
+    ///    never been spent, and it would have succeeded either way.
+    ///
+    /// Under (2) the problem is not solved, only relocated: the extension would
+    /// deplete its own budget with use and start refusing exactly as the app
+    /// does. A burst inside one process lifetime tells them apart, because (2)
+    /// predicts refusals appearing partway through and (1) predicts none.
+    ///
+    /// The asymmetry is worth stating: a burst that survives is strong evidence
+    /// for (1), because a backgrounded app gets refused under much lighter load
+    /// than this. A burst that fails is weaker evidence for (2) — it could be
+    /// specific to the density — and would need the slower, once-a-minute
+    /// protocol before concluding.
+    ///
+    /// Ten is enough to land inside the refusal regime measured on the app (the
+    /// 2026-08-13 capture refused 55 of 133 calls) while keeping the run under
+    /// about a minute, which is as long as a human will hold a keyboard open.
+    private static let burstSize = 10
+
     /// Fixed synthetic input, never the user's text.
     ///
     /// WHY fixed and synthetic: these lines land in a log that gets exported and
@@ -105,16 +135,17 @@ enum AppleFMExtensionProbe {
         report(
             token: token,
             action: "started",
-            details: "availability=\(availability) memBeforeMB=\(memBefore) inputChars=\(fixture.count)"
+            details: "availability=\(availability) memBeforeMB=\(memBefore)"
+                + " inputChars=\(fixture.count) burst=\(burstSize)"
         )
         // Flush before generating, not after. If Q4's teardown kills the process
         // mid-`respond()`, an unflushed start line would be lost too and the run
         // would leave no trace at all — the one outcome that cannot be read.
         PersistentLog.flush()
 
-        // Sample the footprint while the call is in flight. A peak that only
-        // exists during generation is exactly the shape Q3 is looking for, and
-        // a before/after pair would step straight over it.
+        // Sample the footprint across the whole burst. A peak that only exists
+        // during generation is exactly the shape Q3 is looking for, and a
+        // before/after pair would step straight over it.
         let peak = PeakSampler(initial: memBefore)
         let sampling = Task { await peak.sample() }
 
@@ -125,30 +156,48 @@ enum AppleFMExtensionProbe {
         // production type also makes the build itself the Q1a evidence — this
         // file puts `AppleFoundationModelsPolishEngine` into a target compiled
         // with `APPLICATION_EXTENSION_API_ONLY = YES`.
+        //
+        // One engine for the whole burst, as a future implementation would hold
+        // one: a fresh engine per call would mean a fresh session cache too, and
+        // that is not the lifecycle being priced.
         let engine = AppleFoundationModelsPolishEngine()
-        let start = DispatchTime.now().uptimeNanoseconds
-        var outcome: String
-        do {
-            let polished = try await engine.polish(raw: fixture, targetLanguage: .french, mode: .natural)
-            // Length only. The generated text is not logged, for the same
-            // privacy reason the input is a fixture.
-            outcome = "success outputChars=\(polished.count)"
-        } catch {
-            // Reuse the engine's own #315 classification so a refusal here is
-            // directly comparable with the app-side `failureReason` slugs in the
-            // polish export. `rateLimited` versus anything else IS the Q2 answer.
-            outcome = "failed reason=\(engine.failureReason(for: error).slug)"
+
+        for index in 1...burstSize {
+            let start = DispatchTime.now().uptimeNanoseconds
+            var outcome: String
+            do {
+                let polished = try await engine.polish(raw: fixture, targetLanguage: .french, mode: .natural)
+                // Length only. The generated text is not logged, for the same
+                // privacy reason the input is a fixture.
+                outcome = "success outputChars=\(polished.count)"
+            } catch {
+                // Reuse the engine's own #315 classification so a refusal here is
+                // directly comparable with the app-side `failureReason` slugs in
+                // the polish export. `rateLimited` versus anything else IS the
+                // Q2 answer.
+                outcome = "failed reason=\(engine.failureReason(for: error).slug)"
+            }
+            let engineMs = Int((DispatchTime.now().uptimeNanoseconds - start) / 1_000_000)
+
+            report(
+                token: token,
+                action: "call",
+                details: "n=\(index)/\(burstSize) \(outcome) engineMs=\(engineMs)"
+                    + " memMB=\(MemoryFootprint.residentMB()) memPeakMB=\(peak.value)"
+            )
+            // Flush every call. Under Q3's bad outcome the process is jetsam-killed
+            // partway through the burst, and the last line written is the only
+            // evidence of how far it got.
+            PersistentLog.flush()
         }
-        let engineMs = Int((DispatchTime.now().uptimeNanoseconds - start) / 1_000_000)
 
         sampling.cancel()
-        let memAfter = MemoryFootprint.residentMB()
 
         report(
             token: token,
             action: "finished",
-            details: "\(outcome) engineMs=\(engineMs) memBeforeMB=\(memBefore)"
-                + " memPeakMB=\(peak.value) memAfterMB=\(memAfter)"
+            details: "memBeforeMB=\(memBefore) memPeakMB=\(peak.value)"
+                + " memAfterMB=\(MemoryFootprint.residentMB())"
         )
         PersistentLog.flush()
         #else

--- a/DictusKeyboard/AppleFMExtensionProbe.swift
+++ b/DictusKeyboard/AppleFMExtensionProbe.swift
@@ -1,0 +1,206 @@
+// DictusKeyboard/AppleFMExtensionProbe.swift
+import Foundation
+import os
+import DictusCore
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+/// THROWAWAY DIAGNOSTIC CODE for the #357 spike. Delete with the spike.
+///
+/// #357 asks whether the keyboard extension can call Apple Foundation Models,
+/// and specifically whether **the extension's process counts as foreground** for
+/// the rate limiter #315 identified. Apple documents `rateLimited` as happening
+/// only to an app "running in the background", and a controlled device test on
+/// 2026-08-13 showed the rule is applied per call: the same process, seconds
+/// apart, is refused backgrounded and served in ~800 ms when active. DictusApp
+/// is backgrounded for every polish call by design, so polish runs in the one
+/// state Apple deprioritises. The keyboard is in the foreground at exactly the
+/// moment polish would run — nobody has checked whether that is a way out.
+///
+/// WHY this cannot be a test or a simulator run: `docs/agents/simulator.md` §7
+/// establishes by experiment that the Dictus keyboard cannot be enabled in any
+/// simulator, and the entire question is whether the *extension's* process is
+/// treated differently from the app's — so an app-target measurement answers
+/// nothing. The answer has to come off the maintainer's device, which is why
+/// this is a probe that writes to the persistent log he already exports rather
+/// than an assertion.
+///
+/// **Nothing here runs unless it is deliberately armed.** Disarmed — which is
+/// the default and the state this branch sits in — the entire cost is the one
+/// `Bool` read in `runIfArmed()`. Nothing is allocated, no session is built and
+/// no behaviour changes, which matters because the keyboard runs under a hard
+/// memory ceiling and a `didReceiveMemoryWarning` storm is a known hazard here.
+enum AppleFMExtensionProbe {
+
+    /// The component name every line of this probe carries, so one `grep` over
+    /// an exported log pulls the whole run out.
+    private static let component = "AppleFMExtensionProbe"
+
+    /// Fixed synthetic input, never the user's text.
+    ///
+    /// WHY fixed and synthetic: these lines land in a log that gets exported and
+    /// mailed. The rest of the logging in this project is privacy-safe by
+    /// construction (`LogEvent` has no free-text content parameter), and a probe
+    /// is not a reason to break that.
+    ///
+    /// WHY this long: it has to serve two questions at once. Q2 wants an
+    /// ordinary polish-shaped call, and Q4 wants a generation still in flight
+    /// long enough for a human to switch apps and tear the extension down. The
+    /// #315 captures put an 824-character input at roughly 5 s of generation, so
+    /// a few hundred characters buys the seconds Q4 needs while staying a
+    /// realistic dictation. It is unpunctuated spoken French because that is
+    /// what the natural-mode prompt is written against.
+    private static let fixture = """
+    alors ce que je voulais dire c'est que le texte arrive brut sans ponctuation \
+    et il faut le remettre en forme pour qu'il soit lisible donc on garde le sens \
+    et le registre de la personne mais on ajoute la ponctuation les majuscules et \
+    on répare les hésitations parce que sinon le message est difficile à lire quand \
+    on le reçoit et c'est exactement ce que la couche de polissage est censée faire \
+    sur chaque dictée sans jamais inventer de contenu qui n'a pas été dit
+    """
+
+    /// Fire one probe run if, and only if, the App Group flag is set.
+    ///
+    /// Called from exactly one place, `KeyboardRootView.onAppear`, so the run
+    /// happens while the keyboard is on screen — which is the foreground moment
+    /// the whole question is about. Everything below the `guard` is unreachable
+    /// on a normal dictation: disarmed, this function is one `Bool` read.
+    ///
+    /// WHY an App Group flag rather than a gesture or a build flag: the probe
+    /// has to fire on a build the maintainer can install and use normally for
+    /// twenty-five minutes first (driving the app into the refusing state is
+    /// the whole setup for Q2), and it has to be armable *after* that state is
+    /// reached, without rebuilding and without force-quitting anything — a
+    /// relaunch would reset the very state being measured.
+    static func runIfArmed() {
+        guard AppGroup.defaults.bool(forKey: SharedKeys.appleFMExtensionProbeArmed) else { return }
+        // Disarm before running, not after. A probe that was killed
+        // mid-generation — which is Q4's whole scenario — must not re-fire on
+        // the next keyboard appearance and turn a one-shot measurement into a
+        // loop the maintainer cannot switch off from inside the keyboard.
+        AppGroup.defaults.set(false, forKey: SharedKeys.appleFMExtensionProbeArmed)
+        Task { await run() }
+    }
+
+    private static func run() async {
+        // Short token shared by every line of one run, so a start with no
+        // completion is unambiguous. That pairing IS the Q4 answer: no
+        // completion line means the process died with `respond()` in flight.
+        let token = String(UUID().uuidString.prefix(8))
+        let memBefore = MemoryFootprint.residentMB()
+
+        #if canImport(FoundationModels)
+        guard #available(iOS 26.0, *) else {
+            report(token: token, action: "skipped", details: "reason=osTooOld")
+            return
+        }
+
+        // Availability as seen from INSIDE the extension process. This is Q1's
+        // runtime half and it is not answerable from the app: the app reporting
+        // `.available` says nothing about whether the same system service is
+        // reachable across the extension's sandbox boundary.
+        let availability = describe(SystemLanguageModel.default.availability)
+
+        report(
+            token: token,
+            action: "started",
+            details: "availability=\(availability) memBeforeMB=\(memBefore) inputChars=\(fixture.count)"
+        )
+        // Flush before generating, not after. If Q4's teardown kills the process
+        // mid-`respond()`, an unflushed start line would be lost too and the run
+        // would leave no trace at all — the one outcome that cannot be read.
+        PersistentLog.flush()
+
+        // Sample the footprint while the call is in flight. A peak that only
+        // exists during generation is exactly the shape Q3 is looking for, and
+        // a before/after pair would step straight over it.
+        let peak = PeakSampler(initial: memBefore)
+        let sampling = Task { await peak.sample() }
+
+        // The REAL shipping engine, real prompts, real session lifecycle. WHY
+        // not a hand-rolled `LanguageModelSession`: what Q3 needs priced is what
+        // a future implementation would actually pay, and what Q2 needs refused
+        // or served is a call Apple sees as identical to the app's. Using the
+        // production type also makes the build itself the Q1a evidence — this
+        // file puts `AppleFoundationModelsPolishEngine` into a target compiled
+        // with `APPLICATION_EXTENSION_API_ONLY = YES`.
+        let engine = AppleFoundationModelsPolishEngine()
+        let start = DispatchTime.now().uptimeNanoseconds
+        var outcome: String
+        do {
+            let polished = try await engine.polish(raw: fixture, targetLanguage: .french, mode: .natural)
+            // Length only. The generated text is not logged, for the same
+            // privacy reason the input is a fixture.
+            outcome = "success outputChars=\(polished.count)"
+        } catch {
+            // Reuse the engine's own #315 classification so a refusal here is
+            // directly comparable with the app-side `failureReason` slugs in the
+            // polish export. `rateLimited` versus anything else IS the Q2 answer.
+            outcome = "failed reason=\(engine.failureReason(for: error).slug)"
+        }
+        let engineMs = Int((DispatchTime.now().uptimeNanoseconds - start) / 1_000_000)
+
+        sampling.cancel()
+        let memAfter = MemoryFootprint.residentMB()
+
+        report(
+            token: token,
+            action: "finished",
+            details: "\(outcome) engineMs=\(engineMs) memBeforeMB=\(memBefore)"
+                + " memPeakMB=\(peak.value) memAfterMB=\(memAfter)"
+        )
+        PersistentLog.flush()
+        #else
+        report(token: token, action: "skipped", details: "reason=sdkMissing memBeforeMB=\(memBefore)")
+        #endif
+    }
+
+    private static func report(token: String, action: String, details: String) {
+        PersistentLog.log(.diagnosticProbe(
+            component: component,
+            instanceID: token,
+            action: action,
+            details: details
+        ))
+    }
+
+    #if canImport(FoundationModels)
+    @available(iOS 26.0, *)
+    private static func describe(_ availability: SystemLanguageModel.Availability) -> String {
+        switch availability {
+        case .available: return "available"
+        case .unavailable(let reason): return "unavailable:\(reason)"
+        @unknown default: return "unknown"
+        }
+    }
+    #endif
+}
+
+/// Polls `phys_footprint` and keeps the maximum seen, for the duration of one
+/// probe generation.
+///
+/// WHY polling rather than a high-water-mark API: there is no public one. iOS
+/// exposes the current footprint (`MemoryFootprint.residentMB()`, which is what
+/// jetsam scores) and nothing that remembers the peak, so a transient spike
+/// during session creation or generation is invisible to a before/after pair.
+/// 25 ms is fine-grained against a generation measured in hundreds of
+/// milliseconds to seconds, and this task exists only inside an armed run.
+private final class PeakSampler: @unchecked Sendable {
+
+    private let peak: OSAllocatedUnfairLock<Int>
+
+    init(initial: Int) {
+        peak = OSAllocatedUnfairLock(initialState: initial)
+    }
+
+    var value: Int { peak.withLock { $0 } }
+
+    func sample() async {
+        while !Task.isCancelled {
+            let now = MemoryFootprint.residentMB()
+            peak.withLock { $0 = max($0, now) }
+            try? await Task.sleep(nanoseconds: 25_000_000)
+        }
+    }
+}

--- a/DictusKeyboard/KeyboardRootView.swift
+++ b/DictusKeyboard/KeyboardRootView.swift
@@ -357,6 +357,10 @@ struct KeyboardRootView: View {
             // Language is set in KeyboardViewController.viewWillAppear, which fires
             // on every keyboard appearance and picks up any App Group preference changes.
 
+            // #357 spike, throwaway. Returns immediately unless deliberately armed
+            // from the hidden polish debug screen; see AppleFMExtensionProbe.
+            AppleFMExtensionProbe.runIfArmed()
+
             syncWaveformDriver()
         }
         .onDisappear {

--- a/docs/research/357-keyboard-extension-apple-fm.md
+++ b/docs/research/357-keyboard-extension-apple-fm.md
@@ -1,10 +1,23 @@
-# Can the keyboard extension call Apple Foundation Models? — research plan
+# Can the keyboard extension call Apple Foundation Models? — spike findings
 
 **Issue:** [#357](https://github.com/getdictus/dictus-ios/issues/357)
 **Scope:** measurement only. No feature work, no move of the polish call, no change to what a normal dictation does.
 **Date:** 2026-08-13.
 
-**This document is the plan, committed before any measurement was taken**, so the findings can be checked against the criteria rather than against criteria written to fit them. Follows the convention set by [`287-user-dictionary-learning.md`](287-user-dictionary-learning.md). The findings are appended below in a later commit on this branch.
+**The plan below was committed before any measurement was taken** (commit `de3b2fb`), so the findings can be checked against criteria that were not written to fit them. Follows the convention set by [`287-user-dictionary-learning.md`](287-user-dictionary-learning.md).
+
+## The answer, in four lines
+
+| | Question | Answer |
+| --- | --- | --- |
+| **Q1a** | Is `FoundationModels` usable from an app extension, statically? | **Yes, and it is settled.** The extension target compiles and links it, under a compiler setting proven to reject extension-unsafe API. Apple documents no prohibition. |
+| **Q1b** | Does it work at runtime inside the extension? | **Not measured.** Needs the device. |
+| **Q2** | Does a keyboard extension count as foreground for the limiter? | **Not measured.** Needs the device. This is the one that decides the roadmap. |
+| **Q3 / Q4** | Memory cost, and teardown mid-generation | **Not measured.** Need the device. |
+
+**The objection that killed this idea in #315 is dead.** "The extension cannot call Apple FM" is now disproved rather than assumed. What replaces it is a single unanswered question and a probe that answers it in about half an hour of the maintainer's time.
+
+Jump to [Findings](#findings), the [device procedure](#the-device-procedure-what-the-maintainer-runs), or [what I will not assert](#what-i-am-not-comfortable-asserting).
 
 ---
 
@@ -157,21 +170,207 @@ No generated text and no input text is logged — only its length.
 
 ---
 
-## The device procedure
-
-Written out in full in the findings section and in the PR body. Its shape:
-
-1. Arm nothing yet. Drive DictusApp into the refusing state using the recipe measured twice on 2026-08-13: polish on, one ordinary dictation every one to two minutes for roughly twenty-five minutes.
-2. Confirm the refusal is real and current, from the app's own polish debug screen.
-3. Arm the probe, then bring the keyboard up. The probe fires on appearance.
-4. Export the persistent log and send it.
-
-Step 2 is the one that must not be skipped: it is what separates a decisive Q2 answer from an inconclusive one.
-
----
-
 ## What this spike will not do
 
 - It will not move the polish call. #357 says so explicitly, and the move is a significant architectural change — the polish pipeline, its guardrails, the metrics ring and the debug export all live app-side today. It needs its own issue and its own plan.
 - It will not report an app-target measurement as an extension result.
 - It will not label anything **[device]** that was not measured on the device.
+
+---
+
+# Findings
+
+## Q1a — Is `FoundationModels` usable from an app extension, statically? **Yes.**
+
+Five pieces of evidence, in increasing order of weight.
+
+### 1. The SDK carries no extension-unavailability annotation **[sdk]**
+
+`FoundationModels.swiftinterface` for the iOS 26.4 device SDK — 1503 lines, the complete public surface:
+
+```
+/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/
+  iPhoneOS26.4.sdk/System/Library/Frameworks/FoundationModels.framework/
+  Modules/FoundationModels.swiftmodule/arm64e-apple-ios.swiftinterface
+```
+
+```console
+$ grep -c "ApplicationExtension" …/FoundationModels.swiftinterface
+0
+```
+
+Zero. **And the file does use the annotation mechanism** — `@available(tvOS, unavailable)` and `@available(watchOS, unavailable)` appear throughout (lines 14, 15, 18, 19, …). Apple annotates unavailability on this API where it applies; extensions are not among the places it applies.
+
+### 2. The null result is calibrated, so it is a real absence **[sdk]**
+
+A grep that finds nothing proves nothing until you show it can find something. The same pattern **does** occur elsewhere in the same SDK:
+
+```console
+$ grep -rl "iOSApplicationExtension, unavailable" \
+    …/iPhoneOS26.4.sdk/System/Library/Frameworks/ --include='*.swiftinterface'
+…/AppIntents.framework/Modules/AppIntents.swiftmodule/arm64e-apple-ios.swiftinterface
+```
+
+The method detects the annotation when it is present. Its absence from FoundationModels is a fact about FoundationModels, not about the grep.
+
+### 3. The extension target builds, under a setting proven to bite **[build]**
+
+`DictusKeyboard` builds with `APPLICATION_EXTENSION_API_ONLY = YES` — confirmed *in effect*, not merely read out of the pbxproj:
+
+```console
+$ xcodebuild -project Dictus.xcodeproj -target DictusKeyboard -configuration Debug -showBuildSettings
+    APPLICATION_EXTENSION_API_ONLY = YES
+    PRODUCT_BUNDLE_IDENTIFIER = com.pivi.dictus.keyboard
+```
+
+That setting makes extension-unsafe API a hard compile error. With `AppleFMExtensionProbe.swift` — which constructs `AppleFoundationModelsPolishEngine`, reads `SystemLanguageModel.default.availability`, and awaits `session.respond(to:)` through the engine — in that target:
+
+```console
+$ ./scripts/patch-fluidaudio-swift5.sh build/DerivedDataDevice
+$ xcodebuild build -project Dictus.xcodeproj -scheme DictusKeyboard -configuration Debug \
+    -destination 'generic/platform=iOS' -derivedDataPath build/DerivedDataDevice \
+    CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGNING_IDENTITY=""
+** BUILD SUCCEEDED **
+```
+
+**The negative control matters more than the build itself.** A green build under a setting that was silently inert would be worthless, so the setting was tested directly. Temporarily adding `UIApplication.shared.applicationState` to the very same file, in the same target:
+
+```
+DictusKeyboard/AppleFMExtensionProbe.swift:92:27: error: 'shared' is unavailable in
+application extensions for iOS: Use view controller based solutions where appropriate
+instead.
+** BUILD FAILED **
+```
+
+(Reverted immediately; it appears in no commit.) The enforcement is real, so FoundationModels producing no such error is a meaningful result rather than a vacuous one.
+
+### 4. The shipped extension binary actually links it **[build]**
+
+Compiling is not linking. The built `.appex`, device SDK:
+
+```console
+$ otool -L build/DerivedDataDevice/Build/Products/Debug-iphoneos/DictusApp.app/
+    PlugIns/DictusKeyboard.appex/DictusKeyboard.debug.dylib | grep -i foundationmodels
+	/System/Library/Frameworks/FoundationModels.framework/FoundationModels
+	    (compatibility version 1.0.0, current version 1.4.34, weak)
+```
+
+35 FoundationModels symbols are referenced from the extension binary, including exactly the ones this question is about:
+
+```
+FoundationModels.SystemLanguageModel.availability.getter
+static FoundationModels.SystemLanguageModel.default.getter
+enum case for FoundationModels.LanguageModelSession.GenerationError.rateLimited(…)
+```
+
+A note for whoever repeats this: in a Debug configuration the `.appex`'s main binary is a stub and the code lives in `DictusKeyboard.debug.dylib` beside it. `otool -L` on the stub lists no frameworks and looks like a negative result. Check the dylib.
+
+### 5. Apple documents no prohibition — and documents nothing at all **[doc]**
+
+Fetched through Apple's documentation JSON API; the HTML pages are a JS-rendered shell that returns only a title to a plain fetch.
+
+`rateLimited`, quoted exactly — the sentence the whole issue rests on:
+
+> An error that indicates your session has been rate limited.
+>
+> This error will only happen if your app is running in the background and exceeds the system defined rate limit.
+
+— <https://developer.apple.com/documentation/foundationmodels/languagemodelsession/generationerror/ratelimited(_:)>
+
+`prewarm(promptPrefix:)`:
+
+> Calling this method doesn't guarantee that the system loads your assets immediately, particularly if your app is running in the background or the system is under load.
+
+— <https://developer.apple.com/documentation/foundationmodels/languagemodelsession/prewarm(promptprefix:)>
+
+The framework landing page, `SystemLanguageModel`, `LanguageModelSession` and *Generating content and performing tasks with Foundation Models* were each scanned in full for `extension`, `entitlement`, `background`, `daemon`, `process` and `memory`. **None of them mentions app extensions, and none mentions an entitlement.** No entitlement key exists anywhere in the framework's SDK directory, which holds only a `.tbd` stub and the Swift module.
+
+A forum thread that surfaced in search as possibly relevant ("Foundation Models unavailable for…", <https://developer.apple.com/forums/thread/805378>) turns out to concern device *language* restrictions and Siri language settings, not extensions. No documented prohibition was found anywhere.
+
+**So Apple's wording is silent on the question, and that silence is exactly Q2.** "Your app is running in the background" does not say which process it means, and a keyboard extension has no `UIApplication` to have a state at all.
+
+---
+
+## Q1b, Q2, Q3, Q4 — not measured
+
+Not measurable on this machine, for the reason recorded in the plan before any of this began: `docs/agents/simulator.md` §7 establishes by experiment that the Dictus keyboard cannot be enabled in any simulator. No app-target substitute was run, because an app-target result answers a different question than the one asked.
+
+The instrument for all four is `DictusKeyboard/AppleFMExtensionProbe.swift`; the procedure is below.
+
+### The design flaw caught before the probe shipped
+
+Worth recording, because it would have produced a confident wrong answer.
+
+The obvious probe is one call from the extension: if it succeeds while the app is refused, the extension counts as foreground. **That reasoning is broken.** #315 established the budget is per process and only a fresh process resets it — and the extension *is* a different process. So a single success has a second explanation: the extension is merely a fresh process whose background budget has never been spent. Under that explanation the extension would deplete its own budget with use and start refusing exactly as the app does. The problem would be relocated, not solved, and an architecture built on that single green result would ship straight into it.
+
+The probe therefore fires **ten back-to-back generations inside one extension process**. The relocation story predicts refusals appearing partway through; the foreground story predicts none.
+
+The asymmetry is deliberate, and is stated so the result is not over-read: **a surviving burst is strong evidence** (a backgrounded app is refused under far lighter load than ten consecutive calls), while **a failing burst is weaker** — it could be an artefact of the density — and would need the slower once-a-minute protocol before concluding "no".
+
+---
+
+## The device procedure — what the maintainer runs
+
+About thirty minutes, most of it ordinary use. Each step names the question it answers.
+
+**Prerequisites:** a build of this branch on the iPhone; polish enabled; French; Parakeet; the keyboard enabled with Full Access.
+
+1. **Use Dictus normally for about twenty-five minutes**, polish on, one ordinary dictation every one to two minutes. This is the recipe measured twice on 2026-08-13. *Nothing to observe yet — this drives DictusApp into the refusing state.*
+
+2. **Confirm the app is actually refusing. Do not skip this.** Settings → long-press the Version row for 3 seconds → Polish debug. Recent events must show a run of `engineFailed` / `rateLimited`, the latest ones returning in single-digit milliseconds. If they do not, keep dictating and check again. *This is what makes step 4 mean anything: a probe that runs while the app is quietly succeeding proves nothing.*
+
+3. **Arm the probe on that same screen.** Section "#357 spike" → turn on "Arm keyboard Apple FM probe". *From here on, do not force-quit the app and do not restart the phone — a fresh process resets the very state being measured.*
+
+4. **Open any app with a text field, bring up the Dictus keyboard, and leave it on screen for about ninety seconds.** Do not dictate. The probe fires on keyboard appearance and runs ten generations back to back. *Answers Q1b (does Apple FM work at all inside the extension), Q2 (is the extension refused like the app, or served), and Q3 (memory cost).*
+   - If the keyboard visibly resets or disappears during this, say so — that is a jetsam kill, and it is itself the Q3 answer.
+
+5. **Optional, and the only step for Q4.** Re-arm the probe (step 3), bring the keyboard up again, and this time **switch to another app after about five seconds**, while a generation is still running. *Answers Q4: what happens to an in-flight call when the extension is torn down.*
+
+6. **Export and send.** Settings → Debug log → Export, for the persistent log. Also export the Polish debug JSON from step 2's screen — that is what pins the app's refusing state to the same window.
+
+### What the log will say
+
+Every line carries `component=AppleFMExtensionProbe` and one run token, so `grep AppleFMExtensionProbe` pulls a whole run out:
+
+```
+diagnosticProbe AppleFMExtensionProbe <token> started   availability=… memBeforeMB=… burst=10
+diagnosticProbe AppleFMExtensionProbe <token> call      n=1/10 success outputChars=… engineMs=… memMB=… memPeakMB=…
+…
+diagnosticProbe AppleFMExtensionProbe <token> finished  memBeforeMB=… memPeakMB=… memAfterMB=…
+```
+
+How to read it:
+
+| What the lines show | What it means |
+| --- | --- |
+| `availability=available`, ten `success` | **Q1b and Q2 both yes.** The extension is served while the app is refused. The outcome that closes #315 by moving the call. |
+| `availability=available`, `failed reason=rateLimited` appearing partway through | **Q2 no**, subject to the burst caveat above. The extension is on the same budget. |
+| `availability=unavailable:…` | **Q1b no.** Apple FM is not reachable from the extension at runtime, whatever the linker allows. |
+| A `started` line with no `call` lines and no `finished` | The process died before completing a generation — a jetsam kill (Q3) or a teardown (Q4), told apart by whether step 5 was running. |
+| `memPeakMB` across the burst | **Q3.** Both the delta over `memBeforeMB` and the absolute peak matter; the ceiling is absolute. |
+
+### If nothing is run
+
+Q1b, Q2, Q3 and Q4 stay unanswered, and the decision they gate stays blocked: whether #79 Smart Modes can ship on Apple FM, or whether #351 has to move onto the Dictus Pro critical path. No amount of further reading moves it — Apple's documentation does not contain the answer, which is finding 5 above.
+
+---
+
+## Recommendation
+
+**Run the probe before re-ranking anything.** Concretely:
+
+1. **Do not move #351 onto the Pro critical path yet.** Decision 15 of the #315 grilling suspended decision 6 on this measurement. The cheapest reason to assume "no" — that an extension cannot call Apple FM at all — is now disproved, so the pessimistic branch is no longer the default. One device session settles it either way.
+2. **Do not start the move.** Even a clean "yes" on Q2 does not make this a small change, and #357 is explicit that it ends with the answer.
+3. **Keep #315's decision 14 shipping regardless.** Honest degradation is worth having whatever Q2 says, and decision 1 already committed to it independently.
+
+If Q2 comes back yes, the follow-up issue has to cost something this spike deliberately did not design: polish would move onto the keyboard's critical path, where a multi-second LLM call sits between the user finishing speaking and the text appearing, in a process iOS tears down aggressively (Q4) and holds to a hard memory ceiling (Q3). That is a real design problem, and a much better one to have than an engine that refuses.
+
+---
+
+## What I am not comfortable asserting
+
+- **That Apple FM inference runs outside the calling process.** #357's body states it — "Apple FM inference does not run in the calling process; the model is hosted by a system daemon" — and it is the premise that makes Q3 look cheap. **I could not confirm it in any Apple documentation.** The framework pages say nothing about the process model. It is plausible, widely assumed, and unverified here. Q3 must be settled by measurement, not by this premise.
+- **Anything about Q2's likely answer.** The mechanism is undocumented, and a keyboard extension's relationship to `UIApplication.state` is precisely what is at issue. Guessing here is what this spike exists to avoid.
+- **That a clean build guarantees runtime behaviour.** Q1a and Q1b are separated throughout for this reason. The linker permitting a call says nothing about a system service serving it across the extension sandbox.
+- **The Q4 half about raw transcription still reaching the document.** That is a property of an architecture that does not exist yet; today the app owns both the call and the insertion. The probe can only establish what happens to an in-flight `respond()`.
+- **That ten is the right burst size.** It is reasoned — enough to land inside the refusal regime the app exhibits, short enough that a human will hold a keyboard open — but it is not calibrated against a measured extension refusal threshold, because none exists yet.

--- a/docs/research/357-keyboard-extension-apple-fm.md
+++ b/docs/research/357-keyboard-extension-apple-fm.md
@@ -2,7 +2,7 @@
 
 **Issue:** [#357](https://github.com/getdictus/dictus-ios/issues/357)
 **Scope:** measurement only. No feature work, no move of the polish call, no change to what a normal dictation does.
-**Date:** 2026-08-13.
+**Date:** 2026-08-13 (desk work), 2026-08-14 (device run).
 
 **The plan below was committed before any measurement was taken** (commit `de3b2fb`), so the findings can be checked against criteria that were not written to fit them. Follows the convention set by [`287-user-dictionary-learning.md`](287-user-dictionary-learning.md).
 
@@ -10,14 +10,17 @@
 
 | | Question | Answer |
 | --- | --- | --- |
-| **Q1a** | Is `FoundationModels` usable from an app extension, statically? | **Yes, and it is settled.** The extension target compiles and links it, under a compiler setting proven to reject extension-unsafe API. Apple documents no prohibition. |
-| **Q1b** | Does it work at runtime inside the extension? | **Not measured.** Needs the device. |
-| **Q2** | Does a keyboard extension count as foreground for the limiter? | **Not measured.** Needs the device. This is the one that decides the roadmap. |
-| **Q3 / Q4** | Memory cost, and teardown mid-generation | **Not measured.** Need the device. |
+| **Q1a** | Is `FoundationModels` usable from an app extension, statically? | **Yes.** The extension target compiles and links it, under a compiler setting proven to reject extension-unsafe API. Apple documents no prohibition. |
+| **Q1b** | Does it work at runtime inside the extension? | **Yes.** `availability=available` read from inside the extension process, and ten generations returned real text. |
+| **Q2** | Does a keyboard extension count as foreground for the limiter? | **Yes.** Ten consecutive successes from the extension, fired ten seconds after the app's last instant `rateLimited` refusal, same device, same minute. |
+| **Q3** | What does the call cost in the extension's budget? | **7 MB peak delta** (15 → 22 MB), no degradation across ten calls. **Measured on an idle keyboard — see the caveat, it is the top open risk.** |
+| **Q4** | Teardown mid-generation? | **Still not measured.** The optional step was not run. |
 
-**The objection that killed this idea in #315 is dead.** "The extension cannot call Apple FM" is now disproved rather than assumed. What replaces it is a single unanswered question and a probe that answers it in about half an hour of the maintainer's time.
+**The keyboard extension is served while the app is refused.** That is the finding, and it is the one #315 was waiting on. Moving the polish call there does not work around Apple's rate limit — it stops meeting it. Follow-up work is #361.
 
-Jump to [Findings](#findings), the [device procedure](#the-device-procedure-what-the-maintainer-runs), or [what I will not assert](#what-i-am-not-comfortable-asserting).
+Two things fell out that were not the question: there is **no latency penalty**, and Apple FM inference **does not run in the calling process** — a claim #357's own body made without evidence, which the 7 MB delta now supports.
+
+Jump to [Findings](#findings), [the measured results](#q1b-q2-q3--measured-on-device), or [what remains unasserted](#what-i-am-still-not-comfortable-asserting).
 
 ---
 
@@ -43,7 +46,7 @@ Every claim in the findings carries one, and the label is part of the claim.
 | **[code]** | Read in this repository, cited by file and line. |
 | **[doc]** | Apple developer documentation, cited by URL, quoted exactly. |
 | **[build]** | Output of a build or test command run on this machine, command recorded. |
-| **[device]** | Measured on the maintainer's iPhone. **Nothing in this spike can carry this label until he runs the probe.** |
+| **[device]** | Measured on the maintainer's iPhone. Nothing carried this label until he ran the probe on 2026-08-14; the results that now do are in [Q1b, Q2, Q3](#q1b-q2-q3--measured-on-device). |
 | **[derived]** | Inference on top of a labelled fact. The input is sourced; the output is not. |
 
 ---
@@ -59,6 +62,8 @@ Therefore:
 - Q4 likewise requires a live extension.
 
 So this spike splits into **what is answerable now by build and by SDK** (Q1's static half), and **a probe plus a written procedure** for everything else. The probe is the deliverable for Q2/Q3/Q4; the answers arrive when the maintainer runs it.
+
+*(He ran it on 2026-08-14. Q1b, Q2 and Q3 are answered below; Q4 was skipped and is still open.)*
 
 ---
 
@@ -290,87 +295,146 @@ A forum thread that surfaced in search as possibly relevant ("Foundation Models 
 **So Apple's wording is silent on the question, and that silence is exactly Q2.** "Your app is running in the background" does not say which process it means, and a keyboard extension has no `UIApplication` to have a state at all.
 
 ---
+## Q1b, Q2, Q3 — measured on device
 
-## Q1b, Q2, Q3, Q4 — not measured
+Run by the maintainer on 2026-08-14. Build 1.8.0 (26), `rev a3662ef@HEAD`, iPhone16,2, iOS 26.6, Parakeet `parakeet-tdt-0.6b-v3`, polish on, French. **[device]**
 
-Not measurable on this machine, for the reason recorded in the plan before any of this began: `docs/agents/simulator.md` §7 establishes by experiment that the Dictus keyboard cannot be enabled in any simulator. No app-target substitute was run, because an app-target result answers a different question than the one asked.
+### The app was refusing, and that is pinned independently
 
-The instrument for all four is `DictusKeyboard/AppleFMExtensionProbe.swift`; the procedure is below.
+The confound this whole experiment had to avoid was a probe that runs while the app is quietly succeeding. It did not happen. The app's own log, in the four minutes before the probe:
 
-### The design flaw caught before the probe shipped
+```text
+07:28:18  <APP>  polishEngineFailed  other:NSError  engineMs=905   <-- slow: the arming failure
+07:28:27  <APP>  polishEngineFailed  rateLimited    engineMs=10
+07:28:45  <APP>  polishEngineFailed  rateLimited    engineMs=9
+07:28:52  <APP>  polishEngineFailed  rateLimited    engineMs=10
+```
 
-Worth recording, because it would have produced a confident wrong answer.
+That is the exact latch signature #315 documented four times: one slow failure that runs the model and then fails, followed by instant refusals. The polish export from the same session agrees — `success: 11, engineFailed: 4`, reasons `{other:NSError: 1, rateLimited: 3}`, every dictation at `appState=2` (background).
 
-The obvious probe is one call from the extension: if it succeeds while the app is refused, the extension counts as foreground. **That reasoning is broken.** #315 established the budget is per process and only a fresh process resets it — and the extension *is* a different process. So a single success has a second explanation: the extension is merely a fresh process whose background budget has never been spent. Under that explanation the extension would deplete its own budget with use and start refusing exactly as the app does. The problem would be relocated, not solved, and an architecture built on that single green result would ship straight into it.
+**Ten seconds after the app's last instant refusal**, the extension ran.
 
-The probe therefore fires **ten back-to-back generations inside one extension process**. The relocation story predicts refusals appearing partway through; the foreground story predicts none.
+### The burst
 
-The asymmetry is deliberate, and is stated so the result is not over-read: **a surviving burst is strong evidence** (a backgrounded app is refused under far lighter load than ten consecutive calls), while **a failing burst is weaker** — it could be an artefact of the density — and would need the slower once-a-minute protocol before concluding "no".
+```text
+07:29:02  <KBD>  AppleFMExtensionProbe  started  availability=available memBeforeMB=15 inputChars=462 burst=10
+07:29:06  <KBD>  n=1/10   success  outputChars=471  engineMs=4414  memMB=19  memPeakMB=22
+07:29:11  <KBD>  n=2/10   success  outputChars=468  engineMs=4600  memMB=19  memPeakMB=22
+07:29:16  <KBD>  n=3/10   success  outputChars=463  engineMs=5066  memMB=19  memPeakMB=22
+07:29:21  <KBD>  n=4/10   success  outputChars=471  engineMs=4948  memMB=19  memPeakMB=22
+07:29:26  <KBD>  n=5/10   success  outputChars=471  engineMs=4890  memMB=19  memPeakMB=22
+07:29:31  <KBD>  n=6/10   success  outputChars=464  engineMs=4892  memMB=19  memPeakMB=22
+07:29:36  <KBD>  n=7/10   success  outputChars=472  engineMs=4880  memMB=19  memPeakMB=22
+07:29:41  <KBD>  n=8/10   success  outputChars=472  engineMs=4890  memMB=19  memPeakMB=22
+07:29:46  <KBD>  n=9/10   success  outputChars=470  engineMs=4914  memMB=19  memPeakMB=22
+07:29:50  <KBD>  n=10/10  success  outputChars=470  engineMs=4825  memMB=19  memPeakMB=22
+07:29:50  <KBD>  AppleFMExtensionProbe  finished  memBeforeMB=15 memPeakMB=22 memAfterMB=19
+```
+
+### Scored against the criteria written before the run
+
+The criteria in [Falsifiable criteria](#falsifiable-criteria-written-before-measuring) are unchanged from commit `de3b2fb`. Scoring against them, verbatim:
+
+| | Criterion as written | Result |
+| --- | --- | --- |
+| **Q1b YES** | `SystemLanguageModel.default.availability` reports `.available` inside the extension, **and** a `respond()` returns generated text | **Met.** `availability=available`, and ten responses of 463–472 characters. |
+| **Q2 YES** | While DictusApp is **demonstrably** in the refusing state, a burst of ten generations from the extension succeeds with no `rateLimited` | **Met.** Ten of ten, zero refusals, with the app's refusal pinned in the same log window. |
+| **Q2 INCONCLUSIVE** | The app is not actually refusing when the probe runs | **Excluded**, by the four refusals at 07:28:18–07:28:52 and the export. |
+| **Q3 ROOM** | Peak stays clearly below the ceiling with the keyboard's footprint loaded, no memory warning, no process death | **Met at 15 MB baseline only.** 22 MB peak, all ten calls completed, no kill. **The "with the keyboard's footprint already loaded" half was not satisfied — see the caveat.** |
+| **Q4** | Start line with no completion line means the process died in flight | **Not run.** |
+
+### Q2 — the answer, and how strong it is
+
+**The extension is served while the app is refused.** Same device, same model, ten seconds apart, opposite outcomes. The only variable is which process issued the call.
+
+This is the result #315 was waiting on, and it makes the mechanism plain: Apple's "your app is running in the background" is applied to **the process that makes the call**, and a keyboard extension holding the screen is not that.
+
+**How strong: strong, not airtight.** Two things support it and one bounds it.
+
+- The app latches after roughly a dozen calls in a dense session; the extension took ten back-to-back without a single refusal or any sign of degradation — call 10 was as fast as call 1. Under the "fresh process, unspent budget" alternative the burst should have started refusing partway through, as the app does. It did not.
+- **The second argument, which survives even if the first is soft.** Suppose the extension does have its own background budget. It would still not produce the app's failure mode, because iOS tears down and recreates keyboard extensions constantly during normal use — this project has measured roughly nine controller instances across a dictation. A budget that resets that often never accumulates. What makes the limit a *product* problem in DictusApp is precisely that the app process persists for a whole working session and its budget never refills; that condition does not exist in the extension.
+- **The bound.** Ten is not twenty. A 20-call burst in one extension process would settle it outright, and it is cheap now that the instrument exists. Recorded as owed work in #361.
+
+### Q3 — 7 MB, and the caveat that matters more than the number
+
+Peak delta **7 MB** (15 → 22), settling at 19. Flat across all ten calls: no growth, no leak, no memory warning, no jetsam kill.
+
+**This also settles something #357 asserted without evidence.** The issue body claimed "Apple FM inference does not run in the calling process; the model is hosted by a system daemon", and this report declined to assert it because no Apple documentation says so. A 7 MB peak for ten generations of a multi-billion-parameter model is only consistent with the weights living somewhere else. The claim was unsupported when it was made; the measurement happens to confirm it. It is now **[device]**-backed rather than assumed.
+
+**Now the caveat, and it is the top open risk on #361.**
+
+`memBefore` was **15 MB — an idle keyboard**. The probe fires on keyboard appearance, with no dictation in progress, no recording overlay, no waveform, no transcription handoff. During a real dictation the extension carries its full working set, which this project's own notes put near **60 MB, against a ceiling in the same region**.
+
+**7 MB of headroom at 15 MB says nothing about 7 MB of headroom at 55 MB.** The measurement was taken at the wrong moment for the decision it will be used to justify. It is not wrong, it is narrow, and reading it as "the call is cheap, ship it" would be the mistake this report exists to prevent. Re-measuring at the instant the call would actually happen is the first thing #361 has to do.
+
+### Latency — no penalty, and the figure is pessimistic
+
+4414–5066 ms on 462 characters, tight distribution. Against the app on comparable input in the same export: 485 characters in 4231 ms, 622 characters in 4501 ms. **The extension is in the same band as the app.**
+
+And it is the pessimistic figure. The extension does not prewarm, and the engine builds a fresh session for every call. The app's numbers benefit from a `prewarm()` at recording start — though Apple documents that prewarm "does not guarantee that the system loads your assets immediately, particularly if your app is running in the background", so the app may not have been getting much from it either. From the extension, on screen, prewarm would actually do something. Whatever the truth there, moving the call does not cost latency.
+
+### Q4 — still open
+
+The optional teardown step was not run. Nothing in this spike says what happens to an in-flight `respond()` when the extension is torn down, and the probe's start/completion pairing is still the instrument for it.
+
+This matters more after the move than before it: today the app owns the call and survives the keyboard going away. #361 makes the raw transcription durable before any generation starts, precisely so the worst case stays "raw text inserted" rather than "nothing inserted" — and that design needs Q4's answer to be validated rather than assumed.
 
 ---
 
-## The device procedure — what the maintainer runs
+## Should the probe stay on `develop`? — yes, argued
 
-About thirty minutes, most of it ordinary use. Each step names the question it answers.
+Diagnostic code landing on `develop` deserves a reason, so here it is.
 
-**Prerequisites:** a build of this branch on the iPhone; polish enabled; French; Parakeet; the keyboard enabled with Full Access.
+**Keep it.** #361 needs exactly two more measurements, and this probe is the instrument for both:
 
-1. **Use Dictus normally for about twenty-five minutes**, polish on, one ordinary dictation every one to two minutes. This is the recipe measured twice on 2026-08-13. *Nothing to observe yet — this drives DictusApp into the refusing state.*
+1. **Memory at a realistic working set** — the caveat above, and the risk most likely to kill the whole approach.
+2. **A 20-call burst**, to convert Q2 from strong to settled.
 
-2. **Confirm the app is actually refusing. Do not skip this.** Settings → long-press the Version row for 3 seconds → Polish debug. Recent events must show a run of `engineFailed` / `rateLimited`, the latest ones returning in single-digit milliseconds. If they do not, keep dictating and check again. *This is what makes step 4 mean anything: a probe that runs while the app is quietly succeeding proves nothing.*
+Deleting the probe now means rewriting it in a fortnight, rediscovering the same design constraints — the burst, the flush-per-line, the arming channel that survives without a relaunch — and re-reviewing it. That is waste.
 
-3. **Arm the probe on that same screen.** Section "#357 spike" → turn on "Arm keyboard Apple FM probe". *From here on, do not force-quit the app and do not restart the phone — a fresh process resets the very state being measured.*
+The safety argument is the same one it shipped with, now with a device run behind it:
 
-4. **Open any app with a text field, bring up the Dictus keyboard, and leave it on screen for about ninety seconds.** Do not dictate. The probe fires on keyboard appearance and runs ten generations back to back. *Answers Q1b (does Apple FM work at all inside the extension), Q2 (is the extension refused like the app, or served), and Q3 (memory cost).*
-   - If the keyboard visibly resets or disappears during this, say so — that is a jetsam kill, and it is itself the Q3 answer.
+- **Inert by default.** Armed by an App Group bool defaulting to false. Disarmed, the cost is one `Bool` read per keyboard appearance; nothing is allocated on the dictation path.
+- **One-shot**, consumed before the run.
+- **Not user-reachable.** The only arming surface is a toggle on a debug screen reached by a three-second long-press on the Version row in Settings.
+- **Observed harmless.** The device run exercised it end to end: ten Apple FM calls inside the extension, peak 22 MB, no kill, no memory warning, no effect on the keyboard.
 
-5. **Optional, and the only step for Q4.** Re-arm the probe (step 3), bring the keyboard up again, and this time **switch to another app after about five seconds**, while a generation is still running. *Answers Q4: what happens to an in-flight call when the extension is torn down.*
+The one honest cost: it is a live code path in a shipping binary, and the `SharedKeys` entry outlives it. Both are marked "delete with the spike" in the source, and the pbxproj entries use issue-tied IDs (`AA357001` / `AA357002`) so removal is mechanical.
 
-6. **Export and send.** Settings → Debug log → Export, for the persistent log. Also export the Polish debug JSON from step 2's screen — that is what pins the app's refusing state to the same window.
+**Delete it when #361's two measurements are taken**, not before.
 
-### What the log will say
+### How to re-run it
 
-Every line carries `component=AppleFMExtensionProbe` and one run token, so `grep AppleFMExtensionProbe` pulls a whole run out:
+The procedure that produced the results above, kept because #361 needs it twice more.
 
-```
-diagnosticProbe AppleFMExtensionProbe <token> started   availability=… memBeforeMB=… burst=10
-diagnosticProbe AppleFMExtensionProbe <token> call      n=1/10 success outputChars=… engineMs=… memMB=… memPeakMB=…
-…
-diagnosticProbe AppleFMExtensionProbe <token> finished  memBeforeMB=… memPeakMB=… memAfterMB=…
-```
+1. **Drive the app into the refusing state:** polish on, one ordinary dictation every one to two minutes, for roughly twenty-five minutes.
+2. **Confirm it is actually refusing.** Settings → long-press the Version row 3 s → Polish debug. You need a run of `engineFailed` / `rateLimited` with the latest returning in single-digit milliseconds. **Skipping this is what makes a result inconclusive.**
+3. **Arm the probe** on that screen, section "#357 spike". From here on, do not force-quit the app and do not restart the phone — a fresh process resets the state being measured.
+4. **Bring the Dictus keyboard up in any text field and leave it up** for about ninety seconds. The probe fires on appearance.
+5. **Export** the persistent log (Settings → Debug log → Export) and the Polish debug JSON, which is what pins the app's state to the same window.
 
-How to read it:
+For #361's two outstanding measurements, the changes are small and both are one-line edits to `AppleFMExtensionProbe.swift`:
 
-| What the lines show | What it means |
-| --- | --- |
-| `availability=available`, ten `success` | **Q1b and Q2 both yes.** The extension is served while the app is refused. The outcome that closes #315 by moving the call. |
-| `availability=available`, `failed reason=rateLimited` appearing partway through | **Q2 no**, subject to the burst caveat above. The extension is on the same budget. |
-| `availability=unavailable:…` | **Q1b no.** Apple FM is not reachable from the extension at runtime, whatever the linker allows. |
-| A `started` line with no `call` lines and no `finished` | The process died before completing a generation — a jetsam kill (Q3) or a teardown (Q4), told apart by whether step 5 was running. |
-| `memPeakMB` across the burst | **Q3.** Both the delta over `memBeforeMB` and the absolute peak matter; the ceiling is absolute. |
-
-### If nothing is run
-
-Q1b, Q2, Q3 and Q4 stay unanswered, and the decision they gate stays blocked: whether #79 Smart Modes can ship on Apple FM, or whether #351 has to move onto the Dictus Pro critical path. No amount of further reading moves it — Apple's documentation does not contain the answer, which is finding 5 above.
+- **Memory at a realistic working set** — the call site has to move from `KeyboardRootView.onAppear` to the moment a dictation's text comes back, so the extension is carrying its real footprint rather than an idle 15 MB. This is the measurement that could still reverse the decision.
+- **A 20-call burst** — raise `burstSize` from 10 to 20.
 
 ---
 
 ## Recommendation
 
-**Run the probe before re-ranking anything.** Concretely:
+**The direction is settled: move the polish call into the keyboard extension.** That is #361, and it should be treated as a Dictus Pro prerequisite rather than an optimisation — #315 decision 3 holds paid features to a higher reliability bar than free polish, and this is the only measured path to clearing it.
 
-1. **Do not move #351 onto the Pro critical path yet.** Decision 15 of the #315 grilling suspended decision 6 on this measurement. The cheapest reason to assume "no" — that an extension cannot call Apple FM at all — is now disproved, so the pessimistic branch is no longer the default. One device session settles it either way.
-2. **Do not start the move.** Even a clean "yes" on Q2 does not make this a small change, and #357 is explicit that it ends with the answer.
-3. **Keep #315's decision 14 shipping regardless.** Honest degradation is worth having whatever Q2 says, and decision 1 already committed to it independently.
-
-If Q2 comes back yes, the follow-up issue has to cost something this spike deliberately did not design: polish would move onto the keyboard's critical path, where a multi-second LLM call sits between the user finishing speaking and the text appearing, in a process iOS tears down aggressively (Q4) and holds to a hard memory ceiling (Q3). That is a real design problem, and a much better one to have than an engine that refuses.
+1. **Do not move #351 or #268 onto the Pro critical path.** Decision 15 of the #315 grilling suspended decision 6 on this measurement; the measurement came back yes. Apple FM is viable for #79 Smart Modes, from the extension.
+2. **Re-measure memory before committing to #361.** The 7 MB figure was taken on a 15 MB idle keyboard, and the real moment is around 55 MB. This is the one result that could still reverse the decision.
+3. **Take Q4 early in #361**, not late. The durability design depends on it.
+4. **Keep #315's decision 14 shipping regardless.** Honest degradation stays worth having: it is the fallback while #361 is built, it covers `guardrailViolation` and the other non-`rateLimited` reasons which the move does not address, and decision 1 committed to it independently.
 
 ---
 
-## What I am not comfortable asserting
+## What I am still not comfortable asserting
 
-- **That Apple FM inference runs outside the calling process.** #357's body states it — "Apple FM inference does not run in the calling process; the model is hosted by a system daemon" — and it is the premise that makes Q3 look cheap. **I could not confirm it in any Apple documentation.** The framework pages say nothing about the process model. It is plausible, widely assumed, and unverified here. Q3 must be settled by measurement, not by this premise.
-- **Anything about Q2's likely answer.** The mechanism is undocumented, and a keyboard extension's relationship to `UIApplication.state` is precisely what is at issue. Guessing here is what this spike exists to avoid.
-- **That a clean build guarantees runtime behaviour.** Q1a and Q1b are separated throughout for this reason. The linker permitting a call says nothing about a system service serving it across the extension sandbox.
-- **The Q4 half about raw transcription still reaching the document.** That is a property of an architecture that does not exist yet; today the app owns both the call and the insertion. The probe can only establish what happens to an in-flight `respond()`.
-- **That ten is the right burst size.** It is reasoned — enough to land inside the refusal regime the app exhibits, short enough that a human will hold a keyboard open — but it is not calibrated against a measured extension refusal threshold, because none exists yet.
+- **That Q3 generalises to a real dictation.** Stated above and repeated here because it is the claim most likely to be quoted out of context. 7 MB at a 15 MB baseline is not 7 MB at a 55 MB baseline, and only a re-measurement at the real moment settles it.
+- **That Q2 is airtight.** Ten calls against an app-side latch threshold of roughly a dozen is strong, and the teardown-frequency argument backs it independently, but a 20-call burst is what would close it. Recorded as owed.
+- **Anything about Q4.** Not measured, not inferred.
+- **That the latency finding survives the architecture change.** The probe measured a generation in isolation. In #361 the call sits between the transcription arriving and the text being inserted, with an App Group round trip and a Darwin notification around it. The generation will cost what it costs here; the end-to-end wait is a different number that nobody has measured.
+- **That prewarm will help from the extension.** Apple's wording makes it plausible and the app's own use of it may have been doing nothing, but "would actually do something" is an inference from documentation, not a measurement.

--- a/docs/research/357-keyboard-extension-apple-fm.md
+++ b/docs/research/357-keyboard-extension-apple-fm.md
@@ -1,0 +1,164 @@
+# Can the keyboard extension call Apple Foundation Models? — research plan
+
+**Issue:** [#357](https://github.com/getdictus/dictus-ios/issues/357)
+**Scope:** measurement only. No feature work, no move of the polish call, no change to what a normal dictation does.
+**Date:** 2026-08-13.
+
+**This document is the plan, committed before any measurement was taken**, so the findings can be checked against the criteria rather than against criteria written to fit them. Follows the convention set by [`287-user-dictionary-learning.md`](287-user-dictionary-learning.md). The findings are appended below in a later commit on this branch.
+
+---
+
+## Why this spike exists
+
+[#315](https://github.com/getdictus/dictus-ios/issues/315) established, first from Apple's documentation and then from a controlled device experiment on 2026-08-13, that `LanguageModelSession.GenerationError.rateLimited` is a **per-call decision applied to backgrounded processes**. The same process, seconds apart, is refused when backgrounded and served in ~800 ms when active. A foreground visit does not refund the budget; only a fresh process resets it.
+
+DictusApp is backgrounded for every polish call by design — the keyboard extension holds the screen while the app records, transcribes and polishes behind it. So polish runs in the one state Apple deprioritises, on every single dictation.
+
+**The keyboard extension is in the foreground at exactly the moment polish would run.** If the extension's process is treated as foreground by this limiter, the problem stops existing rather than needing to be handled.
+
+Nobody has checked. That is this spike.
+
+---
+
+## Evidence labels
+
+Every claim in the findings carries one, and the label is part of the claim.
+
+| Label | Meaning |
+| --- | --- |
+| **[sdk]** | Read in the iOS SDK on this machine, cited by absolute path and line. |
+| **[code]** | Read in this repository, cited by file and line. |
+| **[doc]** | Apple developer documentation, cited by URL, quoted exactly. |
+| **[build]** | Output of a build or test command run on this machine, command recorded. |
+| **[device]** | Measured on the maintainer's iPhone. **Nothing in this spike can carry this label until he runs the probe.** |
+| **[derived]** | Inference on top of a labelled fact. The input is sourced; the output is not. |
+
+---
+
+## The constraint that shapes this plan
+
+`docs/agents/simulator.md` §7 establishes **by experiment, not by assumption**, that the Dictus keyboard cannot be enabled in any iOS simulator. Four methods were tried and all four failed; the extension registers with the plug-in system but never appears in `UITextInputMode.activeInputModes`.
+
+Therefore:
+
+- **Q2 and Q3 are not measurable by an agent on this machine.** They require the extension's process to actually run.
+- **An app-target measurement cannot stand in for either.** The entire question is whether the *extension's process* is treated differently from the app's. Running the same code in DictusApp answers nothing, and reporting it as an extension result would be worse than reporting nothing.
+- Q4 likewise requires a live extension.
+
+So this spike splits into **what is answerable now by build and by SDK** (Q1's static half), and **a probe plus a written procedure** for everything else. The probe is the deliverable for Q2/Q3/Q4; the answers arrive when the maintainer runs it.
+
+---
+
+## Falsifiable criteria, written before measuring
+
+A spike that concludes "it seems feasible" has failed. Each question below has a stated yes and a stated no.
+
+### Q1 — Is `FoundationModels` usable from an app extension at all?
+
+This question has a static half and a runtime half, and **they are not the same question**. Splitting them is deliberate: a compile proves the toolchain permits the call, not that the system serves it across the extension sandbox boundary.
+
+#### Q1a — static / toolchain
+
+| | Criterion |
+| --- | --- |
+| **YES** | (i) `FoundationModels.swiftinterface` in the iOS SDK carries no `iOSApplicationExtension, unavailable` annotation, **and** that grep is calibrated against a framework in the same SDK where the annotation does appear, so a null result is a real absence and not a broken method; **and** (ii) the `DictusKeyboard` target compiles and links a real `LanguageModelSession` call. |
+| **NO** | A compile error naming the API as unavailable in application extensions, a link failure, or a documented prohibition. |
+
+**Why (ii) is strong evidence and not merely suggestive:** `DictusKeyboard` builds with `APPLICATION_EXTENSION_API_ONLY = YES` (`Dictus.xcodeproj/project.pbxproj:1231`, `:1259`). That setting makes the compiler *enforce* extension-safety — an API marked unavailable to extensions is a hard error, not a warning. A clean build of that target is the toolchain stating that the call is permitted.
+
+**A documented prohibition outranks a clean build.** If Apple documents FoundationModels as unsupported in extensions, that is the answer regardless of what compiles today.
+
+#### Q1b — runtime
+
+| | Criterion |
+| --- | --- |
+| **YES** | Inside the extension process on device: `SystemLanguageModel.default.availability` reports `.available`, **and** a `respond()` returns generated text. |
+| **NO** | Availability reports unavailable inside the extension while the same device reports available to the app; or `respond()` throws `assetsUnavailable`; or the call never returns. |
+
+**Q1a passing does not establish Q1b.** Compile-time permission is not runtime service access. This is measured by the probe.
+
+### Q2 — Does a keyboard extension count as foreground for this limiter?
+
+The question the whole issue turns on.
+
+| | Criterion |
+| --- | --- |
+| **YES** | While DictusApp is **demonstrably** in the refusing state, a probe generation issued from the extension **succeeds**. Decisive. |
+| **NO** | The probe generation throws `rateLimited` in the same window. Also decisive, and it is the answer that re-ranks [#351](https://github.com/getdictus/dictus-ios/issues/351) onto the Dictus Pro critical path. |
+| **INCONCLUSIVE** | The app is not actually refusing at the moment the probe runs. |
+
+The inconclusive row is the trap, and the procedure is built around avoiding it: **the app's refusal must be pinned in the same log window as the probe's result**, not assumed from "I did a lot of dictations". A probe success against an app that was quietly serving requests again proves nothing.
+
+### Q3 — What does a `LanguageModelSession` cost inside the extension's budget?
+
+| | Criterion |
+| --- | --- |
+| **ROOM** | Peak `phys_footprint` during session creation + `respond()` stays clearly below the extension's ceiling, with the keyboard's normal footprint already loaded, and no memory warning or process death follows. |
+| **NO ROOM** | The extension is jetsam-killed (the keyboard visibly resets, and the probe's completion line never reaches the log), or the peak lands close enough to the ceiling that a real dictation on top of it would not fit. |
+
+Both the **delta** and the **absolute peak** must be recorded. The ceiling is absolute, so a small delta on top of an already-high baseline is still a no. The hypothesis under test is #357's own: that inference is hosted by a system daemon and the extension holds only a session object and two strings, making the cost small. That is plausible and unmeasured.
+
+### Q4 — What happens if the extension is torn down mid-generation?
+
+| | Answer shape |
+| --- | --- |
+| The probe logs a start line and a completion line carrying the same run token. If the keyboard is dismissed while a generation is in flight: a completion line naming a cancellation means it fails cleanly; **no completion line at all** means the process was killed with the call in flight. |
+
+Honest limit, stated in advance: the probe can establish what happens to an in-flight `respond()` in the extension. It **cannot** establish "whether the raw transcription still reaches the document", because that is a property of an architecture that does not exist yet — today the app owns the call and the insertion. That half of Q4 is a design question for the follow-up issue, not a measurement available here.
+
+---
+
+## The probe
+
+### What it is
+
+A new file, `DictusKeyboard/AppleFMExtensionProbe.swift`. Throwaway diagnostic code, marked as such, following the precedent of `DictusKeyboard/KeyboardLifecycleProbe.swift` (the #281 probe): observation only, no control flow depends on it.
+
+It runs the **real** engine — `AppleFoundationModelsPolishEngine` from DictusCore, the shipping prompts, the real session lifecycle — on a **fixed synthetic French string**. Using the production engine is what makes the measurement transferable: it prices exactly what a future implementation would pay. Using a fixed string rather than the user's text keeps user speech out of a log that gets exported and mailed.
+
+### Why it is safe to leave on this branch
+
+The branch may sit for a while, so the bar is that a normal dictation must be bit-identical whether this file exists or not.
+
+- **Inert by default.** It is armed by an App Group boolean that defaults to false. Disarmed, the probe's entire cost is one `UserDefaults` bool read, once per keyboard appearance — not per keystroke, not on the dictation path.
+- **One-shot.** Arming is consumed on the first run, so a forgotten flag cannot turn into a probe that fires on every keyboard appearance.
+- **No allocation on the normal path.** The session, the strings and the engine are constructed only inside the armed branch. This matters because the keyboard runs under a hard memory ceiling and a `didReceiveMemoryWarning` storm is a known hazard in this codebase.
+- **One line at one existing call site.** `KeyboardRootView.onAppear`. Deliberately **not** `KeyboardViewController.swift`, `KeyboardLayouts.swift` or `Vendored/Views/KeyboardView.swift` — PR #354 is open against all three.
+- **No new `LogEvent` case.** It reports through the existing `.diagnosticProbe(component:instanceID:action:details:)` event, so `DictusCore` is untouched and nothing has to be kept decoding later.
+
+### Arming surface
+
+A toggle on `PolishDebugView` — the hidden screen already reached by long-pressing the Version row in Settings for 3 seconds, and already the screen the maintainer uses to export polish data. No new navigation, and nothing reachable by an ordinary user.
+
+### What it records
+
+One line when armed and starting, one line on completion or failure, carrying:
+
+- `availability` — `SystemLanguageModel.default.availability` as seen **from inside the extension** (Q1b)
+- `outcome` — success, or the `PolishFailureReason` slug via the engine's existing `failureReason(for:)` mapping (Q2: `rateLimited` or not)
+- `engineMs` — the arming signature from #315 is that the first refusal is slow (52–436 ms) and everything after returns in 4–9 ms
+- `memBefore` / `memAfter` / `memPeak` in MB via the existing `MemoryFootprint` (Q3)
+- a run token shared by the start and completion lines (Q4)
+
+No generated text and no input text is logged — only its length.
+
+---
+
+## The device procedure
+
+Written out in full in the findings section and in the PR body. Its shape:
+
+1. Arm nothing yet. Drive DictusApp into the refusing state using the recipe measured twice on 2026-08-13: polish on, one ordinary dictation every one to two minutes for roughly twenty-five minutes.
+2. Confirm the refusal is real and current, from the app's own polish debug screen.
+3. Arm the probe, then bring the keyboard up. The probe fires on appearance.
+4. Export the persistent log and send it.
+
+Step 2 is the one that must not be skipped: it is what separates a decisive Q2 answer from an inconclusive one.
+
+---
+
+## What this spike will not do
+
+- It will not move the polish call. #357 says so explicitly, and the move is a significant architectural change — the polish pipeline, its guardrails, the metrics ring and the debug export all live app-side today. It needs its own issue and its own plan.
+- It will not report an app-target measurement as an extension result.
+- It will not label anything **[device]** that was not measured on the device.

--- a/docs/research/357-keyboard-extension-apple-fm.md
+++ b/docs/research/357-keyboard-extension-apple-fm.md
@@ -83,11 +83,22 @@ The question the whole issue turns on.
 
 | | Criterion |
 | --- | --- |
-| **YES** | While DictusApp is **demonstrably** in the refusing state, a probe generation issued from the extension **succeeds**. Decisive. |
-| **NO** | The probe generation throws `rateLimited` in the same window. Also decisive, and it is the answer that re-ranks [#351](https://github.com/getdictus/dictus-ios/issues/351) onto the Dictus Pro critical path. |
+| **YES** | While DictusApp is **demonstrably** in the refusing state, a **burst of ten** generations issued from the extension succeeds with no `rateLimited`. |
+| **NO** | The burst starts returning `rateLimited` partway through, in the same window. |
 | **INCONCLUSIVE** | The app is not actually refusing at the moment the probe runs. |
 
-The inconclusive row is the trap, and the procedure is built around avoiding it: **the app's refusal must be pinned in the same log window as the probe's result**, not assumed from "I did a lot of dictations". A probe success against an app that was quietly serving requests again proves nothing.
+Two traps, and the design is built around both.
+
+**The first is the confound that makes a single call worthless.** #315 established the budget is **per process** and only a fresh process resets it. The keyboard extension is a *different process* from DictusApp, so one successful call from it has two explanations that a single result cannot separate:
+
+1. the extension counts as foreground and is never limited — the hypothesis; or
+2. the extension is simply a fresh process whose background budget has never been spent, and it would have succeeded either way.
+
+Under (2) the problem is **not solved, only relocated**: the extension would deplete its own budget with use and start refusing exactly as the app does, and a design built on a single green result would ship straight into it. A burst inside one process lifetime separates them, because (2) predicts refusals appearing partway through and (1) predicts none.
+
+The asymmetry is worth stating in advance: a burst that survives is strong evidence for (1), because a backgrounded app gets refused under far lighter load than ten back-to-back calls. A burst that fails is weaker evidence for (2) — it could be specific to the density — and would need the slower once-a-minute protocol before concluding.
+
+**The second is the inconclusive row.** The app's refusal must be pinned in the same log window as the probe's result, not assumed from "I did a lot of dictations". A probe success against an app that had quietly started serving requests again proves nothing.
 
 ### Q3 — What does a `LanguageModelSession` cost inside the extension's budget?
 
@@ -132,13 +143,15 @@ A toggle on `PolishDebugView` — the hidden screen already reached by long-pres
 
 ### What it records
 
-One line when armed and starting, one line on completion or failure, carrying:
+A `started` line, one `call` line per generation in the burst, and a `finished` line, all sharing one run token so a whole run greps out together. Between them they carry:
 
 - `availability` — `SystemLanguageModel.default.availability` as seen **from inside the extension** (Q1b)
-- `outcome` — success, or the `PolishFailureReason` slug via the engine's existing `failureReason(for:)` mapping (Q2: `rateLimited` or not)
-- `engineMs` — the arming signature from #315 is that the first refusal is slow (52–436 ms) and everything after returns in 4–9 ms
-- `memBefore` / `memAfter` / `memPeak` in MB via the existing `MemoryFootprint` (Q3)
-- a run token shared by the start and completion lines (Q4)
+- `outcome` per call — success, or the `PolishFailureReason` slug via the engine's existing `failureReason(for:)` mapping (Q2: `rateLimited` or not)
+- `engineMs` per call — the arming signature from #315 is that the first refusal is slow (52–436 ms) and everything after returns in 4–9 ms, so the *shape* of a refusal run is as diagnostic as the slug
+- `memMB` per call plus `memPeakMB` from a 25 ms sampler, and `memBefore` / `memAfter`, all via the existing `MemoryFootprint` (Q3)
+- the run token, shared by every line (Q4)
+
+Every line is flushed as it is written. Under Q3's bad outcome the process is jetsam-killed partway through the burst, and the last line to reach disk is the only evidence of how far it got.
 
 No generated text and no input text is logged — only its length.
 


### PR DESCRIPTION
Spike for #357. **A measurement, not an implementation.** No feature work; the polish call has not moved. Follow-up work is #361.

## What this was for

Your flagship paid feature runs on an engine that refuses to work whenever DictusApp is backgrounded, which is always. #315 established that with Apple's own wording and then with your controlled device test on 2026-08-13: `rateLimited` is a per-call decision applied to backgrounded processes, a foreground visit does not refund the budget, and only a fresh process resets it.

The keyboard extension is in the foreground at exactly the moment polish would run. Two objections had killed the idea in #315, both assumed rather than measured. **Both are now disproved.**

## What was found

You ran the probe on 2026-08-14. **The keyboard extension is served while the app is refused.**

```text
07:28:52  <APP>  polishEngineFailed  rateLimited  engineMs=10     <-- app refusing, appState=2
07:29:06  <KBD>  n=1/10   success  engineMs=4414
   …                                                              <-- ten seconds later
07:29:50  <KBD>  n=10/10  success  engineMs=4825                  <-- no degradation
          memBefore 15 MB → memPeak 22 MB → memAfter 19 MB
```

| | Question | Answer |
| --- | --- | --- |
| **Q1a** | Usable from an app extension, statically? | **Yes.** Compiles and links under a compiler setting proven to reject extension-unsafe API. Apple documents no prohibition. |
| **Q1b** | Works at runtime inside the extension? | **Yes.** `availability=available` read from inside the extension process; ten real generations. |
| **Q2** | Does the extension count as foreground for the limiter? | **Yes.** Ten of ten, zero refusals, with the app's refusal pinned in the same log window. |
| **Q3** | Memory cost? | **7 MB peak delta**, flat across ten calls, no kill. **Measured on an idle keyboard — caveat below.** |
| **Q4** | Teardown mid-generation? | **Still not measured.** |

Apple's "your app is running in the background" is applied to **the process making the call**, and a keyboard extension holding the screen is not that. Moving the polish call there does not work around the limit — it stops meeting it.

**No latency penalty:** 4.4–5.1 s on 462 characters, against the app's 485 chars / 4231 ms and 622 chars / 4501 ms on the same export. And it is the pessimistic figure — the extension neither prewarms nor reuses a session.

The falsifiable-criteria section is left **exactly** as committed in `de3b2fb` before any measurement, and scored against verbatim. That is what makes the findings checkable rather than self-graded.

## Two things I am deliberately not letting slide

**The memory number was taken at the wrong moment.** `memBefore` was **15 MB — an idle keyboard**, no dictation, no overlay, no waveform. During a real dictation the extension carries its full working set, which this project's notes put near **60 MB against a ceiling in the same region**. **7 MB of headroom at 15 MB says nothing about 7 MB at 55 MB.** The result is not wrong, it is narrow, and reading it as "the call is cheap, ship it" is the mistake this report exists to prevent. This is now the top open risk on #361, and the first thing it should re-measure.

**Q2 is strong, not airtight.** Ten calls against an app-side latch threshold of roughly a dozen. What backs it independently: iOS tears down and recreates keyboard extensions constantly during normal use, so even a per-extension budget would be reset by ordinary use rather than accumulating over a working session — and accumulation is precisely what makes this a problem in the app. A 20-call burst would settle it outright.

**Q4 was skipped** and is recorded as open, not inferred. It matters more after the move than before it, since today the app owns the call and survives the keyboard going away.

## One claim moves the other way

#357's body asserted that Apple FM inference does not run in the calling process. My pre-run report **declined to assert it**, because no Apple documentation says so. The 7 MB delta for ten generations of a multi-billion-parameter model now supports it. Recorded as measured — and as having been unsupported when it was made.

## Why the probe should stay on `develop`

Diagnostic code landing on `develop` deserves a reason, so the report argues it explicitly.

**#361 needs exactly two more measurements** — memory at a realistic working set, and a 20-call burst — and this probe is the instrument for both. Both are one-line changes to it. Deleting it now means rewriting it in a fortnight, rediscovering the same design constraints and re-reviewing it.

It is **inert by default** (App Group bool defaulting to false; disarmed, the cost is one `Bool` read per keyboard appearance, nothing allocated on the dictation path), **one-shot**, and **not user-reachable** — the only arming surface is a toggle on the debug screen behind a three-second long-press on the Version row. The device run exercised it end to end with no kill, no memory warning, and no effect on the keyboard.

Marked "delete with the spike" in the source, with issue-tied pbxproj IDs (`AA357001` / `AA357002`) so removal is mechanical. **Delete when #361's two measurements are taken**, not before.

## Recommendation

1. **Do not move #351 or #268 onto the Pro critical path.** Decision 15 suspended decision 6 on this measurement; it came back yes. Apple FM is viable for #79 Smart Modes, from the extension.
2. **Re-measure memory before committing to #361.** The one result that could still reverse the decision.
3. **Take Q4 early in #361**, not late — the durability design depends on it.
4. **Keep #315's decision 14 shipping regardless.** It is the fallback while #361 is built, and it covers `guardrailViolation` and the other non-`rateLimited` reasons the move does not address.

## Verification

- `xcodebuild` — `DictusApp`, `DictusKeyboard`, `DictusCore`, device SDK. **BUILD SUCCEEDED**
- `cd DictusCore && swift test` — **920 tests, 0 failures** (CI does not run these)
- `swiftlint lint --strict` — **0 violations in 178 files**
- No `Localizable.xcstrings` churn committed; no version or build number touched.

Report: `docs/research/357-keyboard-extension-apple-fm.md`. Probe: `DictusKeyboard/AppleFMExtensionProbe.swift`.

Merge, never squash. `refs #357` — close by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014epcyo5E8D3KvuXQmZnWA4
