### PR TITLE
Re-assert and instrument the system-haptics allowance (refs #293)

### DIFF
--- a/DictusApp/Audio/UnifiedAudioEngine.swift
+++ b/DictusApp/Audio/UnifiedAudioEngine.swift
@@ -87,6 +87,18 @@ class UnifiedAudioEngine: ObservableObject {
     /// Current accumulated sample count (for zombie engine health check).
     var currentSampleCount: Int { audioSamples.count }
 
+    /// What AVAudioSession actually reports for the system-haptics allowance.
+    ///
+    /// WHY this is read rather than tracked: `setAllowHapticsAndSystemSoundsDuringRecording`
+    /// is a request, not an assignment — the session is free to report something
+    /// else, and the SDK documents the default as NO. When this is false while we
+    /// hold an active session, iOS mutes system haptics device-wide: every
+    /// keyboard including Apple's stops tapping, in every app, for as long as the
+    /// session lives (issue #293).
+    var allowsHapticsDuringRecording: Bool {
+        AVAudioSession.sharedInstance().allowHapticsAndSystemSoundsDuringRecording
+    }
+
     // MARK: - Private
 
     private var engine = AVAudioEngine()
@@ -117,7 +129,12 @@ class UnifiedAudioEngine: ObservableObject {
     /// Whether the audio session has been configured at least once.
     /// WHY: iOS forbids changing AVAudioSession category from background.
     /// We configure once and keep the category set forever.
-    private var sessionConfigured = false
+    ///
+    /// WHY `private(set)` rather than `private` (#293): the `engineStateSnapshot`
+    /// diagnostic used to pass a hardcoded `true` for this field, so every
+    /// `sessionConfigured=true` in a device log was a literal, not a measurement.
+    /// The snapshot now reads the real value.
+    private(set) var sessionConfigured = false
 
     /// True when an AVAudioSession interruption is currently in flight.
     ///
@@ -327,6 +344,7 @@ class UnifiedAudioEngine: ObservableObject {
             engine.stop()
 
             PersistentLog.log(.audioInterruptionBegan(reason: reason))
+            logHapticsAllowance(context: "interruptionBegan")
 
             // Notify in-process listeners (LiveActivityManager, DictationCoordinator)
             // immediately. Darwin notification mirrors for cross-process consumers
@@ -391,6 +409,7 @@ class UnifiedAudioEngine: ObservableObject {
     /// before any future start() call.
     private func handleMediaServicesReset() {
         PersistentLog.log(.audioMediaServicesReset)
+        logHapticsAllowance(context: "mediaServicesReset")
 
         cancelIdleRelease()
         engine.inputNode.removeTap(onBus: 0)
@@ -438,10 +457,52 @@ class UnifiedAudioEngine: ObservableObject {
             try session.setCategory(.playAndRecord, options: [.allowBluetoothA2DP, .defaultToSpeaker, .duckOthers])
         }
         try session.setActive(true)
-        try? session.setAllowHapticsAndSystemSoundsDuringRecording(true)
         sessionConfigured = true
 
         PersistentLog.log(.audioSessionConfigured(category: "playAndRecord"))
+        applyHapticsAllowance(context: "configureAudioSession")
+    }
+
+    // MARK: - System Haptics Allowance (issue #293)
+
+    /// Ask the session to keep system haptics and system sounds alive while we
+    /// hold audio input, then log what it actually reports back.
+    ///
+    /// WHY this is called from every activation path rather than once in
+    /// `configureAudioSession()`: the allowance defaults to NO and belongs to the
+    /// session, not to us. Any path that reaches an active session without
+    /// passing through `configureAudioSession()` — `warmUp()` short-circuiting on
+    /// an already-running engine, `startRecording()` on a warm engine, a
+    /// `startEngine()` that implicitly reactivated the session — would leave it
+    /// unset, and a single such path is enough to mute the whole device.
+    /// Re-asserting is one setter call; not re-asserting is a device-wide bug the
+    /// user cannot attribute to us.
+    ///
+    /// WHY the throw is logged instead of `try?`: before #293 this was a bare
+    /// `try?`, which made a failed call and a successful one produce exactly the
+    /// same (empty) evidence. Three investigations ran blind on that.
+    private func applyHapticsAllowance(context: String) {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setAllowHapticsAndSystemSoundsDuringRecording(true)
+        } catch {
+            PersistentLog.log(.audioHapticsAllowanceFailed(
+                context: context,
+                error: error.localizedDescription
+            ))
+        }
+        logHapticsAllowance(context: context)
+    }
+
+    /// Log the session's current haptics allowance without touching it. Used on
+    /// the teardown paths, where re-asserting would be meaningless — but where
+    /// the value still matters, because "haptics came back" is the observation
+    /// the user reports and this is the line that dates it.
+    private func logHapticsAllowance(context: String) {
+        PersistentLog.log(.audioHapticsAllowance(
+            context: context,
+            allowed: AVAudioSession.sharedInstance().allowHapticsAndSystemSoundsDuringRecording
+        ))
     }
 
     /// Check and request microphone permission if needed.
@@ -484,13 +545,17 @@ class UnifiedAudioEngine: ObservableObject {
 
         guard !engine.isRunning else {
             PersistentLog.log(.engineWarmUpSuccess(context: "already running"))
+            // This short circuit never reaches `startEngine()`, so it is one of
+            // the paths that would otherwise leave the allowance untouched
+            // (issue #293).
+            applyHapticsAllowance(context: "warmUp-alreadyRunning")
             // Re-arm before returning. `cancelIdleRelease()` above dropped
             // whatever was pending, and leaving without re-arming is how the
             // engine used to end up warm forever.
             scheduleIdleRelease(after: Self.warmUpIdleReleaseInterval)
             return
         }
-        try startEngine()
+        try startEngine(context: "warmUp")
         PersistentLog.log(.engineWarmUpSuccess(context: "unifiedEngine-warmUp"))
 
         // NOT in a `defer`: on a `startEngine()` throw we are not warm, and
@@ -506,12 +571,19 @@ class UnifiedAudioEngine: ObservableObject {
         cancelIdleRelease()
 
         if !engine.isRunning {
-            try startEngine()
+            try startEngine(context: "startRecording")
         }
         purgeState()
         isRecording = true
         isRecordingFlag = true
+
         PersistentLog.log(.audioEngineStarted)
+
+        // A warm engine skips `startEngine()` entirely, so this is the second
+        // path that would otherwise never re-assert the allowance — and it is the
+        // one that matters most, because it is the moment iOS starts treating us
+        // as actively recording (issue #293).
+        applyHapticsAllowance(context: "startRecording")
     }
 
     /// Collect recorded samples WITHOUT stopping the engine.
@@ -583,6 +655,7 @@ class UnifiedAudioEngine: ObservableObject {
         PersistentLog.log(.audioEngineStopped)
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
         sessionConfigured = false
+        logHapticsAllowance(context: "deactivateSession")
 
         bufferEnergy = []
         bufferSeconds = 0
@@ -599,7 +672,7 @@ class UnifiedAudioEngine: ObservableObject {
 
         do {
             try configureAudioSession()
-            try startEngine()
+            try startEngine(context: "forceRestart")
             PersistentLog.log(.engineWarmUpSuccess(context: "forceRestart"))
         } catch {
             PersistentLog.log(.engineWarmUpFailed(context: "forceRestart", error: error.localizedDescription))
@@ -717,6 +790,11 @@ class UnifiedAudioEngine: ObservableObject {
         idleReleaseWorkItem = nil
 
         PersistentLog.log(.warmStateReleased(idleSeconds: idleSeconds))
+
+        // The user-visible claim of #293 is "haptics came back on their own about
+        // ten minutes later". This line is what dates the other end of that
+        // window against the release that supposedly caused it.
+        logHapticsAllowance(context: "releaseWarmState-\(reason)")
         if #available(iOS 14.0, *) {
             DictusLogger.app.info("Warm state released after \(idleSeconds, privacy: .public)s idle (reason: \(reason, privacy: .public))")
         }
@@ -728,7 +806,11 @@ class UnifiedAudioEngine: ObservableObject {
     // MARK: - Private Helpers
 
     /// Start the AVAudioEngine with a tap on the input node.
-    private func startEngine() throws {
+    ///
+    /// - Parameter context: names the path that started the engine, so the
+    ///   haptics-allowance line emitted on success says which one it came from
+    ///   (issue #293).
+    private func startEngine(context: String) throws {
         audioSamples = []
         audioThreadEnergy = []
         audioThreadWaveformBins = []
@@ -840,6 +922,14 @@ class UnifiedAudioEngine: ObservableObject {
         // .ended interruption resume) ends up healthy without each caller having
         // to remember to flip the flag.
         isInterrupted = false
+
+        // Re-assert the system-haptics allowance now that the session is truly
+        // carrying input. `configureAudioSession()` sets it before the engine
+        // exists, and `startEngine()` is reachable without it — after a
+        // `releaseWarmState()` deactivation, or when `engine.start()` reactivates
+        // the session implicitly. This is the funnel every start path goes
+        // through (issue #293).
+        applyHapticsAllowance(context: "startEngine-\(context)")
 
         if #available(iOS 14.0, *) {
             DictusLogger.app.info("UnifiedAudioEngine started (hw: \(hwFormat.sampleRate, privacy: .public)Hz -> 16kHz)")

--- a/DictusApp/DictationCoordinator.swift
+++ b/DictusApp/DictationCoordinator.swift
@@ -255,11 +255,16 @@ class DictationCoordinator: ObservableObject {
         ) { [weak self] _ in
             guard let self else { return }
             Task { @MainActor in
+                // `sessionConfigured` used to be a hardcoded `true` here, so
+                // every `sessionConfigured=true` in a device log was a literal
+                // rather than a measurement — including the one quoted as
+                // evidence in #293. Both fields are now read from the engine.
                 PersistentLog.log(.engineStateSnapshot(
                     engineRunning: self.audioEngine.isEngineRunning,
                     isRecording: self.audioEngine.isRecording,
                     hasWhisperKit: self.whisperKit != nil,
-                    sessionConfigured: true,
+                    sessionConfigured: self.audioEngine.sessionConfigured,
+                    allowsHaptics: self.audioEngine.allowsHapticsDuringRecording,
                     context: "didBecomeActive"
                 ))
 

--- a/DictusCore/Sources/DictusCore/LogEvent.swift
+++ b/DictusCore/Sources/DictusCore/LogEvent.swift
@@ -62,6 +62,18 @@ public enum LogEvent: Sendable {
     case audioMediaServicesReset
     case warmStateReleased(idleSeconds: Int)
     case warmStateRestored(context: String)
+    /// The value `AVAudioSession` actually reports for
+    /// `allowHapticsAndSystemSoundsDuringRecording` after a session transition
+    /// (#293). `allowed=false` while the session is active is the bug itself:
+    /// iOS then mutes system haptics device-wide, on every keyboard including
+    /// Apple's, for as long as we hold the session. Emitted on every path that
+    /// activates or tears down the session so a regression shows up in the log
+    /// instead of being inferred from timing.
+    case audioHapticsAllowance(context: String, allowed: Bool)
+    /// `setAllowHapticsAndSystemSoundsDuringRecording` threw. Before #293 this
+    /// call site was a bare `try?`, so a failure was indistinguishable from a
+    /// success.
+    case audioHapticsAllowanceFailed(context: String, error: String)
 
     // MARK: Transcription
     case transcriptionStarted(modelName: String)
@@ -145,7 +157,7 @@ public enum LogEvent: Sendable {
     case engineWarmUpAttempt(context: String)
     case engineWarmUpSuccess(context: String)
     case engineWarmUpFailed(context: String, error: String)
-    case engineStateSnapshot(engineRunning: Bool, isRecording: Bool, hasWhisperKit: Bool, sessionConfigured: Bool, context: String)
+    case engineStateSnapshot(engineRunning: Bool, isRecording: Bool, hasWhisperKit: Bool, sessionConfigured: Bool, allowsHaptics: Bool, context: String)
     case engineCollectResult(sampleCount: Int, engineRunning: Bool)
     case engineDarwinStartReceived(appState: String, engineRunning: Bool)
 
@@ -247,7 +259,8 @@ public enum LogEvent: Sendable {
             return .dictation
         case .audioEngineStarted, .audioEngineStopped, .audioSessionConfigured, .audioSessionFailed,
              .audioInterruptionBegan, .audioInterruptionEnded, .audioRouteChanged,
-             .audioMediaServicesReset, .warmStateReleased, .warmStateRestored:
+             .audioMediaServicesReset, .warmStateReleased, .warmStateRestored,
+             .audioHapticsAllowance, .audioHapticsAllowanceFailed:
             return .audio
         case .transcriptionStarted, .transcriptionCompleted, .transcriptionFailed, .recordingTooShort,
              .transcriptionPerformance:
@@ -322,7 +335,7 @@ public enum LogEvent: Sendable {
              .waveformStall, .waveformTimelineNotFiring,
              .coldStartDarwinFallback, .coldStartStranded, .modelPrewarmTimeout,
              .audioInterruptionBegan, .audioMediaServicesReset,
-             .modelDownloadStalled:
+             .modelDownloadStalled, .audioHapticsAllowanceFailed:
             return .warning
 
         // Info (normal operations: starts, completes, selections, configs)
@@ -347,7 +360,7 @@ public enum LogEvent: Sendable {
              .waveformAppeared, .waveformDisappeared, .waveformRefreshIDChanged,
              .waveformEnergyTransition, .overlayBodyEvaluated, .overlayRecreated,
              .audioInterruptionEnded, .audioRouteChanged,
-             .warmStateReleased, .warmStateRestored,
+             .warmStateReleased, .warmStateRestored, .audioHapticsAllowance,
              .userDictionaryEvicted, .userDictionaryReset, .userDictionaryMigrated,
              .userDictionaryStaleDiscarded, .userDictionaryPruned:
             return .info
@@ -396,6 +409,8 @@ public enum LogEvent: Sendable {
         case .audioMediaServicesReset: return "audioMediaServicesReset"
         case .warmStateReleased: return "warmStateReleased"
         case .warmStateRestored: return "warmStateRestored"
+        case .audioHapticsAllowance: return "audioHapticsAllowance"
+        case .audioHapticsAllowanceFailed: return "audioHapticsAllowanceFailed"
         case .transcriptionStarted: return "transcriptionStarted"
         case .transcriptionCompleted: return "transcriptionCompleted"
         case .transcriptionFailed: return "transcriptionFailed"
@@ -519,6 +534,10 @@ public enum LogEvent: Sendable {
             return "idleSeconds=\(idleSeconds)"
         case .warmStateRestored(let context):
             return "context=\(context)"
+        case .audioHapticsAllowance(let context, let allowed):
+            return "context=\(context) allowed=\(allowed)"
+        case .audioHapticsAllowanceFailed(let context, let error):
+            return "context=\(context) error=\(error)"
 
         // Transcription
         case .transcriptionStarted(let modelName):
@@ -570,8 +589,8 @@ public enum LogEvent: Sendable {
             return "context=\(context)"
         case .engineWarmUpFailed(let context, let error):
             return "context=\(context) error=\(error)"
-        case .engineStateSnapshot(let engineRunning, let isRecording, let hasWhisperKit, let sessionConfigured, let context):
-            return "engineRunning=\(engineRunning) isRecording=\(isRecording) hasWhisperKit=\(hasWhisperKit) sessionConfigured=\(sessionConfigured) context=\(context)"
+        case .engineStateSnapshot(let engineRunning, let isRecording, let hasWhisperKit, let sessionConfigured, let allowsHaptics, let context):
+            return "engineRunning=\(engineRunning) isRecording=\(isRecording) hasWhisperKit=\(hasWhisperKit) sessionConfigured=\(sessionConfigured) allowsHaptics=\(allowsHaptics) context=\(context)"
         case .engineCollectResult(let sampleCount, let engineRunning):
             return "sampleCount=\(sampleCount) engineRunning=\(engineRunning)"
         case .engineDarwinStartReceived(let appState, let engineRunning):

--- a/DictusCore/Tests/DictusCoreTests/LogEventTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/LogEventTests.swift
@@ -199,6 +199,55 @@ final class LogEventTests: XCTestCase {
         XCTAssertEqual(event.subsystem, .audio)
     }
 
+    // MARK: - Haptics allowance (issue #293)
+
+    func testHapticsAllowanceIsInfoAudio() {
+        let event = LogEvent.audioHapticsAllowance(context: "startRecording", allowed: true)
+        XCTAssertEqual(event.level, .info)
+        XCTAssertEqual(event.subsystem, .audio)
+        XCTAssertEqual(event.name, "audioHapticsAllowance")
+    }
+
+    /// The value is the whole point of the line: `allowed=false` while the
+    /// session is active is the device-wide haptics mute (#293). It must be
+    /// greppable verbatim, not encoded in the event's presence.
+    func testHapticsAllowanceCarriesTheEffectiveValue() {
+        let denied = LogEvent.audioHapticsAllowance(context: "warmUp-alreadyRunning", allowed: false)
+        XCTAssertEqual(denied.message, "context=warmUp-alreadyRunning allowed=false")
+
+        let granted = LogEvent.audioHapticsAllowance(context: "configureAudioSession", allowed: true)
+        XCTAssertEqual(granted.message, "context=configureAudioSession allowed=true")
+    }
+
+    /// Before #293 the setter was a bare `try?`, so a throw produced the same
+    /// (empty) evidence as a success. A failure now has its own level.
+    func testHapticsAllowanceFailedIsWarningAudio() {
+        let event = LogEvent.audioHapticsAllowanceFailed(context: "startEngine-warmUp", error: "boom")
+        XCTAssertEqual(event.level, .warning)
+        XCTAssertEqual(event.subsystem, .audio)
+        XCTAssertEqual(event.name, "audioHapticsAllowanceFailed")
+        XCTAssertEqual(event.message, "context=startEngine-warmUp error=boom")
+    }
+
+    /// The snapshot is the periodic line a reader scans; #293 added the
+    /// allowance to it so a regression is visible without correlating two events.
+    func testEngineStateSnapshotReportsHapticsAllowance() {
+        let event = LogEvent.engineStateSnapshot(
+            engineRunning: true,
+            isRecording: false,
+            hasWhisperKit: true,
+            sessionConfigured: true,
+            allowsHaptics: false,
+            context: "didBecomeActive"
+        )
+        XCTAssertEqual(event.subsystem, .audio)
+        XCTAssertEqual(
+            event.message,
+            "engineRunning=true isRecording=false hasWhisperKit=true "
+                + "sessionConfigured=true allowsHaptics=false context=didBecomeActive"
+        )
+    }
+
     // MARK: - Transcription events
 
     func testTranscriptionStartedIsInfoTranscription() {


### PR DESCRIPTION
## What this was for

After a dictation, keyboard haptics stopped working **on the whole device** — on every keyboard including Apple's, in apps that have nothing to do with Dictus — and came back on their own roughly ten minutes later. You hit it during the #266 device validation, and again on build 26.

iOS mutes system haptics while an app holds an active recording session. The one exception is `setAllowHapticsAndSystemSoundsDuringRecording(true)`, which Dictus does call — once, in `configureAudioSession()`, behind a `try?`. Because the engine is deliberately kept warm for ten minutes past the last dictation, the window where that allowance matters is not the length of a dictation: it is ten minutes past the last one.

The issue was closed once and reopened, and the last comment said why every investigation had stalled: a 4871-line debug export contained **zero** haptic-related lines. Nobody could tell whether the API call had succeeded, whether the allowance was true at the moment haptics went missing, or whether the session was even active — `try?` swallowed the throw, and nothing ever read the value back.

So this PR does two things: it makes the allowance **visible in the log**, and it makes sure **no path can leave it unset**.

## To test by hand

Everything below needs a physical device: nothing in a build, a test, or a simulator can observe system haptics. Keyboard haptics must be ON in iOS Settings → Sounds & Haptics → Keyboard Feedback → Haptic.

1. Install this branch on the iPhone. Open Dictus once so the engine warms up, then go to the Home screen.
2. Open **Notes** (or any app that is not Dictus) and type a few characters on **Apple's** keyboard. → You should feel a tap on each key. This is the baseline; if it is already dead here, stop and say so — something else is going on.
3. Switch to the Dictus keyboard and dictate a short sentence. Wait for the text to be inserted.
4. **Immediately** switch back to Apple's keyboard, still in the same app, and type a few characters. → Every key should tap. (Criterion 1 + 2. The engine is still warm at this point, which is exactly the state the bug lives in.)
5. Start a dictation and, **while it is recording**, type on the keyboard. → Keys should still tap during the recording. (Criterion 3.)
6. Wait about 30 seconds, dictate a second time, and repeat step 4. → Still tapping.
7. Leave the phone alone for a bit more than **10 minutes** without dictating, then type again. → Still tapping. (The engine releases itself in that window; nothing should change either way.)
8. If at any point haptics do disappear: **force-quit DictusApp** and type again straight away. If haptics come back on the spot, Dictus is the cause — that is the control the issue asked for. Export the debug log before doing anything else.
9. Export the debug log (Settings → Debug log) and look for `audioHapticsAllowance`. Expect a line after each session transition, and expect `allowed=true` on all of them. Any `allowed=false`, or any `audioHapticsAllowanceFailed`, is the bug caught red-handed — that is what this instrumentation is for.
10. Sanity check that nothing got slower: the first dictation after opening the app should feel the same as before (the fix adds one setter + one getter per transition, nothing per audio buffer).

Also worth a glance while you are on the device, since it touches the same file: dictation still works cold (app killed), warm, and after a phone call interrupts it.

## What changed and why

**`DictusCore/Sources/DictusCore/LogEvent.swift`** — two new events plus one extended:

- `audioHapticsAllowance(context:allowed:)` — the value **the session reports back**, not the one we asked for. The setter is a request and the SDK header documents the default as `NO`, so the read-back is the only thing worth writing down.
- `audioHapticsAllowanceFailed(context:error:)` — the throw, which the bare `try?` used to swallow. A failed call and a successful one produced identical (empty) evidence.
- `engineStateSnapshot` gains `allowsHaptics`. It is the line a reader already scans, so a regression shows up there without correlating two events.

**`DictusApp/Audio/UnifiedAudioEngine.swift`** — the allowance is now re-asserted on every path that reaches an active session, and logged on every path that leaves one.

Three activation paths existed that never touched it:

| Path | Why it was uncovered |
|---|---|
| `startEngine()` | reachable after a `releaseWarmState()` deactivation, and when `engine.start()` reactivates the session implicitly |
| `warmUp()` short-circuit | returns early when the engine is already running, never reaching `startEngine()` |
| `startRecording()` on a warm engine | skips `startEngine()` — and this is the moment iOS starts treating us as actively recording |

`forceRestart()` and the zombie-recovery path are covered transitively, through `configureAudioSession()` + `startEngine()`. The teardown paths (`releaseWarmState`, `deactivateSession`, interruption `.began`, media-services reset) log the value without re-asserting it — "haptics came back on their own" is the observation you reported, and these are the lines that date the other end of that window.

**`DictusApp/DictationCoordinator.swift`** — `engineStateSnapshot` was passing a **hardcoded `true`** for `sessionConfigured`. Every `sessionConfigured=true` in a device log was a literal, not a measurement — including the one quoted as evidence in the issue body. It now reads the engine.

### What this deliberately does not do

The issue body's mechanism was that the call must come **after** `engine.start()` (a WhisperKit-era lesson). Your own controlled test on 2026-08-03 refuted that: with the session active and the engine running, haptics worked. So the existing call **stays where it is**; this adds coverage around it rather than moving it, and cannot regress the path that test proved good.

Untouched, per the brief: the warm-engine strategy and the 10-minute idle release, and the audio session category and its options (#85).

## Acceptance criteria

| Criterion | Status | Evidence |
|---|---|---|
| Haptics in a third-party app right after a dictation, engine warm | **Not verified — device only** | No build or test can observe system haptics. Manual steps 3-4. |
| Haptics on Apple's keyboard in the same state | **Not verified — device only** | Manual steps 3-4. |
| Haptics *during* a Dictus recording | **Not verified — device only** | Manual step 5. |
| The allowance survives `forceRestart` and zombie recovery | **Code-verified, not exercised at runtime** | Both funnel through `configureAudioSession()` + `startEngine(context:)`, which now apply it. Neither path can be triggered in a simulator (no touch injection, no recording). |
| A device log states the allowance's actual value after each session transition | **Verified headlessly** | Built, installed and launched on iPhone 17 Pro Max (iOS 26.5). `dictus_debug.log` now carries `audioHapticsAllowance context=configureAudioSession allowed=true`, `context=startEngine-warmUp allowed=true`, `context=warmUp-alreadyRunning allowed=true`, and `engineStateSnapshot … sessionConfigured=true allowsHaptics=true context=didBecomeActive`. The same file's pre-change lines have no allowance at all — the before/after sits side by side. The 10-minute teardown was also observed: `warmStateReleased idleSeconds=629` followed by `audioHapticsAllowance context=releaseWarmState-idleTimeout allowed=true`. |
| Warm-up latency unchanged | **Verified by diff** | No change to `idleReleaseInterval`, `scheduleIdleRelease`, `releaseWarmState` timing or teardown order. The added work is one setter + one getter per session transition, none of it per audio buffer. |

### One caveat on reading these lines

On the simulator, the read-back still says `allowed=true` **after** `setActive(false)` — the session keeps reporting its configured flag once deactivated, rather than reporting whether haptics are actually suppressed right now.

So read the instrumentation asymmetrically: **`allowed=false` while we hold the session is a definite smoking gun**, and `audioHapticsAllowanceFailed` is proof the API call itself failed. But `allowed=true` does not by itself prove haptics are working — it proves the flag is set, which is the part we control. That is still strictly more than the log said before (nothing), and it is exactly what the reopen criterion needed: it tells you whether the API call landed at the moment of the loss, instead of leaving you to infer it from timing.

### Commands run

```
cd DictusCore && swift test          → 977 tests, 0 failures
swiftlint lint --strict              → 0 violations, 0 serious in 183 files
xcodebuild build -scheme DictusApp   → ** BUILD SUCCEEDED **   (iOS Simulator, iPhone 17 Pro Max)
xcrun simctl install / launch        → log lines above
```

refs #293
