### PR TITLE
D2: the backgrounded ANE reaches the LLM, and still misses the budget (refs #268)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,9 @@ designs/
 
 # Playwright MCP session artifacts
 .playwright-mcp/
+
+# #268 D2 throwaway harness: a pinned ANEMLL checkout and 1.8 GB of Core ML
+# weights, both fetched by tools/ane-harness/setup.sh
+tools/ane-harness/.deps/
+tools/ane-harness/build/
+tools/ane-harness/AneBenchKit/Sources/AneBenchKit/Resources/

--- a/DictusCore/Sources/polish-harness/LocalHTTPPolishEngine.swift
+++ b/DictusCore/Sources/polish-harness/LocalHTTPPolishEngine.swift
@@ -64,12 +64,12 @@ struct LocalHTTPPolishEngine: PolishEngineProtocol {
         self.session = URLSession(configuration: configuration)
     }
 
-    func polish(raw: String,
-                targetLanguage: SupportedLanguage,
-                mode: PolishMode) async throws -> String {
-        let instructions = AppleFoundationModelsPolishEngine.instructions(for: mode, language: targetLanguage)
-        // Byte-identical to the Apple FM engine's user turn.
-        let userPrompt = """
+    /// Byte-identical to the Apple FM engine's user turn, which builds the same
+    /// string inline. Exposed as a function because #268's D2 sends these exact
+    /// bytes to a Core ML model outside this process, and a second hand-copy of
+    /// the framing would silently measure a different prompt.
+    static func userTurn(raw: String) -> String {
+        """
         Polish this text. Output only the polished version, nothing else.
 
         Input:
@@ -77,6 +77,13 @@ struct LocalHTTPPolishEngine: PolishEngineProtocol {
 
         Polished output:
         """
+    }
+
+    func polish(raw: String,
+                targetLanguage: SupportedLanguage,
+                mode: PolishMode) async throws -> String {
+        let instructions = AppleFoundationModelsPolishEngine.instructions(for: mode, language: targetLanguage)
+        let userPrompt = Self.userTurn(raw: raw)
         var body: [String: Any] = [
             "model": model,
             "temperature": temperature,

--- a/DictusCore/Sources/polish-harness/README.md
+++ b/DictusCore/Sources/polish-harness/README.md
@@ -36,6 +36,11 @@ swift run polish-harness show fixtures/seed.json --instructions /tmp/candidate.t
 
 # A/B two prompt files side by side
 swift run polish-harness ab fixtures/seed.json --a /tmp/baseline.txt --b /tmp/candidate.txt
+
+# Print the exact bytes the engine sends for a fixture: the resolved system
+# instructions and the Input/"Polished output:" user turn over pre-passed text.
+# Runs no model, so it needs no Apple Intelligence. --out writes them as files.
+swift run polish-harness prompt Sources/polish-harness/fixtures/seed.json --id 3-long
 ```
 
 ## Fixtures

--- a/DictusCore/Sources/polish-harness/main.swift
+++ b/DictusCore/Sources/polish-harness/main.swift
@@ -43,13 +43,14 @@ func optionValue(_ name: String, in args: [String]) -> String? {
 }
 
 let args = Array(CommandLine.arguments.dropFirst())
-guard let command = args.first, ["show", "eval", "ab"].contains(command), args.count >= 2 else {
+guard let command = args.first, ["show", "eval", "ab", "prompt"].contains(command), args.count >= 2 else {
     print("""
     polish-harness — off-device polish eval (macOS + Apple Intelligence)
 
-      show <fixtures.json> [--runs N] [--instructions <prompt.txt>]
-      eval <fixtures.json> [--instructions <prompt.txt>]
-      ab   <fixtures.json> --a <promptA.txt> --b <promptB.txt>
+      show   <fixtures.json> [--runs N] [--instructions <prompt.txt>]
+      eval   <fixtures.json> [--instructions <prompt.txt>]
+      ab     <fixtures.json> --a <promptA.txt> --b <promptB.txt>
+      prompt <fixtures.json> [--id <fixtureID>] [--out <dir>]
 
     show/eval also accept (#268 spike, throwaway):
       --engine apple-fm | local   (default apple-fm)
@@ -68,6 +69,9 @@ let abB = optionValue("--b", in: args)
 let engineKind = optionValue("--engine", in: args) ?? "apple-fm"
 let localModel = optionValue("--model", in: args)
 let localBaseURL = optionValue("--base-url", in: args) ?? "http://127.0.0.1:11434"
+// #268 D2, throwaway. `prompt` only.
+let promptFixtureID = optionValue("--id", in: args)
+let promptOutputDir = optionValue("--out", in: args)
 
 // MARK: - Load fixtures
 
@@ -100,7 +104,9 @@ guard #available(macOS 26.0, *) else {
 // beside the point, so it is scoped to the engine that needs it rather than to
 // the process.
 #if canImport(FoundationModels)
-if engineKind == "apple-fm" {
+// `prompt` never runs a model — it prints the bytes one would be sent — so it is
+// usable on a machine with Apple Intelligence off, which is the point of it.
+if command != "prompt", engineKind == "apple-fm" {
     switch SystemLanguageModel.default.availability {
     case .available:
         break
@@ -256,6 +262,47 @@ func runHarness() async {
             let b = await runOnce(fx, engine: engineB)
             print("  A (\(a.engineMs)ms): \(a.final)")
             print("  B (\(b.engineMs)ms): \(b.final)")
+        }
+
+    // #268 D2, throwaway. Prints the exact two strings the polish engine sends —
+    // the resolved system instructions and the user turn — for a fixture, so the
+    // ANE measurement runs on the shipping prompt rather than on a paraphrase of
+    // it. The user turn carries the PRE-PASSED text, because that is what the
+    // engine receives: `runOnce` applies `VerbalPunctuationPrepass` first.
+    case "prompt":
+        let selected = promptFixtureID.map { id in fixtures.filter { $0.id == id } } ?? fixtures
+        if selected.isEmpty {
+            print("error: no fixture with id \(promptFixtureID ?? "-") in \(fixturesPath)")
+            exit(1)
+        }
+        for fx in selected {
+            guard let target = fx.language else {
+                print("error: [\(fx.id)] routes through auto mode, which has no per-language prompt")
+                exit(1)
+            }
+            let preprocessed = VerbalPunctuationPrepass.apply(fx.raw, language: target)
+            let mode: PolishMode = .natural
+            let system = AppleFoundationModelsPolishEngine.instructions(for: mode, language: target)
+            let user = LocalHTTPPolishEngine.userTurn(raw: preprocessed)
+            print("━━ [\(fx.id)] lang=\(fx.lang) mode=\(mode.rawValue) "
+                  + "systemChars=\(system.count) userChars=\(user.count)")
+            if let dir = promptOutputDir {
+                let base = URL(fileURLWithPath: dir).appendingPathComponent(fx.id)
+                do {
+                    try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+                    try system.write(to: base.appendingPathComponent("system.txt"), atomically: true, encoding: .utf8)
+                    try user.write(to: base.appendingPathComponent("user.txt"), atomically: true, encoding: .utf8)
+                } catch {
+                    print("error: cannot write to \(base.path): \(error)")
+                    exit(1)
+                }
+                print("  wrote \(base.path)/{system,user}.txt")
+            } else {
+                print("──── system ────")
+                print(system)
+                print("──── user ────")
+                print(user)
+            }
         }
 
     default:

--- a/DictusCore/Sources/polish-harness/main.swift
+++ b/DictusCore/Sources/polish-harness/main.swift
@@ -268,7 +268,11 @@ func runHarness() async {
     // the resolved system instructions and the user turn — for a fixture, so the
     // ANE measurement runs on the shipping prompt rather than on a paraphrase of
     // it. The user turn carries the PRE-PASSED text, because that is what the
-    // engine receives: `runOnce` applies `VerbalPunctuationPrepass` first.
+    // engine receives: `runOnce` applies `VerbalPunctuationPrepass` first, and the
+    // mode is resolved the same way rather than assumed to be `.natural` — a
+    // Parakeet fixture whose detected language differs from its target resolves to
+    // `.repair`, and printing the Natural instructions for it would be printing a
+    // prompt the engine would never send.
     case "prompt":
         let selected = promptFixtureID.map { id in fixtures.filter { $0.id == id } } ?? fixtures
         if selected.isEmpty {
@@ -281,10 +285,16 @@ func runHarness() async {
                 exit(1)
             }
             let preprocessed = VerbalPunctuationPrepass.apply(fx.raw, language: target)
-            let mode: PolishMode = .natural
+            guard let detected = PolishPipeline.detectLanguage(in: preprocessed) else {
+                print("error: [\(fx.id)] language detection returned nil — the pipeline "
+                      + "would skip the engine entirely, so there is no prompt to print")
+                exit(1)
+            }
+            let mode = PolishPipeline.mode(sttEngine: fx.speechEngine, detected: detected, target: target)
             let system = AppleFoundationModelsPolishEngine.instructions(for: mode, language: target)
             let user = LocalHTTPPolishEngine.userTurn(raw: preprocessed)
-            print("━━ [\(fx.id)] lang=\(fx.lang) mode=\(mode.rawValue) "
+            print("━━ [\(fx.id)] lang=\(fx.lang) stt=\(fx.sttEngine ?? "PK") "
+                  + "detected=\(detected.rawValue) mode=\(mode.rawValue) "
                   + "systemChars=\(system.count) userChars=\(user.count)")
             if let dir = promptOutputDir {
                 let base = URL(fileURLWithPath: dir).appendingPathComponent(fx.id)

--- a/docs/research/268-ane-background-llm.md
+++ b/docs/research/268-ane-background-llm.md
@@ -286,7 +286,10 @@ in the background of.
 The apparatus is complete and installed:
 
 - `AneHarness.app`, bundle id `com.pivi.dictus.anebench`, built from this branch,
-  installed on `iPhone16,2` on 2026-08-22 **[measured]**.
+  installed on `iPhone16,2` on 2026-08-22 **[measured]**. It is not a target of
+  `Dictus.xcodeproj`, so the "Generate build info" phase never runs for it and
+  its output reads `rev unknown` — there is no revision line to check on this
+  one, unlike every other build the maintainer validates.
 - It stays alive backgrounded the same way DictusApp does — `UIBackgroundModes:
   audio` plus a running `AVAudioEngine` — because reproducing that state is the
   measurement, not a workaround.

--- a/docs/research/268-ane-background-llm.md
+++ b/docs/research/268-ane-background-llm.md
@@ -181,9 +181,11 @@ Q4_K_M build of the same checkpoint.
 | `qwen_embeddings` | ANE 0 / **CPU 4** | ANE 0 / CPU 4 |
 
 Two things to read here. The transformer body and the LM head are planned
-entirely for the Neural Engine — the 13 CPU operations are the same 13 in both
-columns. And the embedding table is a CPU gather in both, which is expected and
-is 622 MB of FP16 weights that the ANE never touches.
+essentially entirely for the Neural Engine: 1,179 = 1,166 + 13, so the 13
+operations that stay on the CPU under `.cpuAndNeuralEngine` are ones the planner
+never offers to the ANE **[derived]**. And the embedding table is a CPU gather in
+both columns, which is expected — it is 622 MB of FP16 weights the ANE never
+touches.
 
 **The GPU column is zero in every row.** Nothing in this path asks for Metal,
 which is the constraint the predecessor's Finding 1 established.
@@ -229,9 +231,12 @@ leaves **5.8 s**, which is still over the budget **[derived]**.
 
 The control makes the shape of the hardware visible. Moving from CPU to ANE buys
 **6.5×** on prefill and **1.35×** on decode. Set against the predecessor's Metal
-figures for the same checkpoint — 1.37 s warm total, of which ~1.25 s decoded
-~160 tokens — the GPU decodes roughly **4×** faster than the ANE does
-**[derived]**.
+figures for the same checkpoint — 1.25 s of decode inside a 3.82 s cold run — the
+GPU decodes roughly **4×** faster than the ANE does **[derived]**. That factor
+rests on an assumption the predecessor does not state: that its Metal run
+generated about as many tokens as this one's 162. Same prompt, same
+`temperature: 0`, different quantization and a different server, so treat the
+factor as an order of magnitude and not a measurement.
 
 That is a coherent picture rather than an anomaly: decode is one token at a time
 against the whole weight matrix, so it is bound by memory bandwidth, which is

--- a/docs/research/268-ane-background-llm.md
+++ b/docs/research/268-ane-background-llm.md
@@ -65,8 +65,9 @@ reasons the spike expected.**
 5. **The binding term is decode, and no prompt redesign touches it.** Decode is
    9.4 s of the 14 s. The one lever the predecessor identified — shorten the
    1,150-token instruction block — moves prefill only, so even a prompt of length
-   zero leaves 9.4 s **[derived]**. A future candidate would need roughly **3×**
-   ANEMLL 0.3.5's decode rate on this checkpoint to land inside the budget.
+   zero leaves 9.4 s **[derived]**. The bar a future candidate has to clear is in
+   [The decision](#the-decision-against-the-rule-that-was-registered-before-the-measurement),
+   and it is **×2.8 on the whole pipeline** — not on decode alone.
 
 6. **Sustained ANE inference throttles the phone.** A first run that began at
    `thermal=fair` crossed to `serious` within ninety seconds; decode fell from
@@ -118,8 +119,14 @@ resolved instructions come through `AppleFoundationModelsPolishEngine.instructio
 is the same `Input:` / `Polished output:` framing, over text that has been
 through `VerbalPunctuationPrepass`, because that is what the engine receives.
 `setup.sh` copies `seed.json` in rather than letting a second copy of the fixture
-exist. A new `polish-harness prompt` command prints the same two strings, so the
-bytes can be checked by hand.
+exist, and pins the model to an immutable Hub revision so a re-run cannot quietly
+fetch different weights. The **mode** is resolved through `PolishPipeline.mode`
+rather than assumed: a Parakeet fixture whose detected language differs from its
+target resolves to `.repair`, whose instructions are less than half the length of
+Natural's. `3-long` resolves to `.natural`, so the measurement is unaffected — but
+it was assumed rather than resolved until review caught it, and on two of the
+fourteen fixtures the assumption is wrong. A new `polish-harness prompt` command
+prints the same two strings, so the bytes can be checked by hand.
 
 **Thinking is off, and that was checked rather than assumed.** Qwen 3 reasons
 before answering unless the chat template emits an empty `<think></think>`
@@ -146,12 +153,12 @@ a crash-on-launch would be discovered.
 
 | | |
 | --- | --- |
-| Bundle | `anemll/anemll-Qwen-Qwen3-1.7B-ctx2048_0.3.5` **[source]** |
-| Base checkpoint | `Qwen/Qwen3-1.7B` (Apache-2.0), snapshot `0060bc56` per `meta.yaml` **[source]** |
+| Bundle | `anemll/anemll-Qwen-Qwen3-1.7B-ctx2048_0.3.5`, revision `0977a61d` **[source]** — `huggingface.co/anemll/anemll-Qwen-Qwen3-1.7B-ctx2048_0.3.5` |
+| Base checkpoint | `Qwen/Qwen3-1.7B` (Apache-2.0), snapshot `0060bc56d46589041c1048efd1a397421b1142b5` **[source]** — recorded in the bundle's `meta.yaml`, `model_path:` line |
 | Context / batch | 2048 / 64 |
 | Quantization | LUT6 per-channel 4 on the FFN and LM head; embeddings FP16 |
 | On disk | 1.80 GB across four `.mlmodelc` bundles |
-| Conversion | ANEMLL 0.3.5, parameters recorded verbatim in `meta.yaml` **[source]** |
+| Conversion | ANEMLL 0.3.5, parameters recorded verbatim in the bundle's `meta.yaml` (`.deps/model/meta.yaml` after `setup.sh`) **[source]** |
 
 `meta.yaml` carries the full converter invocation — context length, batch size,
 chunk count, LUT settings, `argmax_in_model: false`, `prefill_dynamic_slice:
@@ -161,7 +168,8 @@ issue names.
 
 The 2048 context matters. #268's coverage half was closed partly on ANEMLL's
 documented "M1/A14 limitation: constrained to 512-context monolithic models"
-**[source]**, against a 1,704-token prompt. This bundle is neither monolithic nor
+**[source]** — `github.com/Anemll/Anemll` `README.md`, at the pinned commit
+`fb42f60b2e7a7b4709052c7146d37480bf21941e` — against a 1,704-token prompt. This bundle is neither monolithic nor
 512-context, and the A14 constraint is untouched by anything here — the coverage
 tier stays closed.
 
@@ -322,6 +330,15 @@ correctly reports that it has no revision to report rather than guessing
 commit and the run. So there is no revision line to check on this one, and the
 sha is recorded here instead.
 
+The harness was edited **after** the run, under review, and none of those edits
+touch what was measured: aborting when the audio keep-alive fails (it did not
+fail — the run recorded it running), rendering the background verdict in three
+states instead of two, carrying the model revision into the report, no longer
+clamping a negative decode time (it was never negative), and resolving the prompt
+mode instead of assuming it (`3-long` resolves to the mode that was assumed).
+Re-running would reproduce the same prompt and the same work; the numbers below
+are quoted from the run that happened.
+
 ### Run B — the clean one, thermal `nominal` throughout
 
 ```text
@@ -451,7 +468,8 @@ show it.
 | Every load after that | **2,079 ms** |
 
 ANEMLL's README says "the first time the model loads, macOS will take some time
-to place it on the device. Subsequent loads will be instantaneous" **[source]**.
+to place it on the device. Subsequent loads will be instantaneous" **[source]** —
+the bundle's own `README.md`, "How to Run" section.
 On the phone that is exactly right. On the Mac it was not — two separate
 processes loading the same bundle from the same path both paid 96–104 s
 **[measured]**. Whatever caches the ANE placement works on iOS and did not here.
@@ -553,7 +571,7 @@ Two consequences, neither of which changes this document's conclusion:
 
 ## The decision, against the rule that was registered before the measurement
 
-#268 pre-registered this:
+Issue #268 pre-registered this:
 
 > **Negative** — the ANE cannot hold the prompt, or backgrounded latency lands
 > above the p50 ≤ 5 s budget: **close this issue permanently**. Both rationales
@@ -578,10 +596,24 @@ reopened with it.
 
 **It is not closed on "the ANE is unreachable in the background" either.** It is
 reachable, it is planned, it works. A future reopening would need a decode rate
-roughly **three times** what ANEMLL 0.3.5 delivers on this checkpoint —
-17.3 tok/s measured, and about 55 tok/s needed to land 162 tokens plus prefill
-inside 5 s **[derived]**. That is the number to hold any future candidate to, and
-it is a measurement, not an argument.
+a **×2.8 speed-up of the whole pipeline**, not of decode alone. Stated two ways,
+both from the measured medians of run B **[derived]**:
+
+| | Measured | Needed for a 5 s call |
+| --- | --- | --- |
+| **Whole pipeline scaled uniformly** — 13,834 ms → 5,000 ms | prefill 375 tok/s, decode 17.3 tok/s | prefill **~1,040 tok/s**, decode **~48 tok/s** (**×2.8** on both) |
+| **Decode alone, prefill unchanged** — 4,476 ms of prefill leaves 524 ms | decode 17.3 tok/s | decode **~309 tok/s** (**×18**) |
+
+The first form assumes nothing: it is 13,834 ms against 5,000 ms. The second is
+what "improve the decode rate" costs on its own, and it is the more useful figure
+for anyone reading a new runtime's tokens-per-second headline, because a
+tokens-per-second number says nothing about prefill.
+
+**An earlier draft of this report, and the closing comment on #268, quoted
+~55 tok/s of decode as the bar.** That was wrong: 162 tokens at 55 tok/s is
+2.95 s of decode, which on top of an unchanged 4.48 s prefill is 7.43 s — still
+1.5× over the ceiling. The figure only worked if prefill improved by the same
+factor, which was not stated. Corrected here and on the issue.
 
 ---
 
@@ -594,9 +626,9 @@ transcription cycle moving the same reading by ~35 MB, and there is 3 GB of room
 is not.
 
 **Whether a shorter prompt or a smaller model gets under the budget.** Out of
-scope: #268 is about `qwen3:1.7b`, and its decode rate misses by 3×. A different
-model is a different issue, opened for a named model with a named footprint, as
-the coverage half already requires.
+scope: issue #268 is about `qwen3:1.7b`, and the whole call misses by 2.8×. A
+different model is a different issue, opened for a named model with a named
+footprint, as the coverage half already requires.
 
 **Quality of this LUT6 build through the full 72-check suite.** Finding 7 settles
 the question the suite would have been asked — the build returns its input
@@ -647,7 +679,7 @@ the phone. The App Group write is still attempted and its outcome recorded.
 
 - **That one device generalises.** Everything phone-shaped here is one
   `iPhone16,2` on iOS 26.6. The conclusion survives a wide margin — 14 s against
-  a 5 s ceiling — so a faster phone does not flip it without a 3× improvement,
+  a 5 s ceiling — so a faster phone does not flip it without a 2.8× improvement,
   but the *numbers* are one device's.
 
 - **That the three iterations of run B are a p50.** They are three consecutive
@@ -663,8 +695,9 @@ the phone. The App Group write is still attempted and its outcome recorded.
   untested, and so is whether LUT6 costs anything against the 66/72 the
   predecessor measured on a Q4_K_M build. ANEMLL's own README does warn that
   "Quantization should be improved. LUT4 quality is fairly low due to lack of
-  Block Quantization on Apple Neural Engine" **[source]** — a reason to suspect
-  it, not evidence that it bit here.
+  Block Quantization on Apple Neural Engine" **[source]** (`github.com/Anemll/Anemll`
+  `README.md` at `fb42f60`, "Pre-converted Models") — a reason to suspect it, not
+  evidence that it bit here.
 
 - **That one fixture characterises the quality gap.** Finding 7 is `3-long`, the
   largest shipping fixture. A shorter input leaves more of the window free and
@@ -693,7 +726,9 @@ the phone. The App Group write is still attempted and its outcome recorded.
   an MIT-licensed toolchain and a public checkpoint — not about what the hardware
   could do in principle. A future ANEMLL release could move this number; a
   reopening of #268 on that basis would need it measured, not argued, against the
-  ~55 tok/s the budget implies.
+  bar in [The decision](#the-decision-against-the-rule-that-was-registered-before-the-measurement)
+  — and measured on the whole call, because a decode-rate headline alone cannot
+  clear it.
 
 - **That the thermal curve in run A is characterised.** It is one run, and the
   phone's starting state was not controlled — it read `fair` before any

--- a/docs/research/268-ane-background-llm.md
+++ b/docs/research/268-ane-background-llm.md
@@ -81,7 +81,17 @@ reasons the spike expected.**
    [Deviations](#deviations-from-the-issue). There is no toolchain failure to
    report: the model converted, loaded, and ran.
 
-8. **Loading is a once-per-install cost, not a per-launch one.** 118.5 s the
+8. **The converted build barely polishes, and quality is unreachable on it for a
+   structural reason.** With reasoning off — the only mode that fits — its output
+   differs from its input by **one character**, on the Mac and on the phone
+   identically **[measured]**. Allowed to reason, it reasons coherently and
+   on-task, so the weights are not the problem; but the prompt occupies 1,676 of
+   a 2,048-token window and its reasoning needs 500–700 more, so **the mode that
+   works does not fit** **[measured, derived]**. Quality would need a larger
+   context, and a larger context means more prefill on a call already 2.8× over
+   budget.
+
+9. **Loading is a once-per-install cost, not a per-launch one.** 118.5 s the
    first time on the device, **2.1 s** every time after **[measured]**.
 
 **Against the pre-registered rule this is the negative branch: close #268.** The
@@ -298,6 +308,20 @@ if the ANE is unavailable or busy.
 same prompt, same `temperature: 0`, thinking off. Collected 2026-08-22
 **[measured]**. Two runs, and the difference between them is itself a finding.
 
+### Which build produced these numbers
+
+Line 2 of every export in this repository carries `rev <sha>@<branch>`, and this
+one says **`rev unknown`**. That is not a fault in the run: the harness is not a
+target of `Dictus.xcodeproj`, so the "Generate build info" phase that writes
+`DictusBuildInfo.plist` never runs for it, and `PersistentLog.codeRevision`
+correctly reports that it has no revision to report rather than guessing
+**[code]**.
+
+**The binary on the phone was built from the working tree that became
+`eba99cf`**, and nothing under `tools/ane-harness/App/` changed between that
+commit and the run. So there is no revision line to check on this one, and the
+sha is recorded here instead.
+
 ### Run B — the clean one, thermal `nominal` throughout
 
 ```text
@@ -369,9 +393,27 @@ Prefill is 4.5 s. Even a prompt of length zero leaves 9.4 s, so the one lever th
 predecessor identified — shorten the 1,150-token instruction block — still
 cannot reach the budget **[derived]**.
 
-The iPhone-to-Mac multiplier is **1.65×** on the total (14.0 s against 8.5 s),
-which confirms the predecessor's "a Mac figure is a floor" framing without
-needing it to be conservative.
+### The iPhone-to-Mac multiplier, given separately because it was asked for
+
+Like for like — same runtime, same bundle, same prompt, same compute units,
+medians of three iterations **[measured]**:
+
+| | Mac (M4 Pro, ANE) | iPhone16,2 (ANE) | Multiplier |
+| --- | --- | --- | --- |
+| Prefill, 1,680 tokens | 2,790 ms (602 tok/s) | 4,476 ms (375 tok/s) | **×1.60** |
+| Decode, 162 tokens | 5,845 ms (27.7 tok/s) | 9,358 ms (17.3 tok/s) | **×1.60** |
+| Total | 8,635 ms | 13,834 ms | **×1.60** |
+
+The two terms scale by the same factor, which is the useful thing to know: on
+this runtime the phone is uniformly 1.6× the Mac, so a Mac figure can be scaled
+without asking which half of the call it came from.
+
+**A larger multiplier can be produced by comparing the wrong pairs.** Setting the
+predecessor's Mac figures against these device figures gives roughly ×2.7 on
+prefill and ×4.5 on decode — but those Mac figures are Ollama serving a Q4_K_M
+build on the CPU, and these are ANEMLL serving a LUT6 build on the ANE. Runtime,
+quantization and compute unit all differ, so the ratio measures the change of
+stack, not the change of machine. The table above changes one variable.
 
 ### Run A — what thermal pressure does, and why it is not a footnote
 
@@ -416,6 +458,96 @@ processes loading the same bundle from the same path both paid 96–104 s
 
 So the two-minute load is a once-per-install cost, not a once-per-launch one, and
 it is not an argument against anything.
+
+---
+
+## Finding 7 — the converted model barely polishes, and the reason is not the one it looks like
+
+Noticed by the maintainer on reading the export, and worth recording even though
+latency already decides the issue: on `3-long` the ANE build returns the input
+almost unchanged.
+
+Measured rather than eyeballed — the model's output against the exact text the
+prompt carried **[measured]**:
+
+| Build | Similarity to input | Edits |
+| --- | --- | --- |
+| ANEMLL LUT6, Mac ANE | **0.9992** | one: a final `.` |
+| ANEMLL LUT6, iPhone ANE | **0.9992** | one: a final `.` |
+| `qwen3:1.7b` Q4_K_M via Ollama, same prompt | 0.113 | a real rewrite |
+
+The Mac and the phone produce **byte-identical** 638-character output, so this is
+a property of the build, not of the device. And the Ollama rewrite is a genuine
+polish — punctuation added, `pardon` and `tout simplement` dropped:
+
+> T'aimerais bien tester un texte un peu plus long que je décris à l'oral, comme
+> je le fais en fait. Et justement, quand je ne sais pas trop quoi dire […]
+> L'idée, c'est de voir comment se comporte le modèle et l'application en
+> général.
+
+(It also mangles the opening clause — `Ce que j'aimerais` → `T'aimerais`. Neither
+output is being held up as good here; the point is that one transformed the text
+and the other did not.)
+
+### LUT6 is the obvious suspect and it is probably not the culprit
+
+The two runs differ in more than quantization: **the Ollama run reasoned first
+and the ANE run did not.** Ollama generated 1,800–2,500 characters of reasoning
+before answering **[measured]**, while the harness suppresses reasoning by
+injecting the empty `<think></think>` block. A model that thinks before rewriting
+is not the same model.
+
+Re-running the ANE build with reasoning left on settles it **[measured]**:
+
+```text
+computeUnits=cpuAndNeuralEngine +thinking
+iteration 1 promptTokens=1676 prefillMs=2711 decodeMs=12744 generated=360 stop=max_tokens
+output: <think>
+Okay, let's tackle this input. The user wants the French text polished according
+to the given rules. […] Here, "pardon" is a word that should be replaced with the
+punctuation mark. […]
+```
+
+**The weights are fine.** Allowed to think, the LUT6 build reasons coherently and
+on-task about the French text — it identifies the filler, quotes the rules, works
+through the clauses. This is not a model destroyed by quantization.
+
+### What actually blocks it is the context window
+
+The reasoning above never reaches an answer. It runs to the token cap still
+inside `<think>`, and it cannot do otherwise: the prompt is **1,676 tokens of a
+2,048-token window**, leaving **372 tokens**, and this model's own reasoning on
+this prompt needs 500–700 **[derived, from the Ollama runs]**.
+
+So the two modes available on this bundle are:
+
+- **reasoning off** — fits, and returns the input plus a full stop;
+- **reasoning on** — polishes, and does not fit.
+
+A build with a larger context would be needed to get the quality, and a larger
+context means more prefill on top of a call that is already 2.8× over budget.
+That is why this finding, which looks like a footnote, points the same way as
+the latency: **it makes the gap wider, not narrower.**
+
+### A correction the predecessor should carry
+
+The predecessor established that `chat_template_kwargs: {enable_thinking: false}`
+was accepted and ignored by Ollama while `reasoning_effort: "none"` worked, and
+verified that against `qwen3.5:0.8b`.
+
+On Ollama 0.32.6 today, with `qwen3:1.7b`, **neither key suppresses reasoning**.
+Both were sent and the response still carried 1,812–2,481 characters of it
+**[measured]** — moved into a separate `message.thinking` field rather than
+inlined in `content`, which is why it does not show up by reading the answer.
+
+Two consequences, neither of which changes this document's conclusion:
+
+- `LocalHTTPPolishEngine` reads `message.content` and strips inline reasoning, so
+  the predecessor's **quality** scores are unaffected — the content it scored was
+  clean **[code]**.
+- Its **latency** figures for `qwen3:1.7b` include generating reasoning tokens
+  that were believed to be suppressed, so they are, if anything, overstated
+  against a product that would not pay for them.
 
 ---
 
@@ -466,8 +598,12 @@ scope: #268 is about `qwen3:1.7b`, and its decode rate misses by 3×. A differen
 model is a different issue, opened for a named model with a named footprint, as
 the coverage half already requires.
 
-**Quality of this LUT6 build through `polish-harness eval`.** It would have
-mattered only if the latency had come back positive. See below.
+**Quality of this LUT6 build through the full 72-check suite.** Finding 7 settles
+the question the suite would have been asked — the build returns its input
+unchanged in the only mode that fits its context window — without needing 72
+fixture-runs to say it. Scoring it properly would mean putting an
+OpenAI-compatible façade in front of the ANE runtime, and it would have mattered
+only if latency had come back positive.
 
 ## Deviations from the issue
 
@@ -519,15 +655,21 @@ the phone. The App Group write is still attempted and its outcome recorded.
   narrow (13.8–14.4 s) and that is all it establishes. The budget is written as a
   p50 and this is not one.
 
-- **That LUT6 inherits the 66/72 the predecessor measured.** That score is a
-  Q4_K_M build of `Qwen3-1.7B` served by Ollama; this is a 6-bit look-up-table
-  quantization with per-channel scales, produced by a different toolchain, and
-  ANEMLL's own README warns "Quantization should be improved. LUT4 quality is
-  fairly low due to lack of Block Quantization on Apple Neural Engine"
-  **[source]**. One fixture producing clean French is a sanity gate. Scoring this
-  build would mean putting an OpenAI-compatible façade in front of the ANE
-  runtime and re-running `polish-harness eval` — cheap enough, and worth nothing
-  until the latency question comes back positive.
+- **That LUT6 is why the output is near-identical.** Finding 7 rules out the
+  obvious reading rather than confirming it: allowed to reason, the same build
+  reasons coherently on the same prompt. What is established is that *this
+  build, in the only mode its context window allows*, does not transform the
+  text. Whether a LUT6 build with a 4K context would polish acceptably is
+  untested, and so is whether LUT6 costs anything against the 66/72 the
+  predecessor measured on a Q4_K_M build. ANEMLL's own README does warn that
+  "Quantization should be improved. LUT4 quality is fairly low due to lack of
+  Block Quantization on Apple Neural Engine" **[source]** — a reason to suspect
+  it, not evidence that it bit here.
+
+- **That one fixture characterises the quality gap.** Finding 7 is `3-long`, the
+  largest shipping fixture. A shorter input leaves more of the window free and
+  might behave differently in the reasoning-on mode. The 72-check suite was not
+  run against this build.
 
 - **That 162 generated tokens is representative.** The `3-long` fixture is the
   largest shipping one, and its polished output happens to be close to a copy of
@@ -572,10 +714,11 @@ in that directory's `README.md`.
 cd DictusCore
 swift run polish-harness prompt Sources/polish-harness/fixtures/seed.json --id 3-long
 
-# Mac: the ANE run, and the CPU control
+# Mac: the ANE run, the CPU control, and the reasoning-on control (Finding 7)
 cd tools/ane-harness/AneBenchKit
 swift run -c release ane-bench --iterations 3
 swift run -c release ane-bench --iterations 1 --max-tokens 60 --compute-units cpu
+swift run -c release ane-bench --iterations 1 --max-tokens 360 --thinking
 
 # Phone: build, install, launch (needs the phone unlocked), collect
 cd tools/ane-harness

--- a/docs/research/268-ane-background-llm.md
+++ b/docs/research/268-ane-background-llm.md
@@ -77,8 +77,10 @@ Same scheme as the predecessor, because the two documents are read together.
 
 7. **The device measurement is not in this document yet.** Everything above is a
    Mac. A Mac has no jetsam and no application lifecycle, so it cannot answer the
-   question in #268's title. The apparatus is built, signed and installed on the
-   iPhone; see [What is still missing](#what-is-still-missing).
+   question in #268's title. The apparatus is built, installed on the iPhone, and
+   rehearsed end to end in a simulator with `allIterationsBackgrounded=true`; it
+   is blocked on one thing, which is that `devicectl` will not launch an app on a
+   locked phone. See [What is still missing](#what-is-still-missing).
 
 **Reading so far: the ANE is reachable and the prompt fits, and the candidate
 still misses the latency budget on hardware faster than any iPhone.** The device
@@ -290,8 +292,26 @@ The apparatus is complete and installed:
   `allIterationsBackgrounded`, so a run that was not backgrounded reports itself
   as invalid rather than as a number.
 
-It has not run, for one reason: `devicectl` cannot launch an app on a locked
-phone.
+**The apparatus itself has been run end to end**, on an iPhone 17 Pro Max
+simulator, backgrounded by launching Safari over it **[measured]**. Everything
+except the ANE worked: the app launched, the audio keep-alive kept it alive
+through eight minutes in the background, the model loaded from the bundle, the
+prompt built from DictusCore to the same 1,680 tokens, three iterations ran, the
+results were written and read back, and the file ends
+
+```text
+allIterationsBackgrounded=true
+```
+
+with every sample reading `state=background`. **None of its numbers mean
+anything** — a simulator has no Neural Engine, so it ran the same CPU path that
+produces gibberish on the Mac, at 1.6–4.0 tok/s. It is a rehearsal of the
+protocol, not a measurement, and it is recorded here only because it removes
+"does the harness work" from the list of things the maintainer's unlock window
+could be spent discovering.
+
+It has not run on the phone, for one reason: `devicectl` cannot launch an app on
+a locked phone.
 
 ```text
 Unable to launch com.pivi.dictus.anebench because the device was not, or could
@@ -308,7 +328,13 @@ the results over Wi-Fi. The steps are in the PR and in
 - the iPhone multiplier on 8.3 s, which is the number the decision rule wants;
 - `os_proc_available_memory()` with the model resident, against D1's 3.33 GB
   backgrounded headroom — how much of it a 1.8 GB tenant plus its KV cache
-  actually costs, and what is left for Parakeet's ~800 MB;
+  actually costs, and what is left for Parakeet's ~800 MB. **This one cannot be
+  guessed from the Mac readings, and the reason is worth stating**: with the
+  whole 1.8 GB model loaded, `phys_footprint` read **324 MB** on the Mac and
+  **100 MB** in the simulator **[measured]**. Core ML's weights are mapped, not
+  allocated, so the footprint number does not see most of them. Whether jetsam
+  does is exactly what `os_proc_available_memory()` answers, and it returns 0
+  anywhere but a device **[code]** `DictusCore/DeviceCapabilities.swift:103`;
 - whether the ANE is reachable at all from a backgrounded process for an LLM, or
   whether Core ML silently re-plans onto the CPU there. The harness reads the
   compute plan on device, so this is answerable rather than arguable.

--- a/docs/research/268-ane-background-llm.md
+++ b/docs/research/268-ane-background-llm.md
@@ -1,0 +1,425 @@
+# Can a backgrounded DictusApp reach the ANE for LLM inference? — D2
+
+**Issue:** [#268](https://github.com/getdictus/dictus-ios/issues/268)
+**Scope:** measurement only. No `PolishEngineProtocol` implementation, no model
+delivery, no engine selection, no change to `PolishCoordinator` or to any app
+target.
+**Date:** 2026-08-22.
+**Predecessor:** [`268-second-llm-backend.md`](268-second-llm-backend.md) — the
+2026-08-13 spike and its 2026-08-21 addendum (D1). Read that first; this
+document extends it and assumes its findings.
+
+D2 is the experiment the addendum called decisive:
+
+> The question is whether a ~1.7B model can be made ANE-resident and hold a
+> 1,704-token prefill on modern silicon while backgrounded. A negative result
+> closes #268 completely; a positive one makes `qwen3:1.7b` a real alternative to
+> Apple FM on 8 GB devices.
+
+---
+
+## Evidence labels
+
+Same scheme as the predecessor, because the two documents are read together.
+
+| Label | Meaning |
+| --- | --- |
+| **[code]** | Read in this repository, cited by file and line. |
+| **[source]** | Official API reference, official model card, or a named third-party source file, cited by URL or path. |
+| **[measured]** | Produced by running something during this spike. The command is recorded. |
+| **[field]** | Recorded on the maintainer's own device and quoted in the tracker. |
+| **[derived]** | Arithmetic on top of a sourced fact. The input is sourced; the output is not quoted. |
+
+---
+
+## Summary
+
+1. **The ANE holds the prompt. That question is answered, and it turns out not
+   to be the one that decides.** A 1,680-token prefill runs to completion in a
+   2048-context ANEMLL build of Qwen3 1.7B, stopping on EOS with no window shift
+   and no truncation **[measured]**. The predecessor's "does it fit" worry is
+   closed for modern silicon.
+
+2. **Core ML really does place it on the Neural Engine, and this is read from
+   Core ML rather than inferred from a timing.** `MLComputePlan` reports **1,166
+   ANE operations against 13 CPU** in the transformer chunk under
+   `.cpuAndNeuralEngine`, and **0 ANE against 1,179 CPU** for the same file under
+   `.cpuOnly` **[measured]**.
+
+3. **The decisive cost is decode, not prefill, and no prompt redesign touches
+   it.** On an M4 Pro, ANE-resident, thinking off: prefill of the real French
+   polish prompt is **2.69–3.31 s**, decode of the 162-token answer is
+   **5.80–5.91 s**, total **8.49–9.15 s** per polish call **[measured]**. The
+   pre-registered budget is p50 ≤ 5 s. **Decode alone misses it**, so the one
+   lever the predecessor identified — shorten the 1,150-token instruction block —
+   cannot rescue this: it is arithmetic on the wrong term **[derived]**.
+
+4. **The ANE is much better than the CPU at prefill and barely better at
+   decode.** Same model, same prompt, same process: prefill **6.5× faster**
+   (3.05 s median vs 19.78 s) but decode only **1.35× faster** (27.7 vs
+   20.8 tok/s) **[measured]**. Against the predecessor's Metal figures for the same
+   checkpoint, the GPU decodes roughly **4×** faster than the ANE does
+   **[derived]**. The Neural Engine is not a small GPU; it is a prefill engine.
+
+5. **No conversion was needed, and none was attempted.** ANEMLL publishes
+   `anemll-Qwen-Qwen3-1.7B-ctx2048_0.3.5` — the exact candidate, converted by the
+   toolchain's own authors at the version #268 names, with the conversion
+   parameters recorded in its `meta.yaml` **[source]**. This is a deliberate
+   deviation from the issue's step 1, and it is the reason the time-box the issue
+   set aside for toolchain trouble was not spent. See
+   [Deviations](#deviations-from-the-issue).
+
+6. **Placing the model on the ANE costs 96–104 s of load, every process
+   launch.** Against 21.2 s for the same bundle under `.cpuOnly` **[measured]**. Not
+   fatal — DictusApp is long-lived and pre-loads at launch — but it is a real
+   number that a shipping integration would have to hide, and it is not one the
+   predecessor's Ollama load times (1.7–2.5 s) predict.
+
+7. **The device measurement is not in this document yet.** Everything above is a
+   Mac. A Mac has no jetsam and no application lifecycle, so it cannot answer the
+   question in #268's title. The apparatus is built, signed and installed on the
+   iPhone; see [What is still missing](#what-is-still-missing).
+
+**Reading so far: the ANE is reachable and the prompt fits, and the candidate
+still misses the latency budget on hardware faster than any iPhone.** The device
+run can move that from "indicated" to "measured"; on the evidence here it is
+unlikely to reverse it.
+
+---
+
+## What was built
+
+`tools/ane-harness/` — throwaway, its own Xcode project, referenced by nothing.
+`README.md` there is the operating manual. Two entry points share one
+measurement core:
+
+- `ane-bench`, a macOS CLI — the gate #268's work-split puts before the phone.
+- `AneHarness.app`, an iOS app — the measurement itself.
+
+Three decisions inside it are worth stating, because each one is a way the
+measurement could have been quietly wrong.
+
+**The prompt is built from DictusCore at runtime, not transcribed.** The
+resolved instructions come through `AppleFoundationModelsPolishEngine.instructions(for:language:)`
+— the same entry point both shipping engines use **[code]** — and the user turn
+is the same `Input:` / `Polished output:` framing, over text that has been
+through `VerbalPunctuationPrepass`, because that is what the engine receives.
+`setup.sh` copies `seed.json` in rather than letting a second copy of the fixture
+exist. A new `polish-harness prompt` command prints the same two strings, so the
+bytes can be checked by hand.
+
+**Thinking is off, and that was checked rather than assumed.** Qwen 3 reasons
+before answering unless the chat template emits an empty `<think></think>`
+block; the predecessor threw away an entire measurement pass on finding it had
+run with thinking silently on. The harness appends that block and the recorded
+outputs contain no reasoning.
+
+**Compute placement is read, not inferred.** `MLComputeUnits` is documented as
+"allow", not "require", and the predecessor's own "what I am not comfortable
+asserting" records that the fallback mechanism was never investigated. So the
+harness reads `MLComputePlan.deviceUsage(for:)` per operation, and
+`--compute-units cpu` gives the contrast.
+
+---
+
+## Finding 1 — the model, and why it was not converted here
+
+| | |
+| --- | --- |
+| Bundle | `anemll/anemll-Qwen-Qwen3-1.7B-ctx2048_0.3.5` **[source]** |
+| Base checkpoint | `Qwen/Qwen3-1.7B` (Apache-2.0), snapshot `0060bc56` per `meta.yaml` **[source]** |
+| Context / batch | 2048 / 64 |
+| Quantization | LUT6 per-channel 4 on the FFN and LM head; embeddings FP16 |
+| On disk | 1.80 GB across four `.mlmodelc` bundles |
+| Conversion | ANEMLL 0.3.5, parameters recorded verbatim in `meta.yaml` **[source]** |
+
+`meta.yaml` carries the full converter invocation — context length, batch size,
+chunk count, LUT settings, `argmax_in_model: false`, `prefill_dynamic_slice:
+true`, `anemll_version: 0.3.5`. That is more provenance than a conversion run
+here would have produced, and it is the same toolchain at the same version the
+issue names.
+
+The 2048 context matters. #268's coverage half was closed partly on ANEMLL's
+documented "M1/A14 limitation: constrained to 512-context monolithic models"
+**[source]**, against a 1,704-token prompt. This bundle is neither monolithic nor
+512-context, and the A14 constraint is untouched by anything here — the coverage
+tier stays closed.
+
+## Finding 2 — the ANE holds the prompt
+
+The real prompt tokenises to **1,680 tokens** by the model's own tokenizer
+**[measured]** — the predecessor's 1,704 was the same prompt through Ollama's
+Qwen tokenizer with a different chat-template wrapper, so the two agree to within
+the template overhead.
+
+Every run terminated on `eos_token` after 162 generated tokens, with no window
+shift: 1,680 + 162 = 1,842 of the 2,048-token window **[measured]**.
+
+The output is coherent French, in the speaker's register, with no fabrication and
+no English:
+
+> Ce que j'aimerais bien tester aussi, c'est un texte un petit peu plus long, que
+> je décris à l'oral, comme je suis en train de le faire en fait. […] j'ai envie
+> de voir exactement comment ça se comporte avec dictus mais aussi avec
+> whisperflow.
+
+This is a sanity gate, not a quality score — see
+[What I am not comfortable asserting](#what-i-am-not-comfortable-asserting) on
+what LUT6 does and does not inherit from the 66/72 the predecessor measured on a
+Q4_K_M build of the same checkpoint.
+
+## Finding 3 — Core ML places it on the ANE
+
+`MLComputePlan`, per compiled model, `const` operations excluded **[measured]**:
+
+| Model | `.cpuAndNeuralEngine` | `.cpuOnly` |
+| --- | --- | --- |
+| `qwen_FFN_PF_lut6_chunk_01of02` (the transformer body) | ANE **1,166** / CPU 13 / GPU 0 / undetermined 1,448 | ANE **0** / CPU 1,179 |
+| `qwen_lm_head_lut6` | ANE **50** / CPU 0 | ANE 0 / CPU 50 |
+| `qwen_embeddings` | ANE 0 / **CPU 4** | ANE 0 / CPU 4 |
+
+Two things to read here. The transformer body and the LM head are planned
+entirely for the Neural Engine — the 13 CPU operations are the same 13 in both
+columns. And the embedding table is a CPU gather in both, which is expected and
+is 622 MB of FP16 weights that the ANE never touches.
+
+**The GPU column is zero in every row.** Nothing in this path asks for Metal,
+which is the constraint the predecessor's Finding 1 established.
+
+The 1,448 operations Core ML declines to plan a device for are reported as
+undetermined rather than folded into any column. An absent count is not a zero.
+
+## Finding 4 — latency, and the term that decides
+
+Measured on **Apple M4 Pro, 14 cores, 24 GB, macOS 26.5.1**, `temperature: 0`,
+thinking off, the real French polish prompt, ANEMLL Swift runtime **[measured]**:
+
+| Run | Prefill | Decode (162 tok) | Total | Prefill rate | Decode rate |
+| --- | --- | --- | --- | --- | --- |
+| ANE, iteration 1 | **3,305 ms** | 5,845 ms | **9,150 ms** | 508 tok/s | 27.7 tok/s |
+| ANE, iteration 2 | **2,688 ms** | 5,800 ms | **8,488 ms** | 625 tok/s | 27.9 tok/s |
+| ANE, iteration 3 | **2,790 ms** | 5,910 ms | **8,700 ms** | 602 tok/s | 27.4 tok/s |
+| CPU-only control | **19,784 ms** | 2,890 ms (60 tok) | — | 85 tok/s | 20.8 tok/s |
+
+An earlier two-iteration pass in a separate process reproduces this within noise
+(3,152 / 2,590 ms prefill, 5,732 / 5,709 ms decode) **[measured]**, so the spread
+above is run-to-run variance and not drift.
+
+Against the two numbers the decision rule names:
+
+- Pre-registered budget: **p50 ≤ 5 s**.
+- Apple FM field baseline, backgrounded, on the maintainer's own device:
+  **p50 1,654 ms**, p90 4,842 ms **[field]**.
+
+**8.5 s on an M4 Pro is 5× the Apple FM baseline and 1.7× the budget ceiling.**
+The predecessor establishes that a Mac figure is a *floor* for any iPhone.
+
+### Why the prompt-shortening lever does not apply
+
+The predecessor named one way out of its arithmetic: the instruction block is
+1,150 tokens because Apple FM needed it to be, and a different backend could be
+given a shorter one. That lever moves **prefill**. Prefill here is 2.7–3.3 s of
+an 8.5 s call; decode is 5.8–5.9 s and depends on how much text the user
+dictated, not on how long the instructions are. Even a prompt of length zero
+leaves **5.8 s**, which is still over the budget **[derived]**.
+
+### The ANE is a prefill engine
+
+The control makes the shape of the hardware visible. Moving from CPU to ANE buys
+**6.5×** on prefill and **1.35×** on decode. Set against the predecessor's Metal
+figures for the same checkpoint — 1.37 s warm total, of which ~1.25 s decoded
+~160 tokens — the GPU decodes roughly **4×** faster than the ANE does
+**[derived]**.
+
+That is a coherent picture rather than an anomaly: decode is one token at a time
+against the whole weight matrix, so it is bound by memory bandwidth, which is
+what the ANE has least of. It also explains why published ANE LLM demos are
+impressive on time-to-first-token and quiet about tokens per second.
+
+### One more number the Ollama measurements do not predict
+
+Model load, same bundle, same machine **[measured]**:
+
+| | Load |
+| --- | --- |
+| `.cpuAndNeuralEngine` | **95,827 ms** and **103,636 ms**, two separate processes |
+| `.cpuOnly` | 21,227 ms |
+
+Some 75–82 seconds of that is ANE placement. It is paid per process launch, and
+it did not shrink on a later launch from the same path — ANEMLL's README says
+"subsequent loads will be instantaneous" **[source]**, and that was not observed
+here. DictusApp is long-lived and
+already pre-loads its STT model at launch, so this is an engineering problem
+rather than a blocker — but a first dictation after an app cold start would find
+the model still loading, and no Ollama figure in the predecessor (1.7–2.5 s
+load) hints at it.
+
+## Finding 5 — the CPU is not a fallback for this artifact
+
+The `.cpuOnly` control produced this, on the same prompt that gives clean French
+on the ANE **[measured]**:
+
+```text
+olieottonologagal俑Publish.eTRACT most . 【ITU怪杞
+```
+
+An ANEMLL bundle is not a model that runs anywhere and runs faster on the ANE. It
+is an ANE artifact. Whatever this says about the toolchain, it removes an option
+that might otherwise look available: there is no graceful degradation to the CPU
+if the ANE is unavailable or busy.
+
+---
+
+## What is still missing
+
+**The device run.** This is D2's actual question and it is the one thing a Mac
+cannot stand in for: there is no jetsam on a Mac, and no `applicationState` to be
+in the background of.
+
+The apparatus is complete and installed:
+
+- `AneHarness.app`, bundle id `com.pivi.dictus.anebench`, built from this branch,
+  installed on `iPhone16,2` on 2026-08-22 **[measured]**.
+- It stays alive backgrounded the same way DictusApp does — `UIBackgroundModes:
+  audio` plus a running `AVAudioEngine` — because reproducing that state is the
+  measurement, not a workaround.
+- It loads in the foreground, waits to be backgrounded rather than counting down
+  at the person holding the phone, then runs three iterations on its own.
+- Every reading carries `os_proc_available_memory()`, `phys_footprint`, thermal
+  state **and the lifecycle state it was taken in**. The report prints
+  `allIterationsBackgrounded`, so a run that was not backgrounded reports itself
+  as invalid rather than as a number.
+
+It has not run, for one reason: `devicectl` cannot launch an app on a locked
+phone.
+
+```text
+Unable to launch com.pivi.dictus.anebench because the device was not, or could
+not be, unlocked. (FBSOpenApplicationErrorDomain error 7)
+```
+
+Everything after "unlock the phone" is automatable from the Mac — the run needs
+no taps, and `devicectl device copy from --domain-type appDataContainer` fetches
+the results over Wi-Fi. The steps are in the PR and in
+`tools/ane-harness/README.md`.
+
+**What the device run adds, beyond confirming or refusing the Mac figures:**
+
+- the iPhone multiplier on 8.3 s, which is the number the decision rule wants;
+- `os_proc_available_memory()` with the model resident, against D1's 3.33 GB
+  backgrounded headroom — how much of it a 1.8 GB tenant plus its KV cache
+  actually costs, and what is left for Parakeet's ~800 MB;
+- whether the ANE is reachable at all from a backgrounded process for an LLM, or
+  whether Core ML silently re-plans onto the CPU there. The harness reads the
+  compute plan on device, so this is answerable rather than arguable.
+
+**What was not attempted, and is not on the way to an answer:** running Parakeet
+and the LLM in the same process. D1 gives Parakeet's cost and this gives the
+LLM's; composing them is arithmetic, and the composition is only worth measuring
+if the latency question comes back positive.
+
+---
+
+## Deviations from the issue
+
+**The model was not converted here.** #268 step 1 says "install ANEMLL and
+convert a ~1.7B checkpoint for the ANE", and warns that this is the uncertain
+part, time-boxes it, and asks for a conversion failure to be reported as a
+finding rather than worked around. Neither happened: ANEMLL publishes the
+converted artifact for exactly this checkpoint, at the release the issue names,
+with the conversion parameters recorded. Using it is the same toolchain output
+with better provenance than a local run, and it spent none of the time-box.
+
+This does mean one thing is untested: whether *this machine* can run the ANEMLL
+conversion pipeline. Nothing in #268's question depends on that, and if a future
+integration needs a different context length or quantization it will find out
+then.
+
+**The results do not come out through the App Group.** #268 asks the harness to
+write into the App Group and reuse the `PersistentLog` export path, "so the
+results come out the way D1's did". Signing refuses it:
+
+```text
+error: Provisioning profile "iOS Team Provisioning Profile: *" doesn't support
+the group.solutions.pivi.dictus App Group.
+error: No Accounts: Add a new account in Accounts settings.
+```
+
+The three profiles on this machine carrying that group are bound to
+`com.pivi.dictus`, `.keyboard` and `.widgets`; a new bundle id needs the
+capability enabled in the developer portal, which needs an authenticated Xcode.
+The substance of the requirement — self-running, self-recording, nothing to tap
+while backgrounded — is unaffected. The results land in the app's own Documents
+directory, which `devicectl` reads over Wi-Fi with no interaction at all, which
+is less work for the maintainer than an export would have been. The App Group
+write is still attempted and its outcome recorded.
+
+---
+
+## What I am not comfortable asserting
+
+- **Any iPhone number.** Nothing in this document was measured on a phone. The
+  M4 Pro figures are floors with an unknown multiplier, exactly as the
+  predecessor's were, and the summary says "indicated", not "measured", for that
+  reason.
+
+- **That LUT6 inherits the 66/72 the predecessor measured.** That score is a
+  Q4_K_M build of `Qwen3-1.7B` served by Ollama; this is a 6-bit look-up-table
+  quantization with per-channel scales, produced by a different toolchain, and
+  ANEMLL's own README warns "Quantization should be improved. LUT4 quality is
+  fairly low due to lack of Block Quantization on Apple Neural Engine"
+  **[source]**. One fixture producing clean French is a sanity gate. Scoring this
+  build would mean putting an OpenAI-compatible façade in front of the ANE
+  runtime and re-running `polish-harness eval` — cheap enough, and worth nothing
+  until the latency question comes back positive.
+
+- **That 162 generated tokens is representative.** The `3-long` fixture is the
+  largest shipping one, and its polished output happens to be close to a copy of
+  its input. A mode that condenses or translates would decode a different amount,
+  and decode is the term that decides.
+
+- **That the undetermined operations in the compute plan are ANE operations.**
+  1,448 of them in the FFN chunk is more than the 1,166 that are named. They are
+  reported as undetermined because that is what Core ML returned.
+
+- **That 95.8 s of load is inherent.** It is what this bundle costs on this
+  machine at this ANEMLL version. Whether a monolithic build, a smaller context
+  or a different chunking loads faster was not investigated.
+
+- **That 28 tok/s is the Neural Engine's ceiling rather than ANEMLL's.** What was
+  measured is one open-source runtime, at 0.3.5, on one LUT6 chunked build. Apple
+  runs its own model on the same silicon and does not publish how. The claim this
+  document makes is about the option available to this product today — an
+  MIT-licensed toolchain and a public checkpoint — not about what the hardware
+  could do in principle. A future ANEMLL release could move this number; a
+  reopening of #268 on that basis would need it measured, not argued.
+
+---
+
+## Reproducing
+
+Everything below is `tools/ane-harness/`, after `./setup.sh`. The full manual is
+in that directory's `README.md`.
+
+```sh
+# The exact prompt, from the shipping source of truth
+cd DictusCore
+swift run polish-harness prompt Sources/polish-harness/fixtures/seed.json --id 3-long
+
+# Mac: the ANE run, and the CPU control
+cd tools/ane-harness/AneBenchKit
+swift run -c release ane-bench --iterations 3
+swift run -c release ane-bench --iterations 1 --max-tokens 60 --compute-units cpu
+
+# Phone: build, install, launch (needs the phone unlocked), collect
+cd tools/ane-harness
+xcodebuild build -project AneHarness.xcodeproj -scheme AneHarness -configuration Debug \
+  -destination 'id=<device-id>' -derivedDataPath build/DerivedData -allowProvisioningUpdates
+xcrun devicectl device install app --device <device-id> \
+  build/DerivedData/Build/Products/Debug-iphoneos/AneHarness.app
+xcrun devicectl device process launch --device <device-id> --terminate-existing \
+  com.pivi.dictus.anebench
+# press Home, or launch any other app from the Mac, then:
+xcrun devicectl device copy from --device <device-id> --domain-type appDataContainer \
+  --domain-identifier com.pivi.dictus.anebench --source Documents --destination ./out
+```

--- a/docs/research/268-ane-background-llm.md
+++ b/docs/research/268-ane-background-llm.md
@@ -34,58 +34,59 @@ Same scheme as the predecessor, because the two documents are read together.
 
 ## Summary
 
-1. **The ANE holds the prompt. That question is answered, and it turns out not
-   to be the one that decides.** A 1,680-token prefill runs to completion in a
-   2048-context ANEMLL build of Qwen3 1.7B, stopping on EOS with no window shift
-   and no truncation **[measured]**. The predecessor's "does it fit" worry is
-   closed for modern silicon.
+**#268's question is answered, and the answer is no — but not for any of the
+reasons the spike expected.**
 
-2. **Core ML really does place it on the Neural Engine, and this is read from
-   Core ML rather than inferred from a timing.** `MLComputePlan` reports **1,166
-   ANE operations against 13 CPU** in the transformer chunk under
-   `.cpuAndNeuralEngine`, and **0 ANE against 1,179 CPU** for the same file under
-   `.cpuOnly` **[measured]**.
+1. **A backgrounded DictusApp *can* reach the Neural Engine.** On the phone,
+   backgrounded, Core ML's compute plan is byte-for-byte the Mac's: **1,166 ANE
+   operations against 13 CPU** in the transformer chunk, **0 GPU** everywhere
+   **[measured]**. It does not silently re-plan onto the CPU when the app leaves
+   the foreground. That mechanism was the predecessor's largest open question.
 
-3. **The decisive cost is decode, not prefill, and no prompt redesign touches
-   it.** On an M4 Pro, ANE-resident, thinking off: prefill of the real French
-   polish prompt is **2.69–3.31 s**, decode of the 162-token answer is
-   **5.80–5.91 s**, total **8.49–9.15 s** per polish call **[measured]**. The
-   pre-registered budget is p50 ≤ 5 s. **Decode alone misses it**, so the one
-   lever the predecessor identified — shorten the 1,150-token instruction block —
-   cannot rescue this: it is arithmetic on the wrong term **[derived]**.
+2. **The ANE holds the prompt.** 1,680 tokens of prefill inside a 2048-context
+   ANEMLL build, EOS stop, coherent French **[measured]**.
 
-4. **The ANE is much better than the CPU at prefill and barely better at
-   decode.** Same model, same prompt, same process: prefill **6.5× faster**
-   (3.05 s median vs 19.78 s) but decode only **1.35× faster** (27.7 vs
-   20.8 tok/s) **[measured]**. Against the predecessor's Metal figures for the same
-   checkpoint, the GPU decodes roughly **4×** faster than the ANE does
-   **[derived]**. The Neural Engine is not a small GPU; it is a prefill engine.
+3. **And it costs 14 seconds.** Backgrounded on an `iPhone16,2` at `nominal`
+   thermal, three consecutive iterations: prefill **4.5–4.9 s**, decode
+   **9.3–9.5 s**, **total 13.8–14.4 s** per polish call **[measured]**. The
+   pre-registered budget is p50 ≤ 5 s; the Apple FM field baseline on this exact
+   device is p50 **1,654 ms** **[field]**. That is **2.8× the ceiling and 8.4×
+   the incumbent**.
 
-5. **No conversion was needed, and none was attempted.** ANEMLL publishes
-   `anemll-Qwen-Qwen3-1.7B-ctx2048_0.3.5` — the exact candidate, converted by the
-   toolchain's own authors at the version #268 names, with the conversion
-   parameters recorded in its `meta.yaml` **[source]**. This is a deliberate
-   deviation from the issue's step 1, and it is the reason the time-box the issue
-   set aside for toolchain trouble was not spent. See
-   [Deviations](#deviations-from-the-issue).
+4. **Memory is not the constraint, and the whole memory argument was measuring
+   the wrong thing.** With all 1.8 GB of weights loaded: **3,090 MB** of jetsam
+   headroom left and a `phys_footprint` of **284 MB** **[measured]**, against
+   D1's 3,369 MB baseline on the same device **[field]**. Core ML maps ANE
+   weights instead of allocating them, so **1.8 GB of model costs about 280 MB of
+   the budget jetsam enforces**. The pre-registered 1.2 GB ceiling, D1's
+   correction of it, and the addendum's "does 1.9 GB fit alongside Parakeet"
+   table all priced a quantity that does not bind.
 
-6. **Placing the model on the ANE costs 96–104 s of load, every process
-   launch.** Against 21.2 s for the same bundle under `.cpuOnly` **[measured]**. Not
-   fatal — DictusApp is long-lived and pre-loads at launch — but it is a real
-   number that a shipping integration would have to hide, and it is not one the
-   predecessor's Ollama load times (1.7–2.5 s) predict.
+5. **The binding term is decode, and no prompt redesign touches it.** Decode is
+   9.4 s of the 14 s. The one lever the predecessor identified — shorten the
+   1,150-token instruction block — moves prefill only, so even a prompt of length
+   zero leaves 9.4 s **[derived]**. A future candidate would need roughly **3×**
+   ANEMLL 0.3.5's decode rate on this checkpoint to land inside the budget.
 
-7. **The device measurement is not in this document yet.** Everything above is a
-   Mac. A Mac has no jetsam and no application lifecycle, so it cannot answer the
-   question in #268's title. The apparatus is built, installed on the iPhone, and
-   rehearsed end to end in a simulator with `allIterationsBackgrounded=true`; it
-   is blocked on one thing, which is that `devicectl` will not launch an app on a
-   locked phone. See [What is still missing](#what-is-still-missing).
+6. **Sustained ANE inference throttles the phone.** A first run that began at
+   `thermal=fair` crossed to `serious` within ninety seconds; decode fell from
+   13.5 to 7.0 tok/s and the call reached **33.9 s** **[measured]**. DictusApp
+   stays warm between dictations by design, which is the pattern that produces
+   this curve.
 
-**Reading so far: the ANE is reachable and the prompt fits, and the candidate
-still misses the latency budget on hardware faster than any iPhone.** The device
-run can move that from "indicated" to "measured"; on the evidence here it is
-unlikely to reverse it.
+7. **No conversion was needed and none was attempted.** ANEMLL publishes
+   `anemll-Qwen-Qwen3-1.7B-ctx2048_0.3.5` — the exact candidate, at the release
+   #268 names, conversion parameters recorded in its `meta.yaml` **[source]**. A
+   deliberate deviation from the issue's step 1; see
+   [Deviations](#deviations-from-the-issue). There is no toolchain failure to
+   report: the model converted, loaded, and ran.
+
+8. **Loading is a once-per-install cost, not a per-launch one.** 118.5 s the
+   first time on the device, **2.1 s** every time after **[measured]**.
+
+**Against the pre-registered rule this is the negative branch: close #268.** The
+detail, and what a future reopening would have to show, is in
+[The decision](#the-decision-against-the-rule-that-was-registered-before-the-measurement).
 
 ---
 
@@ -121,6 +122,13 @@ outputs contain no reasoning.
 asserting" records that the fallback mechanism was never investigated. So the
 harness reads `MLComputePlan.deviceUsage(for:)` per operation, and
 `--compute-units cpu` gives the contrast.
+
+**And the protocol was rehearsed before it was used.** The whole flow ran on an
+iPhone 17 Pro Max simulator first, backgrounded by launching Safari over it,
+ending on `allIterationsBackgrounded=true` **[measured]**. None of its numbers
+mean anything — a simulator has no Neural Engine, so it ran the CPU path that
+produces gibberish — but it meant the maintainer's phone was not the place where
+a crash-on-launch would be discovered.
 
 ---
 
@@ -193,7 +201,12 @@ which is the constraint the predecessor's Finding 1 established.
 The 1,448 operations Core ML declines to plan a device for are reported as
 undetermined rather than folded into any column. An absent count is not a zero.
 
-## Finding 4 — latency, and the term that decides
+## Finding 4 — latency on the Mac, and the term that decides
+
+This is the gate, not the answer; Finding 6 has the phone. It is kept because the
+Mac is where the shape of the problem became visible, and because the
+iPhone-to-Mac multiplier it establishes (1.65×) is useful to anyone reading the
+predecessor's Mac-only tables.
 
 Measured on **Apple M4 Pro, 14 cores, 24 GB, macOS 26.5.1**, `temperature: 0`,
 thinking off, the real French polish prompt, ANEMLL Swift runtime **[measured]**:
@@ -216,7 +229,8 @@ Against the two numbers the decision rule names:
   **p50 1,654 ms**, p90 4,842 ms **[field]**.
 
 **8.5 s on an M4 Pro is 5× the Apple FM baseline and 1.7× the budget ceiling.**
-The predecessor establishes that a Mac figure is a *floor* for any iPhone.
+The predecessor establishes that a Mac figure is a *floor* for any iPhone, and
+Finding 6 measures the multiplier: **1.65×**, for 14.0 s on the phone.
 
 ### Why the prompt-shortening lever does not apply
 
@@ -252,14 +266,15 @@ Model load, same bundle, same machine **[measured]**:
 | `.cpuAndNeuralEngine` | **95,827 ms** and **103,636 ms**, two separate processes |
 | `.cpuOnly` | 21,227 ms |
 
-Some 75–82 seconds of that is ANE placement. It is paid per process launch, and
-it did not shrink on a later launch from the same path — ANEMLL's README says
-"subsequent loads will be instantaneous" **[source]**, and that was not observed
-here. DictusApp is long-lived and
-already pre-loads its STT model at launch, so this is an engineering problem
-rather than a blocker — but a first dictation after an app cold start would find
-the model still loading, and no Ollama figure in the predecessor (1.7–2.5 s
-load) hints at it.
+Some 75–82 seconds of that is ANE placement, and on the Mac it did not shrink on
+a later launch from the same path — ANEMLL's README says "subsequent loads will
+be instantaneous" **[source]** and that was not observed here.
+
+**On the phone it is.** Finding 6 measures 118.5 s the first time and 2.1 s every
+time after, so the Mac behaviour above is a macOS quirk and not a property of the
+model. It is recorded rather than dropped because it is what the Mac gate saw,
+and because it would otherwise look like an unexplained discrepancy with the
+device figures.
 
 ## Finding 5 — the CPU is not a fallback for this artifact
 
@@ -277,82 +292,182 @@ if the ANE is unavailable or busy.
 
 ---
 
-## What is still missing
+## Finding 6 — the device, backgrounded: the measurement #268 asked for
 
-**The device run.** This is D2's actual question and it is the one thing a Mac
-cannot stand in for: there is no jetsam on a Mac, and no `applicationState` to be
-in the background of.
+`iPhone16,2`, iOS 26.6, 8 GB, `AneHarness.app` backgrounded, three iterations,
+same prompt, same `temperature: 0`, thinking off. Collected 2026-08-22
+**[measured]**. Two runs, and the difference between them is itself a finding.
 
-The apparatus is complete and installed:
-
-- `AneHarness.app`, bundle id `com.pivi.dictus.anebench`, built from this branch,
-  installed on `iPhone16,2` on 2026-08-22 **[measured]**. It is not a target of
-  `Dictus.xcodeproj`, so the "Generate build info" phase never runs for it and
-  its output reads `rev unknown` — there is no revision line to check on this
-  one, unlike every other build the maintainer validates.
-- It stays alive backgrounded the same way DictusApp does — `UIBackgroundModes:
-  audio` plus a running `AVAudioEngine` — because reproducing that state is the
-  measurement, not a workaround.
-- It loads in the foreground, waits to be backgrounded rather than counting down
-  at the person holding the phone, then runs three iterations on its own.
-- Every reading carries `os_proc_available_memory()`, `phys_footprint`, thermal
-  state **and the lifecycle state it was taken in**. The report prints
-  `allIterationsBackgrounded`, so a run that was not backgrounded reports itself
-  as invalid rather than as a number.
-
-**The apparatus itself has been run end to end**, on an iPhone 17 Pro Max
-simulator, backgrounded by launching Safari over it **[measured]**. Everything
-except the ANE worked: the app launched, the audio keep-alive kept it alive
-through eight minutes in the background, the model loaded from the bundle, the
-prompt built from DictusCore to the same 1,680 tokens, three iterations ran, the
-results were written and read back, and the file ends
+### Run B — the clean one, thermal `nominal` throughout
 
 ```text
+ane-bench — #268 D2
+rev unknown | iPhone16,2 | Version 26.6 (Build 23G71) | ramGB=8
+model ctx=2048 batch=64 computeUnits=cpuAndNeuralEngine
+prompt 3-long systemChars=5483 userChars=729
+modelLoadMs=2079
+computePlan qwen_FFN_PF_lut6_chunk_01of02.mlmodelc: ANE 1166 / CPU 13 / GPU 0
+iteration 1 prefillMs=4947 (340 tok/s) decodeMs=9480 generated=162 (17.1 tok/s) totalMs=14427 stop=eos_token
+  iteration1.start available=3091MB footprint=284MB thermal=nominal state=background
+  iteration1.done  available=3090MB footprint=285MB thermal=nominal state=background
+iteration 2 prefillMs=4463 (376 tok/s) decodeMs=9337 generated=162 (17.4 tok/s) totalMs=13800 stop=eos_token
+iteration 3 prefillMs=4476 (375 tok/s) decodeMs=9358 generated=162 (17.3 tok/s) totalMs=13834 stop=eos_token
 allIterationsBackgrounded=true
 ```
 
-with every sample reading `state=background`. **None of its numbers mean
-anything** — a simulator has no Neural Engine, so it ran the same CPU path that
-produces gibberish on the Mac, at 1.6–4.0 tok/s. It is a rehearsal of the
-protocol, not a measurement, and it is recorded here only because it removes
-"does the harness work" from the list of things the maintainer's unlock window
-could be spent discovering.
+Every sample in every iteration reads `state=background` and `thermal=nominal`.
+This is the number.
 
-It has not run on the phone, for one reason: `devicectl` cannot launch an app on
-a locked phone.
+### What it answers
 
-```text
-Unable to launch com.pivi.dictus.anebench because the device was not, or could
-not be, unlocked. (FBSOpenApplicationErrorDomain error 7)
-```
+**The ANE is reachable from a backgrounded app, and the compute plan proves it
+rather than implying it.** The on-device plan is byte-for-byte the Mac's — 1,166
+ANE operations against 13 CPU in the transformer chunk, 0 GPU in every row
+**[measured]**. Core ML does not silently re-plan onto the CPU when the app
+leaves the foreground. That was an open mechanism in the predecessor, named in
+its own "what I am not comfortable asserting", and it is now closed.
 
-Everything after "unlock the phone" is automatable from the Mac — the run needs
-no taps, and `devicectl device copy from --domain-type appDataContainer` fetches
-the results over Wi-Fi. The steps are in the PR and in
-`tools/ane-harness/README.md`.
+**The prompt fits.** 1,680 tokens of prefill, EOS stop after 162 generated
+tokens, coherent French identical in substance to the Mac's.
 
-**What the device run adds, beyond confirming or refusing the Mac figures:**
+**Memory is not the constraint, and it is not close.** This is the result that
+most contradicts the predecessor:
 
-- the iPhone multiplier on 8.3 s, which is the number the decision rule wants;
-- `os_proc_available_memory()` with the model resident, against D1's 3.33 GB
-  backgrounded headroom — how much of it a 1.8 GB tenant plus its KV cache
-  actually costs, and what is left for Parakeet's ~800 MB. **This one cannot be
-  guessed from the Mac readings, and the reason is worth stating**: with the
-  whole 1.8 GB model loaded, `phys_footprint` read **324 MB** on the Mac and
-  **100 MB** in the simulator **[measured]**. Core ML's weights are mapped, not
-  allocated, so the footprint number does not see most of them. Whether jetsam
-  does is exactly what `os_proc_available_memory()` answers, and it returns 0
-  anywhere but a device **[code]** `DictusCore/DeviceCapabilities.swift:103`;
-- whether the ANE is reachable at all from a backgrounded process for an LLM, or
-  whether Core ML silently re-plans onto the CPU there. The harness reads the
-  compute plan on device, so this is answerable rather than arguable.
+| | |
+| --- | --- |
+| Jetsam headroom with the whole model loaded | **3,090 MB** |
+| `phys_footprint` | **284–285 MB** |
+| D1's baseline, DictusApp at launch, same device | 3,369 MB **[field]** |
 
-**What was not attempted, and is not on the way to an answer:** running Parakeet
-and the LLM in the same process. D1 gives Parakeet's cost and this gives the
-LLM's; composing them is arithmetic, and the composition is only worth measuring
-if the latency question comes back positive.
+**1.8 GB of weights cost about 280 MB of jetsam headroom.** Core ML maps ANE
+weights rather than allocating them into the process, so almost none of the model
+lands in the budget jetsam enforces. The 280 MB is a comparison across two
+different processes — this harness against DictusApp in D1 — so read it as an
+order of magnitude; the load-bearing figure is the absolute one, **3,090 MB still
+available with the model fully loaded and running**, which needs no comparison at
+all. Every memory argument in the predecessor —
+the pre-registered 1.2 GB ceiling, the correction to 3.33 GB, the "does 1.9 GB
+fit alongside Parakeet's ~800 MB" arithmetic in the addendum — was measuring the
+wrong quantity. Neither the ceiling nor its falsification decides anything.
+
+The readings are also flat across three iterations (3,091 → 3,090 → 3,091 MB), so
+the KV cache does not grow between calls.
+
+### What it refuses
+
+| | Backgrounded, `nominal` | Budget | Apple FM field baseline |
+| --- | --- | --- | --- |
+| Prefill, 1,680 tokens | 4,463 – 4,947 ms | | |
+| Decode, 162 tokens | 9,337 – 9,480 ms | | |
+| **Total per polish call** | **13,800 – 14,427 ms** | **≤ 5,000 ms** | **1,654 ms** **[field]** |
+
+**2.8× the budget ceiling and 8.4× what Apple FM actually delivers on this
+device.** Not a near miss.
+
+And the term that decides is decode, as the Mac indicated: 9.4 s of a 14 s call.
+Prefill is 4.5 s. Even a prompt of length zero leaves 9.4 s, so the one lever the
+predecessor identified — shorten the 1,150-token instruction block — still
+cannot reach the budget **[derived]**.
+
+The iPhone-to-Mac multiplier is **1.65×** on the total (14.0 s against 8.5 s),
+which confirms the predecessor's "a Mac figure is a floor" framing without
+needing it to be conservative.
+
+### Run A — what thermal pressure does, and why it is not a footnote
+
+The first run started at `thermal=fair` and crossed to `serious` during it
+**[measured]**:
+
+| Iteration | Prefill | Decode | Total | Thermal |
+| --- | --- | --- | --- | --- |
+| 1 | 8,966 ms | 12,042 ms | **21,008 ms** | `fair` |
+| 2 | 9,743 ms | 17,370 ms | **27,113 ms** | `fair` → `serious` |
+| 3 | 10,725 ms | 23,158 ms | **33,883 ms** | `serious` |
+
+Decode falls from 13.5 to 7.0 tok/s across roughly ninety seconds of ANE work.
+**Sustained LLM inference on the ANE heats an iPhone until the SoC throttles**,
+and the throttled figure is 34 s — 6.8× the budget.
+
+This matters more for Dictus than a benchmark footnote suggests, because
+DictusApp runs under `UIBackgroundModes: audio` and stays warm between
+dictations. A user dictating repeatedly would be holding the ANE busy in exactly
+the pattern that produced this curve, and thermal state also throttles the
+transcription that has to happen first.
+
+Iterations 2 and 3 of run A carry `state=active` — the app came to the foreground
+mid-run — so run A does not qualify as a background measurement and its file says
+`allIterationsBackgrounded=false`. Its iteration 1 is clean and is quoted above
+on its own terms. Run B replaces it as the measurement; run A is kept because the
+thermal curve is real evidence and run B, being short and starting cold, does not
+show it.
+
+### The load cost, corrected
+
+| | |
+| --- | --- |
+| First load on the device, ever | **118,501 ms** |
+| Every load after that | **2,079 ms** |
+
+ANEMLL's README says "the first time the model loads, macOS will take some time
+to place it on the device. Subsequent loads will be instantaneous" **[source]**.
+On the phone that is exactly right. On the Mac it was not — two separate
+processes loading the same bundle from the same path both paid 96–104 s
+**[measured]**. Whatever caches the ANE placement works on iOS and did not here.
+
+So the two-minute load is a once-per-install cost, not a once-per-launch one, and
+it is not an argument against anything.
 
 ---
+
+## The decision, against the rule that was registered before the measurement
+
+#268 pre-registered this:
+
+> **Negative** — the ANE cannot hold the prompt, or backgrounded latency lands
+> above the p50 ≤ 5 s budget: **close this issue permanently**. Both rationales
+> are then answered and a second local backend is not a thing Dictus does.
+
+The first clause fails and the second holds. The ANE *does* hold the prompt, and
+memory turned out not to be a constraint at all — but backgrounded latency is
+**13.8–14.4 s at nominal thermal and up to 33.9 s under thermal pressure**,
+against a 5 s ceiling and a 1,654 ms incumbent.
+
+**That is the negative branch. #268 should be closed.**
+
+Two things are worth saying about *how* it is closed, because they are not the
+same as the reasons anyone expected.
+
+**It is not closed on memory.** The predecessor's whole arithmetic — a 1.2 GB
+ceiling, D1's correction to 3.33 GB, the table of which candidates fit — measured
+a quantity that does not bind. An ANE-resident Core ML model costs the app
+roughly 280 MB of jetsam headroom regardless of how many gigabytes of weights it
+has. If this question is ever reopened, that page of reasoning should not be
+reopened with it.
+
+**It is not closed on "the ANE is unreachable in the background" either.** It is
+reachable, it is planned, it works. A future reopening would need a decode rate
+roughly **three times** what ANEMLL 0.3.5 delivers on this checkpoint —
+17.3 tok/s measured, and about 55 tok/s needed to land 162 tokens plus prefill
+inside 5 s **[derived]**. That is the number to hold any future candidate to, and
+it is a measurement, not an argument.
+
+---
+
+## What was not measured, and does not need to be
+
+**Parakeet and the LLM resident in one process.** The composition is no longer
+interesting: the LLM costs ~280 MB of headroom, D1 showed Parakeet's whole
+transcription cycle moving the same reading by ~35 MB, and there is 3 GB of room
+**[derived]**. Memory was never going to be the deciding term and now demonstrably
+is not.
+
+**Whether a shorter prompt or a smaller model gets under the budget.** Out of
+scope: #268 is about `qwen3:1.7b`, and its decode rate misses by 3×. A different
+model is a different issue, opened for a named model with a named footprint, as
+the coverage half already requires.
+
+**Quality of this LUT6 build through `polish-harness eval`.** It would have
+mattered only if the latency had come back positive. See below.
 
 ## Deviations from the issue
 
@@ -384,18 +499,25 @@ The three profiles on this machine carrying that group are bound to
 capability enabled in the developer portal, which needs an authenticated Xcode.
 The substance of the requirement — self-running, self-recording, nothing to tap
 while backgrounded — is unaffected. The results land in the app's own Documents
-directory, which `devicectl` reads over Wi-Fi with no interaction at all, which
-is less work for the maintainer than an export would have been. The App Group
-write is still attempted and its outcome recorded.
+directory, which `devicectl device copy from --domain-type appDataContainer`
+reads over Wi-Fi. In practice this cost the maintainer *less* than the App Group
+route would have: the entire measurement — launch, background, three iterations,
+collection — was driven from the Mac, and the only human act in it was unlocking
+the phone. The App Group write is still attempted and its outcome recorded.
 
 ---
 
 ## What I am not comfortable asserting
 
-- **Any iPhone number.** Nothing in this document was measured on a phone. The
-  M4 Pro figures are floors with an unknown multiplier, exactly as the
-  predecessor's were, and the summary says "indicated", not "measured", for that
-  reason.
+- **That one device generalises.** Everything phone-shaped here is one
+  `iPhone16,2` on iOS 26.6. The conclusion survives a wide margin — 14 s against
+  a 5 s ceiling — so a faster phone does not flip it without a 3× improvement,
+  but the *numbers* are one device's.
+
+- **That the three iterations of run B are a p50.** They are three consecutive
+  calls on one fixture, minutes apart, in one thermal state. The spread is
+  narrow (13.8–14.4 s) and that is all it establishes. The budget is written as a
+  p50 and this is not one.
 
 - **That LUT6 inherits the 66/72 the predecessor measured.** That score is a
   Q4_K_M build of `Qwen3-1.7B` served by Ollama; this is a 6-bit look-up-table
@@ -416,17 +538,27 @@ write is still attempted and its outcome recorded.
   1,448 of them in the FFN chunk is more than the 1,166 that are named. They are
   reported as undetermined because that is what Core ML returned.
 
-- **That 95.8 s of load is inherent.** It is what this bundle costs on this
-  machine at this ANEMLL version. Whether a monolithic build, a smaller context
-  or a different chunking loads faster was not investigated.
+- **That the load numbers say anything about a shipping integration.** 118.5 s
+  once and 2.1 s after is what this bundle costs on this device at this ANEMLL
+  version, installed as an app resource. A real integration would download the
+  weights rather than bundle them, and whether the ANE placement cache survives
+  that, an OS update, or a device reboot was not tested.
 
-- **That 28 tok/s is the Neural Engine's ceiling rather than ANEMLL's.** What was
-  measured is one open-source runtime, at 0.3.5, on one LUT6 chunked build. Apple
-  runs its own model on the same silicon and does not publish how. The claim this
-  document makes is about the option available to this product today — an
-  MIT-licensed toolchain and a public checkpoint — not about what the hardware
+- **That 17.3 tok/s is the Neural Engine's ceiling rather than ANEMLL's.** What
+  was measured is one open-source runtime, at 0.3.5, on one LUT6 chunked build.
+  Apple runs its own model on the same silicon and does not publish how. The
+  claim this document makes is about the option available to this product today —
+  an MIT-licensed toolchain and a public checkpoint — not about what the hardware
   could do in principle. A future ANEMLL release could move this number; a
-  reopening of #268 on that basis would need it measured, not argued.
+  reopening of #268 on that basis would need it measured, not argued, against the
+  ~55 tok/s the budget implies.
+
+- **That the thermal curve in run A is characterised.** It is one run, and the
+  phone's starting state was not controlled — it read `fair` before any
+  measurement began. What it shows is that ANE inference at this duty cycle
+  reaches `serious` and that decode degrades roughly 2× when it does. How quickly
+  it recovers, and what a realistic dictation cadence would do, were not
+  measured.
 
 ---
 
@@ -453,7 +585,12 @@ xcrun devicectl device install app --device <device-id> \
   build/DerivedData/Build/Products/Debug-iphoneos/AneHarness.app
 xcrun devicectl device process launch --device <device-id> --terminate-existing \
   com.pivi.dictus.anebench
-# press Home, or launch any other app from the Mac, then:
+
+# Poll Documents/phase.txt until it reads waiting-for-background (~2 min the first
+# time, ~5 s after), then background the harness without touching the phone:
+xcrun devicectl device process launch --device <device-id> com.apple.Preferences
+
+# Poll again until phase.txt reads done (~45 s), then:
 xcrun devicectl device copy from --device <device-id> --domain-type appDataContainer \
   --domain-identifier com.pivi.dictus.anebench --source Documents --destination ./out
 ```

--- a/tools/ane-harness/AneBenchKit/Package.swift
+++ b/tools/ane-harness/AneBenchKit/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version: 6.0
+//
+// THROWAWAY — #268 D2. Not part of the app: nothing in Dictus.xcodeproj, in
+// DictusCore's package, or in CI references this. It exists to answer one
+// question — can a backgrounded DictusApp reach the Neural Engine to run an
+// LLM — and it is meant to be deleted with the branch that carries it.
+//
+// `../.deps/Anemll` does not exist in a fresh checkout: run ../setup.sh first,
+// or this manifest fails to load.
+import PackageDescription
+
+let package = Package(
+    name: "ane-harness",
+    // macOS 26 comes from DictusCore, which the polish prompts live in;
+    // iOS 18 is AnemllCore's floor. The harness itself needs neither.
+    platforms: [.iOS(.v18), .macOS("26.0")],
+    products: [
+        .library(name: "AneBenchKit", targets: ["AneBenchKit"]),
+        .executable(name: "ane-bench", targets: ["ane-bench"])
+    ],
+    dependencies: [
+        .package(path: "../../../DictusCore"),
+        .package(path: "../.deps/Anemll/anemll-swift-cli")
+    ],
+    targets: [
+        .target(
+            name: "AneBenchKit",
+            dependencies: [
+                .product(name: "DictusCore", package: "DictusCore"),
+                .product(name: "AnemllCore", package: "anemll-swift-cli")
+            ],
+            resources: [.copy("Resources/seed.json")]
+        ),
+        .executableTarget(name: "ane-bench", dependencies: ["AneBenchKit"])
+    ]
+)

--- a/tools/ane-harness/AneBenchKit/Sources/AneBenchKit/AneBenchRunner.swift
+++ b/tools/ane-harness/AneBenchKit/Sources/AneBenchKit/AneBenchRunner.swift
@@ -27,17 +27,25 @@ public actor AneBenchRunner {
         /// same harness can produce the contrast that proves the ANE was doing
         /// the work — a fast number alone does not name a processor.
         public let computeUnits: MLComputeUnits
+        /// Leave Qwen 3's reasoning on. Off by default because a polish call is a
+        /// rewrite and no shipping product would pay for the tokens; exposed
+        /// because "the converted model barely polishes" and "the converted model
+        /// was not allowed to think" are two different explanations and only a
+        /// run with this flipped tells them apart.
+        public let allowThinking: Bool
 
         public init(modelDirectory: URL,
                     maxNewTokens: Int = 280,
                     iterations: Int = 3,
                     fixtureID: String = "3-long",
-                    computeUnits: MLComputeUnits = .cpuAndNeuralEngine) {
+                    computeUnits: MLComputeUnits = .cpuAndNeuralEngine,
+                    allowThinking: Bool = false) {
             self.modelDirectory = modelDirectory
             self.maxNewTokens = maxNewTokens
             self.iterations = iterations
             self.fixtureID = fixtureID
             self.computeUnits = computeUnits
+            self.allowThinking = allowThinking
         }
     }
 
@@ -94,7 +102,9 @@ public actor AneBenchRunner {
         }
         let prompt = try PolishPrompt.natural(fixtureID: configuration.fixtureID)
         self.prompt = prompt
-        self.promptTokens = Self.tokens(for: prompt, tokenizer: tokenizer)
+        self.promptTokens = Self.tokens(for: prompt,
+                                        tokenizer: tokenizer,
+                                        allowThinking: configuration.allowThinking)
 
         progress("Loading Core ML models onto the Neural Engine…")
         let loadStart = Date()
@@ -184,7 +194,8 @@ public actor AneBenchRunner {
             systemVersion: ProcessInfo.processInfo.operatingSystemVersionString,
             physicalMemoryGB: capabilities.physicalMemoryGB,
             modelBundle: configuration.modelDirectory.lastPathComponent,
-            computeUnits: Self.describe(configuration.computeUnits),
+            computeUnits: Self.describe(configuration.computeUnits)
+                + (configuration.allowThinking ? " +thinking" : ""),
             contextLength: config.contextLength,
             batchSize: config.batchSize,
             fixtureID: prompt.fixtureID,
@@ -216,12 +227,15 @@ public actor AneBenchRunner {
     /// with thinking silently ON and discarded the whole pass when it noticed —
     /// a polish call is a rewrite, not a puzzle, and letting the model reason
     /// reports a latency no shipped product would pay.
-    private static func tokens(for prompt: PolishPrompt, tokenizer: Tokenizer) -> [Int] {
+    private static func tokens(for prompt: PolishPrompt,
+                               tokenizer: Tokenizer,
+                               allowThinking: Bool) -> [Int] {
         let templated = tokenizer.applyChatTemplate(
             input: [Tokenizer.ChatMessage.system(prompt.system),
                     Tokenizer.ChatMessage.user(prompt.user)],
             addGenerationPrompt: true
         )
+        guard !allowThinking else { return templated }
         return templated + tokenizer.tokenize("<think>\n\n</think>\n\n")
     }
 }

--- a/tools/ane-harness/AneBenchKit/Sources/AneBenchKit/AneBenchRunner.swift
+++ b/tools/ane-harness/AneBenchKit/Sources/AneBenchKit/AneBenchRunner.swift
@@ -52,11 +52,17 @@ public actor AneBenchRunner {
     public enum RunError: Error, CustomStringConvertible {
         case metaMissing(URL)
         case notLoaded
+        /// The shipping polish prompts are reached through an entry point gated on
+        /// iOS/macOS 26. Its own case, because "the OS is too old" and "you called
+        /// run() before prepare()" send a reader to different places.
+        case unsupportedOSVersion
 
         public var description: String {
             switch self {
             case .metaMissing(let url): return "meta.yaml not found at \(url.path)"
             case .notLoaded: return "prepare() must succeed before run()"
+            case .unsupportedOSVersion:
+                return "the shipping polish prompts need iOS 26 / macOS 26 or later"
             }
         }
     }
@@ -68,6 +74,7 @@ public actor AneBenchRunner {
     private var prompt: PolishPrompt?
     private var promptTokens: [Int] = []
     private var modelLoadMs = 0
+    private var modelRevision = "unknown"
     private var computePlans: [ComputePlanSummary] = []
     private var notes: [String] = []
 
@@ -86,6 +93,10 @@ public actor AneBenchRunner {
             throw RunError.metaMissing(metaURL)
         }
 
+        modelRevision = (try? String(contentsOf: configuration.modelDirectory
+            .appendingPathComponent("REVISION.txt"), encoding: .utf8))?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? "unknown"
+
         progress("Reading meta.yaml…")
         let config = try YAMLConfig.load(from: metaURL.path)
         self.config = config
@@ -98,9 +109,9 @@ public actor AneBenchRunner {
         guard #available(iOS 26.0, macOS 26.0, *) else {
             // The prompts are reached through the Apple FM engine's one entry
             // point, which carries that gate. Nothing here calls Apple's model.
-            throw RunError.notLoaded
+            throw RunError.unsupportedOSVersion
         }
-        let prompt = try PolishPrompt.natural(fixtureID: configuration.fixtureID)
+        let prompt = try PolishPrompt.resolved(fixtureID: configuration.fixtureID)
         self.prompt = prompt
         self.promptTokens = Self.tokens(for: prompt,
                                         tokenizer: tokenizer,
@@ -172,13 +183,23 @@ public actor AneBenchRunner {
             let totalSeconds = Date().timeIntervalSince(callStart)
             samples.append(await ProcessProbe.sample("iteration\(index).done", since: origin))
 
+            // Not clamped. The runtime reports prefill separately and this
+            // derives decode by subtraction, so a negative difference would mean
+            // the two clocks disagree — a measurement fault. Clamping it to zero
+            // would print a plausible decode time for a run that should be thrown
+            // away, which is the one thing a harness must never do.
             let prefillMs = Int(prefillSeconds * 1000)
+            let decodeMs = Int(totalSeconds * 1000) - prefillMs
+            if decodeMs < 0 {
+                notes.append("iteration \(index): prefill (\(prefillMs) ms) exceeds the "
+                             + "measured call (\(Int(totalSeconds * 1000)) ms) — timings are unreliable")
+            }
             iterations.append(IterationReport(
                 index: index,
                 promptTokens: promptTokens.count,
                 generatedTokens: tokens.count,
                 prefillMs: prefillMs,
-                decodeMs: max(0, Int(totalSeconds * 1000) - prefillMs),
+                decodeMs: decodeMs,
                 stopReason: stopReason,
                 output: tokenizer.detokenize(tokens),
                 samples: samples
@@ -194,11 +215,12 @@ public actor AneBenchRunner {
             systemVersion: ProcessInfo.processInfo.operatingSystemVersionString,
             physicalMemoryGB: capabilities.physicalMemoryGB,
             modelBundle: configuration.modelDirectory.lastPathComponent,
+            modelRevision: modelRevision,
             computeUnits: Self.describe(configuration.computeUnits)
                 + (configuration.allowThinking ? " +thinking" : ""),
             contextLength: config.contextLength,
             batchSize: config.batchSize,
-            fixtureID: prompt.fixtureID,
+            fixtureID: "\(prompt.fixtureID) (\(prompt.mode))",
             systemPromptChars: prompt.system.count,
             userTurnChars: prompt.user.count,
             modelLoadMs: modelLoadMs,

--- a/tools/ane-harness/AneBenchKit/Sources/AneBenchKit/AneBenchRunner.swift
+++ b/tools/ane-harness/AneBenchKit/Sources/AneBenchKit/AneBenchRunner.swift
@@ -1,0 +1,227 @@
+// tools/ane-harness/Sources/AneBenchKit/AneBenchRunner.swift
+//
+// THROWAWAY — #268 D2. The measurement itself.
+//
+// Load and run are two separate calls on purpose. Placing a 1.9 GB model on the
+// Neural Engine is a one-off cost the OS pays and caches; #268 asks what a
+// polish call costs, and a polish call in the shipping product never pays it.
+// Splitting them also lets the iOS harness load while the maintainer is still
+// looking at the screen and run once he has backgrounded the app, which is the
+// only state the question is about.
+import Foundation
+import CoreML
+import AnemllCore
+import DictusCore
+
+public actor AneBenchRunner {
+
+    public struct Configuration: Sendable {
+        /// Directory holding meta.yaml and the .mlmodelc bundles.
+        public let modelDirectory: URL
+        /// Upper bound on generated tokens. The shipping polish output for the
+        /// `3-long` fixture is ~200 tokens; the cap is a guard, not a target.
+        public let maxNewTokens: Int
+        public let iterations: Int
+        public let fixtureID: String
+        /// `.cpuAndNeuralEngine` is the experiment. `.cpuOnly` exists so the
+        /// same harness can produce the contrast that proves the ANE was doing
+        /// the work — a fast number alone does not name a processor.
+        public let computeUnits: MLComputeUnits
+
+        public init(modelDirectory: URL,
+                    maxNewTokens: Int = 280,
+                    iterations: Int = 3,
+                    fixtureID: String = "3-long",
+                    computeUnits: MLComputeUnits = .cpuAndNeuralEngine) {
+            self.modelDirectory = modelDirectory
+            self.maxNewTokens = maxNewTokens
+            self.iterations = iterations
+            self.fixtureID = fixtureID
+            self.computeUnits = computeUnits
+        }
+    }
+
+    public enum RunError: Error, CustomStringConvertible {
+        case metaMissing(URL)
+        case notLoaded
+
+        public var description: String {
+            switch self {
+            case .metaMissing(let url): return "meta.yaml not found at \(url.path)"
+            case .notLoaded: return "prepare() must succeed before run()"
+            }
+        }
+    }
+
+    private let configuration: Configuration
+    private var config: YAMLConfig?
+    private var tokenizer: Tokenizer?
+    private var inference: InferenceManager?
+    private var prompt: PolishPrompt?
+    private var promptTokens: [Int] = []
+    private var modelLoadMs = 0
+    private var computePlans: [ComputePlanSummary] = []
+    private var notes: [String] = []
+
+    public init(configuration: Configuration) {
+        self.configuration = configuration
+    }
+
+    // MARK: - Phase 1: load (foreground)
+
+    /// Load the tokenizer and the Core ML bundles, build the prompt, and read
+    /// Core ML's compute plan. Everything expensive and everything that is not
+    /// the measurement.
+    public func prepare(progress: @Sendable @escaping (String) -> Void) async throws {
+        let metaURL = configuration.modelDirectory.appendingPathComponent("meta.yaml")
+        guard FileManager.default.fileExists(atPath: metaURL.path) else {
+            throw RunError.metaMissing(metaURL)
+        }
+
+        progress("Reading meta.yaml…")
+        let config = try YAMLConfig.load(from: metaURL.path)
+        self.config = config
+
+        progress("Loading tokenizer…")
+        let tokenizer = try await Tokenizer(modelPath: config.tokenizerModel, template: "qwen")
+        self.tokenizer = tokenizer
+
+        progress("Building the shipping polish prompt…")
+        guard #available(iOS 26.0, macOS 26.0, *) else {
+            // The prompts are reached through the Apple FM engine's one entry
+            // point, which carries that gate. Nothing here calls Apple's model.
+            throw RunError.notLoaded
+        }
+        let prompt = try PolishPrompt.natural(fixtureID: configuration.fixtureID)
+        self.prompt = prompt
+        self.promptTokens = Self.tokens(for: prompt, tokenizer: tokenizer)
+
+        progress("Loading Core ML models onto the Neural Engine…")
+        let loadStart = Date()
+        let loader = ModelLoader()
+        // `.cpuAndNeuralEngine` is not a preference here, it is the experiment:
+        // it is the same value FluidAudio sets for Parakeet, which is the one
+        // path this product already knows runs backgrounded.
+        let models = try await loader.loadModel(
+            from: config,
+            configuration: ModelLoader.Configuration(computeUnits: configuration.computeUnits)
+        )
+        modelLoadMs = Int(Date().timeIntervalSince(loadStart) * 1000)
+
+        inference = try InferenceManager(
+            models: models,
+            contextLength: config.contextLength,
+            batchSize: config.batchSize,
+            splitLMHead: config.splitLMHead,
+            v110: config.configVersion == "0.1.1",
+            argmaxInModel: config.argmaxInModel,
+            slidingWindow: config.slidingWindow,
+            updateMaskPrefill: config.updateMaskPrefill,
+            prefillDynamicSlice: config.prefillDynamicSlice,
+            modelPrefix: config.modelPrefix,
+            vocabSize: config.vocabSize,
+            lmHeadChunkSizes: config.lmHeadChunkSizes
+        )
+
+        progress("Reading the Core ML compute plan…")
+        if #available(iOS 17.4, macOS 14.4, *) {
+            for path in [config.ffnPath, config.lmheadPath, config.embedPath] {
+                if let summary = await ComputePlanProbe.summarize(modelAt: URL(fileURLWithPath: path),
+                                                                 computeUnits: configuration.computeUnits) {
+                    computePlans.append(summary)
+                } else {
+                    notes.append("compute plan unavailable for \(URL(fileURLWithPath: path).lastPathComponent)")
+                }
+            }
+        }
+        progress("Ready.")
+    }
+
+    // MARK: - Phase 2: measure (background)
+
+    public func run(progress: @Sendable @escaping (String) -> Void) async throws -> BenchReport {
+        guard let inference, let tokenizer, let prompt, let config else { throw RunError.notLoaded }
+        let origin = Date()
+        var iterations: [IterationReport] = []
+
+        for index in 1...max(1, configuration.iterations) {
+            progress("Iteration \(index)…")
+            var samples: [ProcessSample] = []
+            samples.append(await ProcessProbe.sample("iteration\(index).start", since: origin))
+
+            var generated: [Int] = []
+            let callStart = Date()
+            let (tokens, prefillSeconds, stopReason) = try await inference.generateResponse(
+                initialTokens: promptTokens,
+                temperature: 0,
+                maxTokens: configuration.maxNewTokens,
+                eosTokens: tokenizer.eosTokenIds,
+                tokenizer: tokenizer,
+                onToken: { token in generated.append(token) }
+            )
+            let totalSeconds = Date().timeIntervalSince(callStart)
+            samples.append(await ProcessProbe.sample("iteration\(index).done", since: origin))
+
+            let prefillMs = Int(prefillSeconds * 1000)
+            iterations.append(IterationReport(
+                index: index,
+                promptTokens: promptTokens.count,
+                generatedTokens: tokens.count,
+                prefillMs: prefillMs,
+                decodeMs: max(0, Int(totalSeconds * 1000) - prefillMs),
+                stopReason: stopReason,
+                output: tokenizer.detokenize(tokens),
+                samples: samples
+            ))
+            _ = generated
+        }
+
+        let capabilities = DeviceCapabilities.current()
+        return BenchReport(
+            startedAt: origin,
+            codeRevision: PersistentLog.codeRevision,
+            deviceModel: capabilities.deviceModelIdentifier,
+            systemVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+            physicalMemoryGB: capabilities.physicalMemoryGB,
+            modelBundle: configuration.modelDirectory.lastPathComponent,
+            computeUnits: Self.describe(configuration.computeUnits),
+            contextLength: config.contextLength,
+            batchSize: config.batchSize,
+            fixtureID: prompt.fixtureID,
+            systemPromptChars: prompt.system.count,
+            userTurnChars: prompt.user.count,
+            modelLoadMs: modelLoadMs,
+            computePlans: computePlans,
+            iterations: iterations,
+            notes: notes
+        )
+    }
+
+    private static func describe(_ units: MLComputeUnits) -> String {
+        switch units {
+        case .cpuOnly: return "cpuOnly"
+        case .cpuAndGPU: return "cpuAndGPU"
+        case .all: return "all"
+        case .cpuAndNeuralEngine: return "cpuAndNeuralEngine"
+        @unknown default: return "unknown"
+        }
+    }
+
+    // MARK: - Prompt tokenisation
+
+    /// System + user through the model's own ChatML template, then the empty
+    /// thinking block Qwen 3's template emits for `enable_thinking=false`.
+    ///
+    /// This is not a detail. The predecessor spike measured a reasoning model
+    /// with thinking silently ON and discarded the whole pass when it noticed —
+    /// a polish call is a rewrite, not a puzzle, and letting the model reason
+    /// reports a latency no shipped product would pay.
+    private static func tokens(for prompt: PolishPrompt, tokenizer: Tokenizer) -> [Int] {
+        let templated = tokenizer.applyChatTemplate(
+            input: [Tokenizer.ChatMessage.system(prompt.system),
+                    Tokenizer.ChatMessage.user(prompt.user)],
+            addGenerationPrompt: true
+        )
+        return templated + tokenizer.tokenize("<think>\n\n</think>\n\n")
+    }
+}

--- a/tools/ane-harness/AneBenchKit/Sources/AneBenchKit/BenchReport.swift
+++ b/tools/ane-harness/AneBenchKit/Sources/AneBenchKit/BenchReport.swift
@@ -1,0 +1,123 @@
+// tools/ane-harness/Sources/AneBenchKit/BenchReport.swift
+//
+// THROWAWAY — #268 D2. The shape of what comes back off the phone.
+import Foundation
+
+/// One memory/thermal/lifecycle reading, taken at a named point in the run.
+///
+/// `appState` is the reason this struct exists at all. A latency figure from a
+/// foregrounded app answers a different question than the one #268 asks, and
+/// nothing in the numbers themselves would reveal the difference — so every
+/// reading carries the lifecycle state it was taken in, and the report refuses
+/// to be read as a background measurement unless they all say `background`.
+public struct ProcessSample: Codable, Sendable {
+    public let label: String
+    /// Seconds since the run started.
+    public let atSeconds: Double
+    /// `os_proc_available_memory()` in MB — jetsam headroom. 0 off-device.
+    public let availableMemoryMB: Int
+    /// `phys_footprint` in MB — what jetsam counts against the app.
+    public let footprintMB: Int
+    public let thermalState: String
+    public let appState: String
+
+    public var line: String {
+        String(format: "%-22@ t=%6.2fs available=%5dMB footprint=%5dMB thermal=%@ state=%@",
+               label as NSString, atSeconds, availableMemoryMB, footprintMB,
+               thermalState as NSString, appState as NSString)
+    }
+}
+
+/// What one prompt costs, split the way the budget is written: prefill and
+/// decode are separate numbers because they scale with different things and
+/// only one of them is under the product's control.
+public struct IterationReport: Codable, Sendable {
+    public let index: Int
+    public let promptTokens: Int
+    public let generatedTokens: Int
+    public let prefillMs: Int
+    public let decodeMs: Int
+    public let stopReason: String
+    public let output: String
+    public let samples: [ProcessSample]
+
+    public var totalMs: Int { prefillMs + decodeMs }
+    public var decodeTokensPerSecond: Double {
+        decodeMs > 0 ? Double(generatedTokens) * 1000.0 / Double(decodeMs) : 0
+    }
+    public var prefillTokensPerSecond: Double {
+        prefillMs > 0 ? Double(promptTokens) * 1000.0 / Double(prefillMs) : 0
+    }
+}
+
+/// Which compute device Core ML says it will run each operation on, counted
+/// over one `.mlmodelc`. Read from `MLComputePlan`, not inferred from timings.
+public struct ComputePlanSummary: Codable, Sendable {
+    public let modelName: String
+    public let neuralEngineOps: Int
+    public let cpuOps: Int
+    public let gpuOps: Int
+    public let unknownOps: Int
+
+    public var totalOps: Int { neuralEngineOps + cpuOps + gpuOps + unknownOps }
+    public var neuralEngineShare: Double {
+        totalOps > 0 ? Double(neuralEngineOps) / Double(totalOps) : 0
+    }
+
+    public var line: String {
+        String(format: "%@: ANE %d / CPU %d / GPU %d / unknown %d  (%.1f%% ANE)",
+               modelName, neuralEngineOps, cpuOps, gpuOps, unknownOps, neuralEngineShare * 100)
+    }
+}
+
+public struct BenchReport: Codable, Sendable {
+    public let startedAt: Date
+    public let codeRevision: String
+    public let deviceModel: String
+    public let systemVersion: String
+    public let physicalMemoryGB: Int
+    public let modelBundle: String
+    /// The `MLComputeUnits` the models were loaded with — the independent
+    /// variable of the whole experiment, so it travels with the numbers.
+    public let computeUnits: String
+    public let contextLength: Int
+    public let batchSize: Int
+    public let fixtureID: String
+    public let systemPromptChars: Int
+    public let userTurnChars: Int
+    public let modelLoadMs: Int
+    public let computePlans: [ComputePlanSummary]
+    public let iterations: [IterationReport]
+    public let notes: [String]
+
+    /// True only when every sample in every iteration was taken with the app
+    /// backgrounded. The whole point of D2.
+    public var allIterationsBackgrounded: Bool {
+        !iterations.isEmpty && iterations.allSatisfy { iteration in
+            !iteration.samples.isEmpty && iteration.samples.allSatisfy { $0.appState == "background" }
+        }
+    }
+
+    public func rendered() -> String {
+        var out: [String] = []
+        out.append("ane-bench — #268 D2")
+        out.append("rev \(codeRevision) | \(deviceModel) | \(systemVersion) | ramGB=\(physicalMemoryGB)")
+        out.append("model \(modelBundle) ctx=\(contextLength) batch=\(batchSize) computeUnits=\(computeUnits)")
+        out.append("prompt \(fixtureID) systemChars=\(systemPromptChars) userChars=\(userTurnChars)")
+        out.append("modelLoadMs=\(modelLoadMs)")
+        for plan in computePlans { out.append("computePlan \(plan.line)") }
+        for iteration in iterations {
+            out.append(String(format: "iteration %d promptTokens=%d prefillMs=%d (%.0f tok/s) "
+                              + "decodeMs=%d generated=%d (%.1f tok/s) totalMs=%d stop=%@",
+                              iteration.index, iteration.promptTokens, iteration.prefillMs,
+                              iteration.prefillTokensPerSecond, iteration.decodeMs,
+                              iteration.generatedTokens, iteration.decodeTokensPerSecond,
+                              iteration.totalMs, iteration.stopReason as NSString))
+            for sample in iteration.samples { out.append("  \(sample.line)") }
+            out.append("  output: \(iteration.output)")
+        }
+        out.append("allIterationsBackgrounded=\(allIterationsBackgrounded)")
+        for note in notes { out.append("note: \(note)") }
+        return out.joined(separator: "\n")
+    }
+}

--- a/tools/ane-harness/AneBenchKit/Sources/AneBenchKit/BenchReport.swift
+++ b/tools/ane-harness/AneBenchKit/Sources/AneBenchKit/BenchReport.swift
@@ -77,6 +77,10 @@ public struct BenchReport: Codable, Sendable {
     public let systemVersion: String
     public let physicalMemoryGB: Int
     public let modelBundle: String
+    /// The Hugging Face revision `setup.sh` pinned, read from the bundle. "unknown"
+    /// when the file is absent — a bundle fetched some other way, which is exactly
+    /// the case a reader needs to be told about rather than left to assume.
+    public let modelRevision: String
     /// The `MLComputeUnits` the models were loaded with — the independent
     /// variable of the whole experiment, so it travels with the numbers.
     public let computeUnits: String
@@ -90,19 +94,31 @@ public struct BenchReport: Codable, Sendable {
     public let iterations: [IterationReport]
     public let notes: [String]
 
-    /// True only when every sample in every iteration was taken with the app
-    /// backgrounded. The whole point of D2.
-    public var allIterationsBackgrounded: Bool {
-        !iterations.isEmpty && iterations.allSatisfy { iteration in
-            !iteration.samples.isEmpty && iteration.samples.allSatisfy { $0.appState == "background" }
-        }
+    /// Whether every sample in every iteration was taken with the app
+    /// backgrounded — the whole point of D2.
+    ///
+    /// Three states, not two. macOS has no application lifecycle, so
+    /// `ProcessProbe` reports `n/a` there and a two-state flag would render
+    /// `false` on every Mac run — indistinguishable from a device run that
+    /// measured the wrong thing. This report is read to decide whether a run
+    /// counts, so "not applicable" must not look like "failed".
+    public enum BackgroundVerdict: String, Codable, Sendable {
+        case yes, no, notApplicable = "n/a (no application lifecycle)"
+    }
+
+    public var backgroundVerdict: BackgroundVerdict {
+        let samples = iterations.flatMap(\.samples)
+        guard !samples.isEmpty else { return .no }
+        if samples.allSatisfy({ $0.appState == "n/a" }) { return .notApplicable }
+        return samples.allSatisfy({ $0.appState == "background" }) ? .yes : .no
     }
 
     public func rendered() -> String {
         var out: [String] = []
         out.append("ane-bench — #268 D2")
         out.append("rev \(codeRevision) | \(deviceModel) | \(systemVersion) | ramGB=\(physicalMemoryGB)")
-        out.append("model \(modelBundle) ctx=\(contextLength) batch=\(batchSize) computeUnits=\(computeUnits)")
+        out.append("model \(modelBundle) rev=\(modelRevision) ctx=\(contextLength) "
+                   + "batch=\(batchSize) computeUnits=\(computeUnits)")
         out.append("prompt \(fixtureID) systemChars=\(systemPromptChars) userChars=\(userTurnChars)")
         out.append("modelLoadMs=\(modelLoadMs)")
         for plan in computePlans { out.append("computePlan \(plan.line)") }
@@ -116,7 +132,7 @@ public struct BenchReport: Codable, Sendable {
             for sample in iteration.samples { out.append("  \(sample.line)") }
             out.append("  output: \(iteration.output)")
         }
-        out.append("allIterationsBackgrounded=\(allIterationsBackgrounded)")
+        out.append("allIterationsBackgrounded=\(backgroundVerdict.rawValue)")
         for note in notes { out.append("note: \(note)") }
         return out.joined(separator: "\n")
     }

--- a/tools/ane-harness/AneBenchKit/Sources/AneBenchKit/ComputePlanProbe.swift
+++ b/tools/ane-harness/AneBenchKit/Sources/AneBenchKit/ComputePlanProbe.swift
@@ -1,0 +1,64 @@
+// tools/ane-harness/Sources/AneBenchKit/ComputePlanProbe.swift
+//
+// THROWAWAY — #268 D2.
+//
+// A latency figure does not say which processor produced it. `MLComputeUnits`
+// is documented as "allow", not "require" — the report this spike extends says
+// so explicitly and records that the mechanism was never investigated. So the
+// claim "this ran on the Neural Engine" is taken from Core ML's own compute
+// plan, which names the anticipated device per operation, rather than inferred
+// from a number being fast.
+import Foundation
+import CoreML
+
+public enum ComputePlanProbe {
+
+    /// Count anticipated compute devices over one compiled model.
+    ///
+    /// Returns nil when the plan cannot be built (an older OS, or a model
+    /// Core ML declines to plan) — an absent count is reported as absent, never
+    /// as zero ANE operations.
+    @available(iOS 17.4, macOS 14.4, *)
+    public static func summarize(modelAt url: URL,
+                                 computeUnits: MLComputeUnits = .cpuAndNeuralEngine) async -> ComputePlanSummary? {
+        let configuration = MLModelConfiguration()
+        configuration.computeUnits = computeUnits
+        guard let plan = try? await MLComputePlan.load(contentsOf: url, configuration: configuration) else {
+            return nil
+        }
+        guard case let .program(program) = plan.modelStructure else { return nil }
+
+        var ane = 0, cpu = 0, gpu = 0, unknown = 0
+        for (_, function) in program.functions {
+            walk(function.block, plan: plan, ane: &ane, cpu: &cpu, gpu: &gpu, unknown: &unknown)
+        }
+        return ComputePlanSummary(
+            modelName: url.lastPathComponent,
+            neuralEngineOps: ane,
+            cpuOps: cpu,
+            gpuOps: gpu,
+            unknownOps: unknown
+        )
+    }
+
+    @available(iOS 17.4, macOS 14.4, *)
+    private static func walk(_ block: MLModelStructure.Program.Block,
+                             plan: MLComputePlan,
+                             ane: inout Int, cpu: inout Int, gpu: inout Int, unknown: inout Int) {
+        for operation in block.operations {
+            // `const` is a weight, not work. Counting them would drown the ratio
+            // in operations no processor ever executes.
+            if operation.operatorName != "const" {
+                switch plan.deviceUsage(for: operation)?.preferred {
+                case .some(.neuralEngine): ane += 1
+                case .some(.cpu): cpu += 1
+                case .some(.gpu): gpu += 1
+                default: unknown += 1
+                }
+            }
+            for nested in operation.blocks {
+                walk(nested, plan: plan, ane: &ane, cpu: &cpu, gpu: &gpu, unknown: &unknown)
+            }
+        }
+    }
+}

--- a/tools/ane-harness/AneBenchKit/Sources/AneBenchKit/PolishPrompt.swift
+++ b/tools/ane-harness/AneBenchKit/Sources/AneBenchKit/PolishPrompt.swift
@@ -19,14 +19,22 @@ public struct PolishPrompt: Sendable {
     public let user: String
     /// Which fixture the user turn was built from.
     public let fixtureID: String
+    /// The mode the pipeline resolved for this fixture, printed alongside the
+    /// numbers so the report says which instruction set was measured.
+    public let mode: String
 
     /// Build the prompt for a fixture id in the bundled copy of `seed.json`.
     ///
     /// Throws rather than falling back to a hardcoded string: a prompt that is
     /// almost the shipping one produces a number that looks like an answer and
-    /// is not one.
+    /// is not one. For the same reason the mode is resolved through
+    /// `PolishPipeline.mode` instead of assumed to be `.natural` — a Parakeet
+    /// fixture whose detected language differs from its target resolves to
+    /// `.repair`, whose instructions are less than half the length, and measuring
+    /// prefill on the wrong instruction set would measure the wrong prompt.
+    /// (`3-long`, the fixture D2 uses, resolves to `.natural`.)
     @available(iOS 26.0, macOS 26.0, *)
-    public static func natural(fixtureID: String = "3-long") throws -> PolishPrompt {
+    public static func resolved(fixtureID: String = "3-long") throws -> PolishPrompt {
         guard let url = Bundle.module.url(forResource: "seed", withExtension: "json") else {
             throw PromptError.fixturesMissing
         }
@@ -38,8 +46,14 @@ public struct PolishPrompt: Sendable {
             throw PromptError.unsupportedLanguage(fixture.lang)
         }
         let preprocessed = VerbalPunctuationPrepass.apply(fixture.raw, language: language)
+        guard let detected = PolishPipeline.detectLanguage(in: preprocessed) else {
+            throw PromptError.languageUndetected(fixture.id)
+        }
+        let mode = PolishPipeline.mode(sttEngine: fixture.speechEngine,
+                                       detected: detected,
+                                       target: language)
         return PolishPrompt(
-            system: AppleFoundationModelsPolishEngine.instructions(for: .natural, language: language),
+            system: AppleFoundationModelsPolishEngine.instructions(for: mode, language: language),
             // Byte-identical to `AppleFoundationModelsPolishEngine.polish`, which
             // builds this string inline, and to `LocalHTTPPolishEngine.userTurn`,
             // which the off-device spike measured through.
@@ -51,7 +65,8 @@ public struct PolishPrompt: Sendable {
 
             Polished output:
             """,
-            fixtureID: fixture.id
+            fixtureID: fixture.id,
+            mode: mode.rawValue
         )
     }
 
@@ -61,12 +76,17 @@ public struct PolishPrompt: Sendable {
         let id: String
         let raw: String
         let lang: String
+        let sttEngine: String?
+
+        /// Matches `polish-harness`'s `Fixture`: Parakeet unless stated.
+        var speechEngine: SpeechEngine { sttEngine == "WK" ? .whisperKit : .parakeet }
     }
 
     public enum PromptError: Error, CustomStringConvertible {
         case fixturesMissing
         case noSuchFixture(String)
         case unsupportedLanguage(String)
+        case languageUndetected(String)
 
         public var description: String {
             switch self {
@@ -76,6 +96,9 @@ public struct PolishPrompt: Sendable {
                 return "no fixture with id \(id) in seed.json"
             case .unsupportedLanguage(let code):
                 return "fixture language \(code) has no per-language polish prompt"
+            case .languageUndetected(let id):
+                return "language detection returned nil for \(id) — the pipeline would "
+                     + "skip the engine, so there is no prompt to measure"
             }
         }
     }

--- a/tools/ane-harness/AneBenchKit/Sources/AneBenchKit/PolishPrompt.swift
+++ b/tools/ane-harness/AneBenchKit/Sources/AneBenchKit/PolishPrompt.swift
@@ -1,0 +1,82 @@
+// tools/ane-harness/Sources/AneBenchKit/PolishPrompt.swift
+//
+// THROWAWAY — #268 D2.
+//
+// The measurement is only worth taking on the real prompt. #268 asks for
+// "the real `PolishNaturalPromptFR` system message plus the `3-long` fixture —
+// 1,704 tokens of prefill", and every byte of that is reachable from DictusCore
+// rather than transcribed here: the instructions through the one entry point
+// both shipping engines use, the fixture from a copy of the harness fixture
+// file, and the pre-pass because that is what runs before the engine sees the
+// text.
+import Foundation
+import DictusCore
+
+public struct PolishPrompt: Sendable {
+    /// Resolved per-(mode, language) instructions — the system message.
+    public let system: String
+    /// The Input/"Polished output:" user turn, over pre-passed text.
+    public let user: String
+    /// Which fixture the user turn was built from.
+    public let fixtureID: String
+
+    /// Build the prompt for a fixture id in the bundled copy of `seed.json`.
+    ///
+    /// Throws rather than falling back to a hardcoded string: a prompt that is
+    /// almost the shipping one produces a number that looks like an answer and
+    /// is not one.
+    @available(iOS 26.0, macOS 26.0, *)
+    public static func natural(fixtureID: String = "3-long") throws -> PolishPrompt {
+        guard let url = Bundle.module.url(forResource: "seed", withExtension: "json") else {
+            throw PromptError.fixturesMissing
+        }
+        let fixtures = try JSONDecoder().decode([SeedFixture].self, from: Data(contentsOf: url))
+        guard let fixture = fixtures.first(where: { $0.id == fixtureID }) else {
+            throw PromptError.noSuchFixture(fixtureID)
+        }
+        guard let language = SupportedLanguage(rawValue: fixture.lang) else {
+            throw PromptError.unsupportedLanguage(fixture.lang)
+        }
+        let preprocessed = VerbalPunctuationPrepass.apply(fixture.raw, language: language)
+        return PolishPrompt(
+            system: AppleFoundationModelsPolishEngine.instructions(for: .natural, language: language),
+            // Byte-identical to `AppleFoundationModelsPolishEngine.polish`, which
+            // builds this string inline, and to `LocalHTTPPolishEngine.userTurn`,
+            // which the off-device spike measured through.
+            user: """
+            Polish this text. Output only the polished version, nothing else.
+
+            Input:
+            \(preprocessed)
+
+            Polished output:
+            """,
+            fixtureID: fixture.id
+        )
+    }
+
+    /// Only the fields this harness reads. `polish-harness`'s own `Fixture` has
+    /// the expectations too; scoring is not what D2 is for.
+    private struct SeedFixture: Decodable {
+        let id: String
+        let raw: String
+        let lang: String
+    }
+
+    public enum PromptError: Error, CustomStringConvertible {
+        case fixturesMissing
+        case noSuchFixture(String)
+        case unsupportedLanguage(String)
+
+        public var description: String {
+            switch self {
+            case .fixturesMissing:
+                return "seed.json is not in the bundle — run tools/ane-harness/setup.sh"
+            case .noSuchFixture(let id):
+                return "no fixture with id \(id) in seed.json"
+            case .unsupportedLanguage(let code):
+                return "fixture language \(code) has no per-language polish prompt"
+            }
+        }
+    }
+}

--- a/tools/ane-harness/AneBenchKit/Sources/AneBenchKit/ProcessProbe.swift
+++ b/tools/ane-harness/AneBenchKit/Sources/AneBenchKit/ProcessProbe.swift
@@ -1,0 +1,54 @@
+// tools/ane-harness/Sources/AneBenchKit/ProcessProbe.swift
+//
+// THROWAWAY — #268 D2. Same readings D1 took, from the same two calls, so the
+// two measurements can be laid side by side without a conversion: jetsam
+// headroom from `os_proc_available_memory()` (DictusCore's `DeviceCapabilities`)
+// and `phys_footprint` (DictusCore's `MemoryFootprint`).
+import Foundation
+import DictusCore
+#if canImport(UIKit)
+import UIKit
+#endif
+
+public enum ProcessProbe {
+
+    /// Take a labelled reading. `origin` anchors `atSeconds`.
+    public static func sample(_ label: String, since origin: Date) async -> ProcessSample {
+        let capabilities = DeviceCapabilities.current()
+        return ProcessSample(
+            label: label,
+            atSeconds: Date().timeIntervalSince(origin),
+            availableMemoryMB: capabilities.availableMemoryMB,
+            footprintMB: MemoryFootprint.residentMB(),
+            thermalState: describe(capabilities.thermalState),
+            appState: await applicationState()
+        )
+    }
+
+    /// "background" / "active" / "inactive" on iOS; "n/a" on the Mac, where the
+    /// distinction this harness exists to make does not exist.
+    public static func applicationState() async -> String {
+        #if canImport(UIKit)
+        return await MainActor.run {
+            switch UIApplication.shared.applicationState {
+            case .background: return "background"
+            case .inactive: return "inactive"
+            case .active: return "active"
+            @unknown default: return "unknown"
+            }
+        }
+        #else
+        return "n/a"
+        #endif
+    }
+
+    private static func describe(_ state: ProcessInfo.ThermalState) -> String {
+        switch state {
+        case .nominal: return "nominal"
+        case .fair: return "fair"
+        case .serious: return "serious"
+        case .critical: return "critical"
+        @unknown default: return "unknown"
+        }
+    }
+}

--- a/tools/ane-harness/AneBenchKit/Sources/ane-bench/main.swift
+++ b/tools/ane-harness/AneBenchKit/Sources/ane-bench/main.swift
@@ -31,7 +31,18 @@ let fixtureID = option("--fixture") ?? "3-long"
 // `--compute-units cpu` is the control: same model, same prompt, same process,
 // Core ML told not to use the Neural Engine. The gap between the two runs is
 // what makes "it ran on the ANE" a measurement rather than an assumption.
-let computeUnits: MLComputeUnits = (option("--compute-units") == "cpu") ? .cpuOnly : .cpuAndNeuralEngine
+//
+// Unknown values are rejected rather than defaulted. A typo silently producing an
+// ANE run labelled `computeUnits=cpuAndNeuralEngine` would look exactly like the
+// control it was meant to be, and the whole ANE claim rests on that pair differing.
+let computeUnits: MLComputeUnits
+switch option("--compute-units") {
+case nil, "ane": computeUnits = .cpuAndNeuralEngine
+case "cpu":      computeUnits = .cpuOnly
+case let other:
+    FileHandle.standardError.write(Data("error: --compute-units expects 'ane' or 'cpu', got '\(other ?? "")'\n".utf8))
+    exit(2)
+}
 
 let runner = AneBenchRunner(configuration: AneBenchRunner.Configuration(
     modelDirectory: modelDirectory,
@@ -46,9 +57,10 @@ do {
     try await runner.prepare { message in FileHandle.standardError.write(Data("… \(message)\n".utf8)) }
     let report = try await runner.run { message in FileHandle.standardError.write(Data("… \(message)\n".utf8)) }
     print(report.rendered())
-    if let json = try? JSONEncoder().encode(report),
-       let path = option("--json") {
-        try json.write(to: URL(fileURLWithPath: path))
+    // `try`, not `try?`: a caller who passed --json and got exit 0 would believe the
+    // file is there. And the encode only runs when a path was actually asked for.
+    if let path = option("--json") {
+        try JSONEncoder().encode(report).write(to: URL(fileURLWithPath: path))
         FileHandle.standardError.write(Data("wrote \(path)\n".utf8))
     }
 } catch {

--- a/tools/ane-harness/AneBenchKit/Sources/ane-bench/main.swift
+++ b/tools/ane-harness/AneBenchKit/Sources/ane-bench/main.swift
@@ -38,7 +38,8 @@ let runner = AneBenchRunner(configuration: AneBenchRunner.Configuration(
     maxNewTokens: maxNewTokens,
     iterations: iterations,
     fixtureID: fixtureID,
-    computeUnits: computeUnits
+    computeUnits: computeUnits,
+    allowThinking: CommandLine.arguments.contains("--thinking")
 ))
 
 do {

--- a/tools/ane-harness/AneBenchKit/Sources/ane-bench/main.swift
+++ b/tools/ane-harness/AneBenchKit/Sources/ane-bench/main.swift
@@ -1,0 +1,55 @@
+// tools/ane-harness/Sources/ane-bench/main.swift
+//
+// THROWAWAY — #268 D2, Mac side. The gate #268's work-split puts before the
+// phone: does the converted model load, does Core ML actually place it on the
+// Neural Engine, and does it produce sane French on the shipping prompt.
+//
+// It cannot answer the issue's question. There is no jetsam on a Mac and no
+// application lifecycle to be in the background of, so what it produces is a
+// floor and a sanity check, exactly as the predecessor spike's Mac figures were.
+import Foundation
+import CoreML
+import AneBenchKit
+
+func option(_ name: String) -> String? {
+    let arguments = CommandLine.arguments
+    guard let index = arguments.firstIndex(of: name), index + 1 < arguments.count else { return nil }
+    return arguments[index + 1]
+}
+
+let defaultModel = URL(fileURLWithPath: #filePath)
+    .deletingLastPathComponent()   // ane-bench
+    .deletingLastPathComponent()   // Sources
+    .deletingLastPathComponent()   // ane-harness
+    .appendingPathComponent(".deps/model")
+
+let modelDirectory = option("--model").map { URL(fileURLWithPath: $0) } ?? defaultModel
+let iterations = Int(option("--iterations") ?? "2") ?? 2
+let maxNewTokens = Int(option("--max-tokens") ?? "280") ?? 280
+let fixtureID = option("--fixture") ?? "3-long"
+// `--compute-units cpu` is the control: same model, same prompt, same process,
+// Core ML told not to use the Neural Engine. The gap between the two runs is
+// what makes "it ran on the ANE" a measurement rather than an assumption.
+let computeUnits: MLComputeUnits = (option("--compute-units") == "cpu") ? .cpuOnly : .cpuAndNeuralEngine
+
+let runner = AneBenchRunner(configuration: AneBenchRunner.Configuration(
+    modelDirectory: modelDirectory,
+    maxNewTokens: maxNewTokens,
+    iterations: iterations,
+    fixtureID: fixtureID,
+    computeUnits: computeUnits
+))
+
+do {
+    try await runner.prepare { message in FileHandle.standardError.write(Data("… \(message)\n".utf8)) }
+    let report = try await runner.run { message in FileHandle.standardError.write(Data("… \(message)\n".utf8)) }
+    print(report.rendered())
+    if let json = try? JSONEncoder().encode(report),
+       let path = option("--json") {
+        try json.write(to: URL(fileURLWithPath: path))
+        FileHandle.standardError.write(Data("wrote \(path)\n".utf8))
+    }
+} catch {
+    FileHandle.standardError.write(Data("error: \(error)\n".utf8))
+    exit(1)
+}

--- a/tools/ane-harness/AneBenchKit/Sources/ane-bench/main.swift
+++ b/tools/ane-harness/AneBenchKit/Sources/ane-bench/main.swift
@@ -20,6 +20,7 @@ func option(_ name: String) -> String? {
 let defaultModel = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent()   // ane-bench
     .deletingLastPathComponent()   // Sources
+    .deletingLastPathComponent()   // AneBenchKit
     .deletingLastPathComponent()   // ane-harness
     .appendingPathComponent(".deps/model")
 

--- a/tools/ane-harness/AneHarness.xcodeproj/project.pbxproj
+++ b/tools/ane-harness/AneHarness.xcodeproj/project.pbxproj
@@ -1,0 +1,364 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		347BF7C391068E2A819289DE /* HarnessController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B06555A99F19DCDE005695F /* HarnessController.swift */; };
+		35A08C5576CCF6BA5E903542 /* AneHarnessApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF83D5A7BB8D6661D2B7DD8 /* AneHarnessApp.swift */; };
+		372227164FA479820FEDF355 /* BackgroundAudioKeepAlive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504AD77105D5904F8EFF9B48 /* BackgroundAudioKeepAlive.swift */; };
+		46AC98924C09DADDD6D3728A /* model in Resources */ = {isa = PBXBuildFile; fileRef = 7C47CA0B091591E13FAE8785 /* model */; };
+		D09578650C10761C2FF5D4FD /* AneBenchKit in Frameworks */ = {isa = PBXBuildFile; productRef = 5D8D6ECE53DAE237F3EEDE8B /* AneBenchKit */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		504AD77105D5904F8EFF9B48 /* BackgroundAudioKeepAlive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundAudioKeepAlive.swift; sourceTree = "<group>"; };
+		592CC4825E1312ED7367D164 /* AneHarness.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = AneHarness.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		7C47CA0B091591E13FAE8785 /* model */ = {isa = PBXFileReference; lastKnownFileType = folder; name = model; path = .deps/model; sourceTree = SOURCE_ROOT; };
+		8ED0B727AC002F4379842ECB /* AneBenchKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = AneBenchKit; path = AneBenchKit; sourceTree = SOURCE_ROOT; };
+		9B06555A99F19DCDE005695F /* HarnessController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessController.swift; sourceTree = "<group>"; };
+		ACF83D5A7BB8D6661D2B7DD8 /* AneHarnessApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AneHarnessApp.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		AC705E80C06F737B1324AEDE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D09578650C10761C2FF5D4FD /* AneBenchKit in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		244BAE08ADB13E6DD87E1D1D /* .deps */ = {
+			isa = PBXGroup;
+			children = (
+				7C47CA0B091591E13FAE8785 /* model */,
+			);
+			path = .deps;
+			sourceTree = "<group>";
+		};
+		6CA3BD19DB53876693509C7E = {
+			isa = PBXGroup;
+			children = (
+				244BAE08ADB13E6DD87E1D1D /* .deps */,
+				F9452921E7EADA12FAE49581 /* App */,
+				9A1B4BE526145D0A283532C0 /* Packages */,
+				B06E9B740DD92950A6F0FE15 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		9A1B4BE526145D0A283532C0 /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				8ED0B727AC002F4379842ECB /* AneBenchKit */,
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
+		B06E9B740DD92950A6F0FE15 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				592CC4825E1312ED7367D164 /* AneHarness.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		F9452921E7EADA12FAE49581 /* App */ = {
+			isa = PBXGroup;
+			children = (
+				ACF83D5A7BB8D6661D2B7DD8 /* AneHarnessApp.swift */,
+				504AD77105D5904F8EFF9B48 /* BackgroundAudioKeepAlive.swift */,
+				9B06555A99F19DCDE005695F /* HarnessController.swift */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		9A2B3E0D02A6964F24F0E402 /* AneHarness */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C51A75E77957F875E5D6EA7A /* Build configuration list for PBXNativeTarget "AneHarness" */;
+			buildPhases = (
+				E299783E7FBB56235A45544E /* Sources */,
+				82E5E0E5EE4BA687AF40DB76 /* Resources */,
+				AC705E80C06F737B1324AEDE /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AneHarness;
+			packageProductDependencies = (
+				5D8D6ECE53DAE237F3EEDE8B /* AneBenchKit */,
+			);
+			productName = AneHarness;
+			productReference = 592CC4825E1312ED7367D164 /* AneHarness.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		61252A4CF83CA88F6BFE1254 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+					9A2B3E0D02A6964F24F0E402 = {
+						DevelopmentTeam = 9B8B36C2FA;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = FB21050BA4E286623AFA0D95 /* Build configuration list for PBXProject "AneHarness" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 6CA3BD19DB53876693509C7E;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				04BA3352EB6245FFD3498897 /* XCLocalSwiftPackageReference "AneBenchKit" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = B06E9B740DD92950A6F0FE15 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				9A2B3E0D02A6964F24F0E402 /* AneHarness */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		82E5E0E5EE4BA687AF40DB76 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				46AC98924C09DADDD6D3728A /* model in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		E299783E7FBB56235A45544E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				35A08C5576CCF6BA5E903542 /* AneHarnessApp.swift in Sources */,
+				372227164FA479820FEDF355 /* BackgroundAudioKeepAlive.swift in Sources */,
+				347BF7C391068E2A819289DE /* HarnessController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		23AE26BA101EE5978FC3728A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		796EA287FA4BD2D6F39CCE5C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		A1417880045697980A4BFFDF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 9B8B36C2FA;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				INFOPLIST_FILE = App/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.pivi.dictus.anebench;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		CB120382F54CEFEBA0D8568F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 9B8B36C2FA;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				INFOPLIST_FILE = App/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.pivi.dictus.anebench;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		C51A75E77957F875E5D6EA7A /* Build configuration list for PBXNativeTarget "AneHarness" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A1417880045697980A4BFFDF /* Debug */,
+				CB120382F54CEFEBA0D8568F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		FB21050BA4E286623AFA0D95 /* Build configuration list for PBXProject "AneHarness" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				23AE26BA101EE5978FC3728A /* Debug */,
+				796EA287FA4BD2D6F39CCE5C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		04BA3352EB6245FFD3498897 /* XCLocalSwiftPackageReference "AneBenchKit" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = AneBenchKit;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		5D8D6ECE53DAE237F3EEDE8B /* AneBenchKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AneBenchKit;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 61252A4CF83CA88F6BFE1254 /* Project object */;
+}

--- a/tools/ane-harness/AneHarness.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/tools/ane-harness/AneHarness.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/tools/ane-harness/App/AneHarnessApp.swift
+++ b/tools/ane-harness/App/AneHarnessApp.swift
@@ -1,0 +1,60 @@
+// tools/ane-harness/App/AneHarnessApp.swift
+//
+// THROWAWAY — #268 D2, phone side.
+//
+// The measurement has to happen while the app is backgrounded, and a
+// backgrounded app cannot be tapped. So the harness is self-running: it loads
+// in the foreground, tells the maintainer to press Home, and then runs on its
+// own whether or not anyone is watching. It stays alive backgrounded the same
+// way DictusApp does — `UIBackgroundModes: audio` plus a running audio engine —
+// because reproducing that state is the point, not a workaround for it.
+import SwiftUI
+import DictusCore
+
+@main
+struct AneHarnessApp: App {
+    @StateObject private var controller = HarnessController()
+
+    var body: some Scene {
+        WindowGroup {
+            HarnessView(controller: controller)
+                .task { await controller.start() }
+        }
+    }
+}
+
+struct HarnessView: View {
+    @ObservedObject var controller: HarnessController
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text(controller.headline)
+                        .font(.headline)
+                    if let countdown = controller.countdown {
+                        Text("Press Home now — waiting \(countdown) s, then it runs anyway.")
+                            .font(.title3.monospacedDigit())
+                            .foregroundStyle(.orange)
+                    }
+                    Text(controller.status)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                    if !controller.resultText.isEmpty {
+                        Divider()
+                        Text(controller.resultText)
+                            .font(.system(.footnote, design: .monospaced))
+                            .textSelection(.enabled)
+                        if let url = controller.resultFileURL {
+                            ShareLink(item: url) { Label("Export the JSON", systemImage: "square.and.arrow.up") }
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+            }
+            .navigationTitle("ANE bench — #268")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}

--- a/tools/ane-harness/App/BackgroundAudioKeepAlive.swift
+++ b/tools/ane-harness/App/BackgroundAudioKeepAlive.swift
@@ -1,0 +1,60 @@
+// tools/ane-harness/App/BackgroundAudioKeepAlive.swift
+//
+// THROWAWAY — #268 D2.
+//
+// An ordinary iOS app gets suspended seconds after it leaves the foreground, so
+// without this the harness could not run backgrounded at all. DictusApp stays
+// alive for exactly this reason and by exactly this means — `UIBackgroundModes:
+// audio` in Info.plist plus an AVAudioEngine that never stops — so reproducing
+// it here is not a trick to keep the benchmark running: it is part of the state
+// under test. The engine also costs the memory a real dictation costs, which the
+// footprint readings should see.
+import AVFoundation
+import DictusCore
+
+final class BackgroundAudioKeepAlive {
+
+    private let engine = AVAudioEngine()
+    private var player: AVAudioPlayerNode?
+
+    /// Configure the session and start a silent tone. Returns a human-readable
+    /// outcome — a failure here invalidates the run rather than degrading it, so
+    /// it has to reach the report.
+    func start() -> String {
+        do {
+            let session = AVAudioSession.sharedInstance()
+            // `.playAndRecord` mirrors DictusApp, which records. `.mixWithOthers`
+            // so the harness does not stop whatever the maintainer is listening to.
+            try session.setCategory(.playAndRecord,
+                                    mode: .default,
+                                    options: [.mixWithOthers, .defaultToSpeaker, .allowBluetooth])
+            try session.setActive(true)
+
+            let player = AVAudioPlayerNode()
+            self.player = player
+            let format = engine.outputNode.inputFormat(forBus: 0)
+            engine.attach(player)
+            engine.connect(player, to: engine.mainMixerNode, format: format)
+            guard let buffer = Self.silentBuffer(format: format) else {
+                return "audio keep-alive: could not build the silent buffer"
+            }
+            try engine.start()
+            player.scheduleBuffer(buffer, at: nil, options: .loops)
+            player.play()
+            return "audio keep-alive: running (playAndRecord, silent loop)"
+        } catch {
+            return "audio keep-alive FAILED: \(error.localizedDescription)"
+        }
+    }
+
+    private static func silentBuffer(format: AVAudioFormat) -> AVAudioPCMBuffer? {
+        let frames = AVAudioFrameCount(format.sampleRate)
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames) else { return nil }
+        buffer.frameLength = frames
+        for channel in 0..<Int(format.channelCount) {
+            guard let data = buffer.floatChannelData?[channel] else { continue }
+            for frame in 0..<Int(frames) { data[frame] = 0 }
+        }
+        return buffer
+    }
+}

--- a/tools/ane-harness/App/BackgroundAudioKeepAlive.swift
+++ b/tools/ane-harness/App/BackgroundAudioKeepAlive.swift
@@ -17,10 +17,25 @@ final class BackgroundAudioKeepAlive {
     private let engine = AVAudioEngine()
     private var player: AVAudioPlayerNode?
 
-    /// Configure the session and start a silent tone. Returns a human-readable
-    /// outcome — a failure here invalidates the run rather than degrading it, so
-    /// it has to reach the report.
-    func start() -> String {
+    enum StartError: Error, CustomStringConvertible {
+        case silentBufferUnavailable
+        case session(String)
+
+        public var description: String {
+            switch self {
+            case .silentBufferUnavailable: return "could not build the silent buffer"
+            case .session(let message): return message
+            }
+        }
+    }
+
+    /// Configure the session and start a silent tone.
+    ///
+    /// Throws rather than reporting, because a failure here does not degrade the
+    /// measurement — it invalidates it. Without the audio background mode holding
+    /// the process, iOS suspends the app seconds after it leaves the foreground,
+    /// and whatever the benchmark then reports is not a backgrounded run.
+    func start() throws -> String {
         do {
             let session = AVAudioSession.sharedInstance()
             // `.playAndRecord` mirrors DictusApp, which records. `.mixWithOthers`
@@ -36,14 +51,16 @@ final class BackgroundAudioKeepAlive {
             engine.attach(player)
             engine.connect(player, to: engine.mainMixerNode, format: format)
             guard let buffer = Self.silentBuffer(format: format) else {
-                return "audio keep-alive: could not build the silent buffer"
+                throw StartError.silentBufferUnavailable
             }
             try engine.start()
             player.scheduleBuffer(buffer, at: nil, options: .loops)
             player.play()
             return "audio keep-alive: running (playAndRecord, silent loop)"
+        } catch let error as StartError {
+            throw error
         } catch {
-            return "audio keep-alive FAILED: \(error.localizedDescription)"
+            throw StartError.session(error.localizedDescription)
         }
     }
 

--- a/tools/ane-harness/App/HarnessController.swift
+++ b/tools/ane-harness/App/HarnessController.swift
@@ -35,8 +35,18 @@ final class HarnessController: ObservableObject {
         guard !started else { return }
         started = true
 
-        let audioOutcome = keepAlive.start()
-        append(audioOutcome)
+        // Stop here on failure. A run without the keep-alive is not a backgrounded
+        // run — iOS would suspend the process — so continuing would produce numbers
+        // that look like an answer and are not one.
+        do {
+            append(try keepAlive.start())
+        } catch {
+            headline = "Audio keep-alive failed — the run cannot be trusted"
+            append("\(error)")
+            writePhase("failed")
+            record(text: "ane-bench ABORTED: audio keep-alive failed: \(error)", json: nil)
+            return
+        }
 
         guard let modelDirectory = Bundle.main.url(forResource: "model", withExtension: nil) else {
             headline = "No model in the bundle"
@@ -87,7 +97,7 @@ final class HarnessController: ObservableObject {
             }
             let rendered = report.rendered()
             resultText = rendered
-            headline = report.allIterationsBackgrounded
+            headline = report.backgroundVerdict == .yes
                 ? "Done — measured while backgrounded"
                 : "Done — but NOT fully backgrounded (see state= below)"
             record(text: rendered, json: try? JSONEncoder().encode(report))

--- a/tools/ane-harness/App/HarnessController.swift
+++ b/tools/ane-harness/App/HarnessController.swift
@@ -1,0 +1,161 @@
+// tools/ane-harness/App/HarnessController.swift
+//
+// THROWAWAY — #268 D2. The self-running protocol.
+//
+// Load (foreground) → wait to be backgrounded → run → write. The only human
+// act in the whole protocol is pressing Home, and even that is a wait rather
+// than a countdown, so nothing races the person holding the phone.
+import Foundation
+import SwiftUI
+import AneBenchKit
+import DictusCore
+
+@MainActor
+final class HarnessController: ObservableObject {
+
+    /// How long to wait for someone to background the app before running
+    /// anyway. Running anyway matters: a report that says `state=active` is a
+    /// useful failure, whereas a harness that waits forever is a dead phone in
+    /// a pocket and no data at all.
+    private static let backgroundWaitSeconds = 180
+    /// Settle time after the app goes to the background, so the transition's own
+    /// work is not inside the measurement.
+    private static let settleSeconds = 5
+
+    @Published private(set) var headline = "Starting…"
+    @Published private(set) var status = ""
+    @Published private(set) var countdown: Int?
+    @Published private(set) var resultText = ""
+    @Published private(set) var resultFileURL: URL?
+
+    private let keepAlive = BackgroundAudioKeepAlive()
+    private var started = false
+
+    func start() async {
+        guard !started else { return }
+        started = true
+
+        let audioOutcome = keepAlive.start()
+        append(audioOutcome)
+
+        guard let modelDirectory = Bundle.main.url(forResource: "model", withExtension: nil) else {
+            headline = "No model in the bundle"
+            append("The 'model' folder reference is missing — see tools/ane-harness/README.md.")
+            return
+        }
+
+        let runner = AneBenchRunner(configuration: AneBenchRunner.Configuration(
+            modelDirectory: modelDirectory
+        ))
+
+        headline = "Loading the model — keep the app open"
+        writePhase("loading")
+        do {
+            try await runner.prepare { message in
+                Task { @MainActor in self.append(message) }
+            }
+        } catch {
+            headline = "Load failed"
+            append("\(error)")
+            writePhase("failed")
+            record(text: "ane-bench LOAD FAILED: \(error)", json: nil)
+            return
+        }
+
+        headline = "Loaded. Press Home now."
+        writePhase("waiting-for-background")
+        // Wait for the lifecycle transition rather than counting down to it. A
+        // countdown races the person holding the phone; this cannot.
+        var waited = 0
+        while await ProcessProbe.applicationState() != "background", waited < Self.backgroundWaitSeconds {
+            countdown = Self.backgroundWaitSeconds - waited
+            try? await Task.sleep(for: .seconds(1))
+            waited += 1
+        }
+        countdown = nil
+        if waited >= Self.backgroundWaitSeconds {
+            append("never went to the background within \(Self.backgroundWaitSeconds)s — running anyway")
+        }
+        try? await Task.sleep(for: .seconds(Self.settleSeconds))
+
+        headline = "Running…"
+        writePhase("running")
+        append("state at start of run: \(await ProcessProbe.applicationState())")
+        do {
+            let report = try await runner.run { message in
+                Task { @MainActor in self.append(message) }
+            }
+            let rendered = report.rendered()
+            resultText = rendered
+            headline = report.allIterationsBackgrounded
+                ? "Done — measured while backgrounded"
+                : "Done — but NOT fully backgrounded (see state= below)"
+            record(text: rendered, json: try? JSONEncoder().encode(report))
+            writePhase("done")
+        } catch {
+            headline = "Run failed"
+            append("\(error)")
+            record(text: "ane-bench RUN FAILED: \(error)", json: nil)
+            writePhase("failed")
+        }
+    }
+
+    /// One word in a known file, so the run can be followed from the Mac with
+    /// `devicectl device copy from` while the phone sits in a pocket. Without it
+    /// the only way to know whether the model had finished loading would be to
+    /// look at the screen, which is the thing this harness exists to avoid.
+    private func writePhase(_ phase: String) {
+        let url = Self.documentsDirectory.appendingPathComponent("phase.txt")
+        try? phase.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private static var documentsDirectory: URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+    }
+
+    private func append(_ message: String) {
+        status = status.isEmpty ? message : status + "\n" + message
+    }
+
+    /// Three destinations, because they fail differently.
+    ///
+    /// #268 asks for the App Group, so that the results come out through the
+    /// export path D1's did. This bundle id cannot be signed with that
+    /// entitlement on this machine (see project.yml), so that write is attempted
+    /// and reported rather than assumed: `PersistentLog` no-ops without the
+    /// container. What actually carries the numbers is the app's own Documents
+    /// directory — reachable from the Mac over Wi-Fi with `devicectl device copy
+    /// from`, from the Files app, and from the share sheet on screen.
+    private func record(text: String, json: Data?) {
+        for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            Self.logToPersistentLog(String(line))
+        }
+        PersistentLog.flush()
+
+        let name = "ane-bench-\(Int(Date().timeIntervalSince1970))"
+        let documents = Self.documentsDirectory
+        let textURL = documents.appendingPathComponent("\(name).txt")
+        try? text.write(to: textURL, atomically: true, encoding: .utf8)
+        resultFileURL = textURL
+
+        if let json {
+            try? json.write(to: documents.appendingPathComponent("\(name).json"))
+            if let container = AppGroup.containerURL {
+                try? json.write(to: container.appendingPathComponent("\(name).json"))
+                append("wrote results into the App Group container")
+            } else {
+                append("App Group container unavailable — results are in the app's Documents only")
+            }
+        }
+    }
+
+    /// `PersistentLog`'s typed `LogEvent` API cannot carry a benchmark line, and
+    /// adding a case to it would mean changing a shipped framework for a
+    /// throwaway. The deprecated free-text entry point is the honest choice;
+    /// marking this wrapper deprecated too is what keeps the build warning-free
+    /// without hiding that it is the legacy path.
+    @available(*, deprecated)
+    private static func logToPersistentLog(_ line: String) {
+        PersistentLog.log(line)
+    }
+}

--- a/tools/ane-harness/App/Info.plist
+++ b/tools/ane-harness/App/Info.plist
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>ANE bench</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>The benchmark configures the same audio session DictusApp uses so it keeps running in the background. It never records.</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
+	<key>UIFileSharingEnabled</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+</dict>
+</plist>

--- a/tools/ane-harness/README.md
+++ b/tools/ane-harness/README.md
@@ -1,0 +1,108 @@
+# ANE harness — #268 D2
+
+**Throwaway.** Nothing here is a step toward shipping a second LLM backend. It
+exists to answer one question and is meant to be deleted with the branch:
+
+> Can a backgrounded DictusApp reach the Neural Engine to run an LLM, and hold a
+> ~1,700-token prefill there?
+
+Nothing in `Dictus.xcodeproj`, `DictusCore`, or CI references this directory.
+The findings are in [`docs/research/268-ane-background-llm.md`](../../docs/research/268-ane-background-llm.md).
+
+## What it measures, and on what
+
+- **Model:** `anemll/anemll-Qwen-Qwen3-1.7B-ctx2048_0.3.5` — ANEMLL's own
+  pre-converted Core ML build of Qwen3 1.7B. 2048-token context, batch 64, LUT6
+  on the FFN and LM head. 1.8 GB of `.mlmodelc` on disk.
+- **Prompt:** the shipping one, built at runtime from DictusCore — the resolved
+  `PolishNaturalPromptFR` instructions as the system message and the `3-long`
+  fixture through `VerbalPunctuationPrepass` in the Input/"Polished output:"
+  framing. ~1,680 tokens by the model's own tokenizer.
+- **Compute units:** `.cpuAndNeuralEngine`, the value FluidAudio sets for
+  Parakeet — the one path this product already knows runs backgrounded.
+
+## Setup
+
+```bash
+cd tools/ane-harness
+./setup.sh          # clones ANEMLL at a pinned sha, downloads 1.8 GB of weights
+```
+
+Both land in `.deps/`, which is gitignored. `setup.sh` also copies
+`seed.json` next to the kit's sources, so the harness reads the same fixture the
+polish harness does rather than a transcription of it.
+
+## Mac gate
+
+Does it load, is Core ML really placing it on the ANE, is the French sane:
+
+```bash
+cd tools/ane-harness/AneBenchKit
+swift run -c release ane-bench --iterations 2
+swift run -c release ane-bench --iterations 1 --max-tokens 60 --compute-units cpu   # the control
+```
+
+A Mac has no jetsam and no application lifecycle, so this cannot answer #268.
+It is a floor and a sanity check, exactly as the predecessor spike's Mac figures
+were.
+
+## Phone
+
+```bash
+cd tools/ane-harness
+xcodegen
+xcodebuild build -project AneHarness.xcodeproj -scheme AneHarness -configuration Debug \
+  -destination 'id=<device-id>' -derivedDataPath build/DerivedData -allowProvisioningUpdates
+xcrun devicectl device install app --device <device-id> \
+  build/DerivedData/Build/Products/Debug-iphoneos/AneHarness.app
+```
+
+The app is ~1.8 GB, so the install takes a couple of minutes over Wi-Fi.
+
+Then, with the phone **unlocked**:
+
+```bash
+xcrun devicectl device process launch --device <device-id> --terminate-existing com.pivi.dictus.anebench
+```
+
+It loads the model in the foreground, then shows "Loaded. Press Home now." and
+waits. Press Home — or launch any other app from the Mac, which backgrounds it
+the same way — and it runs on its own. Nothing needs tapping while it runs.
+
+Follow it and collect it without touching the phone:
+
+```bash
+xcrun devicectl device copy from --device <device-id> --domain-type appDataContainer \
+  --domain-identifier com.pivi.dictus.anebench --source Documents --destination ./out
+```
+
+`Documents/phase.txt` is one word — `loading`, `waiting-for-background`,
+`running`, `done`, `failed`. The results are `ane-bench-<epoch>.txt` and
+`.json`. They are also on screen when the app is reopened, with a share sheet.
+
+**Every reading carries the lifecycle state it was taken in**, and the report
+prints `allIterationsBackgrounded`. A run that says `state=active` is not an
+answer to #268 and the file says so rather than looking like one.
+
+## Layout
+
+| Path | What |
+| --- | --- |
+| `setup.sh` | fetches ANEMLL + the model, copies the fixtures |
+| `AneBenchKit/` | the SwiftPM package: prompt, runner, compute-plan probe, `ane-bench` CLI |
+| `App/` | the iOS app: audio keep-alive, self-running protocol, result writing |
+| `project.yml` | xcodegen input; regenerate with `xcodegen` |
+| `.deps/` | gitignored — the ANEMLL checkout and the weights |
+
+## Two things that are not obvious
+
+**Thinking is off, deliberately.** Qwen 3 reasons before answering unless the
+chat template emits an empty `<think></think>` block, and the predecessor spike
+threw away a whole measurement pass after finding it had run with thinking
+silently on. `AneBenchRunner.tokens(for:tokenizer:)` appends that block.
+
+**No App Group.** #268 asked for the results to come out through the persistent
+log, and this bundle id cannot be signed with `group.solutions.pivi.dictus` on
+this machine — see the comment in `project.yml`. The write is attempted and its
+outcome reported; what actually carries the numbers is the app's own Documents
+directory.

--- a/tools/ane-harness/project.yml
+++ b/tools/ane-harness/project.yml
@@ -1,0 +1,68 @@
+# tools/ane-harness/project.yml
+#
+# THROWAWAY — #268 D2. xcodegen input for the benchmark app.
+#
+# A project of its own rather than a target in Dictus.xcodeproj, deliberately:
+# #268 puts "no change to any app target" in scope, and adding an SPM dependency
+# and a target to the shared project file to answer a research question would
+# make every other build resolve a package it does not need.
+#
+# Regenerate with `xcodegen` from this directory. Run ./setup.sh first — the
+# model folder and the ANEMLL checkout it references do not exist otherwise.
+name: AneHarness
+options:
+  bundleIdPrefix: com.pivi.dictus
+  deploymentTarget:
+    iOS: "26.0"
+  createIntermediateGroups: true
+
+packages:
+  AneBenchKit:
+    path: AneBenchKit
+
+targets:
+  AneHarness:
+    type: application
+    platform: iOS
+    sources:
+      - path: App
+        excludes:
+          - Info.plist
+      # A folder reference, not a group: the 1.8 GB of .mlmodelc bundles are
+      # copied into Resources whole, so `Bundle.main.url(forResource: "model")`
+      # finds a directory with meta.yaml at its root.
+      - path: .deps/model
+        type: folder
+        buildPhase: resources
+    dependencies:
+      - package: AneBenchKit
+        product: AneBenchKit
+    # No `info:` / `entitlements:` blocks: those make xcodegen *generate* those
+    # files, overwriting the ones checked in here. The build settings below point
+    # at the authored files instead.
+    #
+    # No entitlements file at all, and #268 asked for one. The harness was first
+    # built with `group.solutions.pivi.dictus` so its results would come out
+    # through DictusApp's persistent-log export, the way D1's did. Signing
+    # refuses it:
+    #
+    #   error: Provisioning profile "iOS Team Provisioning Profile: *" doesn't
+    #   support the group.solutions.pivi.dictus App Group.
+    #   error: No Accounts: Add a new account in Accounts settings.
+    #
+    # The three profiles on this machine that carry that group are bound to
+    # com.pivi.dictus, .keyboard and .widgets; a new bundle id needs the
+    # capability enabled in the developer portal, which needs an authenticated
+    # Xcode. So the results leave the phone from the app's own Documents
+    # directory instead — `devicectl device copy from --domain-type
+    # appDataContainer` fetches them over Wi-Fi with nothing to tap, and
+    # UIFileSharingEnabled puts them in the Files app as a fallback.
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.pivi.dictus.anebench
+        DEVELOPMENT_TEAM: 9B8B36C2FA
+        CODE_SIGN_STYLE: Automatic
+        INFOPLIST_FILE: App/Info.plist
+        SWIFT_VERSION: "6.0"
+        TARGETED_DEVICE_FAMILY: "1"
+        ENABLE_USER_SCRIPT_SANDBOXING: NO

--- a/tools/ane-harness/setup.sh
+++ b/tools/ane-harness/setup.sh
@@ -23,6 +23,23 @@ ANEMLL_SHA="fb42f60b2e7a7b4709052c7146d37480bf21941e"
 # shipping French polish prompt is ~1,700), batch 64, LUT6 on the FFN and LM
 # head, FP16 embeddings. Its meta.yaml records the exact conversion parameters.
 MODEL_REPO="anemll/anemll-Qwen-Qwen3-1.7B-ctx2048_0.3.5"
+# Pinned. `main` is mutable on the Hub, and a report whose whole value is measured
+# evidence cannot rest on "whatever that repo held the day it ran". The revision
+# is written next to the weights so the benchmark can put it in its own output.
+MODEL_REVISION="0977a61d00e39118aab5ed1e510f1d228df5eefd"
+
+# Everything AneBenchRunner loads. A partial or stale download otherwise surfaces
+# as a Core ML error three minutes into a device run.
+MODEL_FILES=(
+    "meta.yaml"
+    "config.json"
+    "tokenizer.json"
+    "tokenizer_config.json"
+    "qwen_embeddings.mlmodelc/coremldata.bin"
+    "qwen_lm_head_lut6.mlmodelc/coremldata.bin"
+    "qwen_FFN_PF_lut6_chunk_01of02.mlmodelc/coremldata.bin"
+    "qwen_FFN_PF_lut6_chunk_02of02.mlmodelc/coremldata.bin"
+)
 
 mkdir -p "$DEPS"
 
@@ -36,13 +53,21 @@ git -C "$DEPS/Anemll" fetch --quiet origin "$ANEMLL_SHA" 2>/dev/null || git -C "
 git -C "$DEPS/Anemll" checkout --quiet --detach "$ANEMLL_SHA"
 echo "ANEMLL at $(git -C "$DEPS/Anemll" rev-parse --short HEAD)"
 
-if [ -f "$DEPS/model/meta.yaml" ]; then
-    echo "Model bundle present."
+if [ "$(cat "$DEPS/model/REVISION.txt" 2>/dev/null)" = "$MODEL_REVISION" ]; then
+    echo "Model bundle present at $MODEL_REVISION."
 else
-    echo "Downloading $MODEL_REPO (~1.8 GB)…"
+    echo "Downloading $MODEL_REPO @ ${MODEL_REVISION:0:8} (~1.8 GB)…"
     command -v hf >/dev/null 2>&1 || { echo "error: the 'hf' CLI is required (pip install huggingface_hub)"; exit 1; }
-    hf download "$MODEL_REPO" --local-dir "$DEPS/model"
+    hf download "$MODEL_REPO" --revision "$MODEL_REVISION" --local-dir "$DEPS/model"
+    printf '%s\n' "$MODEL_REVISION" > "$DEPS/model/REVISION.txt"
 fi
+
+missing=0
+for f in "${MODEL_FILES[@]}"; do
+    [ -e "$DEPS/model/$f" ] || { echo "error: missing $f"; missing=1; }
+done
+[ "$missing" -eq 0 ] || { echo "The model bundle is incomplete. Delete $DEPS/model and re-run."; exit 1; }
+echo "Model bundle verified: ${#MODEL_FILES[@]} required paths present."
 
 # The harness builds the prompt from DictusCore at runtime, but the raw fixture
 # text lives in the polish-harness resource bundle, which another target cannot

--- a/tools/ane-harness/setup.sh
+++ b/tools/ane-harness/setup.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# tools/ane-harness/setup.sh
+#
+# THROWAWAY — #268 D2. Fetches everything the ANE harness needs and that this
+# repository deliberately does not carry: the ANEMLL Swift runtime (a git
+# checkout, because its Package.swift is not at its repository root and SPM
+# cannot address a subdirectory of a remote) and the converted Core ML model
+# (1.8 GB of weights).
+#
+# Both land in .deps/, which is gitignored. Run this once per worktree before
+# building anything under tools/ane-harness.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPS="$HERE/.deps"
+
+# Pinned so the measurement is reproducible. 0.3.5 beta, the release whose
+# conversion pipeline produced the model bundle below.
+ANEMLL_REPO="https://github.com/Anemll/Anemll.git"
+ANEMLL_SHA="fb42f60b2e7a7b4709052c7146d37480bf21941e"
+
+# ANEMLL's own pre-converted Qwen3-1.7B for the ANE: 2048-token context (the
+# shipping French polish prompt is ~1,700), batch 64, LUT6 on the FFN and LM
+# head, FP16 embeddings. Its meta.yaml records the exact conversion parameters.
+MODEL_REPO="anemll/anemll-Qwen-Qwen3-1.7B-ctx2048_0.3.5"
+
+mkdir -p "$DEPS"
+
+if [ -d "$DEPS/Anemll/.git" ]; then
+    echo "ANEMLL checkout present."
+else
+    echo "Cloning ANEMLL…"
+    git clone --quiet "$ANEMLL_REPO" "$DEPS/Anemll"
+fi
+git -C "$DEPS/Anemll" fetch --quiet origin "$ANEMLL_SHA" 2>/dev/null || git -C "$DEPS/Anemll" fetch --quiet origin
+git -C "$DEPS/Anemll" checkout --quiet --detach "$ANEMLL_SHA"
+echo "ANEMLL at $(git -C "$DEPS/Anemll" rev-parse --short HEAD)"
+
+if [ -f "$DEPS/model/meta.yaml" ]; then
+    echo "Model bundle present."
+else
+    echo "Downloading $MODEL_REPO (~1.8 GB)…"
+    command -v hf >/dev/null 2>&1 || { echo "error: the 'hf' CLI is required (pip install huggingface_hub)"; exit 1; }
+    hf download "$MODEL_REPO" --local-dir "$DEPS/model"
+fi
+
+# The harness builds the prompt from DictusCore at runtime, but the raw fixture
+# text lives in the polish-harness resource bundle, which another target cannot
+# reach. Copy it in rather than transcribing it: a hand copy is a second source
+# of truth that drifts, and this measurement is only worth anything if the
+# prompt is byte-identical to the shipping one.
+mkdir -p "$HERE/AneBenchKit/Sources/AneBenchKit/Resources"
+cp "$HERE/../../DictusCore/Sources/polish-harness/fixtures/seed.json" \
+   "$HERE/AneBenchKit/Sources/AneBenchKit/Resources/seed.json"
+echo "Copied seed.json fixtures."
+
+echo
+echo "Ready. Next:"
+echo "  cd $HERE/AneBenchKit && swift run -c release ane-bench   # Mac gate: loads, ANE, sane French"
+echo "  cd $HERE && xcodegen                                     # iOS harness, see README.md"


### PR DESCRIPTION
## What this was for

Dictus polishes while the app is backgrounded — the keyboard holds the foreground, DictusApp does the model call. Apple's own model punishes exactly that: `rateLimited` "will only happen if your app is running in the background", and #315 caught runs of nearly twelve minutes with zero successes. #268 asked whether a second local LLM could sidestep that latch.

The 2026-08-13 spike answered most of it, and D1 (your phone, 2026-08-21) then falsified the memory ceiling three candidates had been rejected on. One candidate survived — `qwen3:1.7b` — and its viability came down to one question:

**Can a backgrounded DictusApp reach the Neural Engine to run an LLM, and hold a 1,704-token prefill there?**

That is D2. The rule was pre-registered before any measurement: a negative closes #268 permanently; a positive opens a follow-up scoped against #351.

**It came back negative, and the measurement is done.** Your phone, backgrounded, three iterations at nominal thermal.

## To test by hand

**Nothing, and that is not padding.** The measurement this PR exists for is collected: you unlocked the phone at 18:27, the run was driven from the Mac, and the results are in the report. There is no device validation left to do, because this branch ships no behaviour — it is a report plus throwaway code in `tools/ane-harness/`, referenced by nothing in `Dictus.xcodeproj`, `DictusCore`, or CI.

Two optional things, neither of which gates the merge:

1. **Delete `ANE bench` from your phone** when convenient. It is 1.8 GB of throwaway.
2. **If you want to re-run it yourself**, the full command sequence is at the end of `docs/research/268-ane-background-llm.md`. It needs the phone unlocked and nothing else.

What was verified and how:

| Check | Result |
| --- | --- |
| `cd DictusCore && swift test` | 973 tests, 0 failures |
| `swiftlint lint --strict` | 0 violations, 184 files |
| `xcodebuild -scheme DictusCore-Package -destination generic/platform=iOS` | BUILD SUCCEEDED |
| iOS harness, device build + install | `App installed: com.pivi.dictus.anebench` |
| Protocol rehearsal, iPhone 17 Pro Max simulator | `allIterationsBackgrounded=true` |
| **Device measurement, `iPhone16,2`, backgrounded** | **`allIterationsBackgrounded=true`, thermal `nominal`** |

## What came back

Three iterations, backgrounded, `thermal=nominal` on every sample:

```text
rev unknown | iPhone16,2 | Version 26.6 (Build 23G71) | ramGB=8
computeUnits=cpuAndNeuralEngine   modelLoadMs=2079
computePlan qwen_FFN_PF_lut6_chunk_01of02.mlmodelc: ANE 1166 / CPU 13 / GPU 0
iteration 1 prefillMs=4947 decodeMs=9480 generated=162 totalMs=14427 stop=eos_token
  iteration1.start available=3091MB footprint=284MB thermal=nominal state=background
iteration 2 prefillMs=4463 decodeMs=9337 generated=162 totalMs=13800 stop=eos_token
iteration 3 prefillMs=4476 decodeMs=9358 generated=162 totalMs=13834 stop=eos_token
allIterationsBackgrounded=true
```

**Both open questions came back positive, and the third one decides.**

- **The ANE is reachable from a backgrounded app.** The on-device compute plan is byte-for-byte the Mac's: 1,166 ANE operations against 13 CPU, 0 GPU. Core ML does not silently re-plan onto the CPU when the app leaves the foreground — the predecessor's largest open mechanism, now closed, and closed by reading Core ML rather than inferring from a timing.
- **The prompt fits.** 1,680 tokens, EOS stop, coherent French.
- **And it costs 14 seconds.** Against a pre-registered ceiling of 5 s and an Apple FM field baseline of 1,654 ms on that same phone: **2.8× the ceiling, 8.4× the incumbent.** Decode is 9.4 s of the 14 s, so shortening the 1,150-token prompt — the one lever the predecessor identified — cannot reach the budget even at prompt length zero.

**The iPhone-to-Mac multiplier, like for like** (same runtime, same bundle, same compute units, medians of three):

| | Mac (M4 Pro, ANE) | iPhone16,2 (ANE) | ×  |
| --- | --- | --- | --- |
| Prefill, 1,680 tok | 2,790 ms (602 tok/s) | 4,476 ms (375 tok/s) | **1.60** |
| Decode, 162 tok | 5,845 ms (27.7 tok/s) | 9,358 ms (17.3 tok/s) | **1.60** |
| Total | 8,635 ms | 13,834 ms | **1.60** |

Both terms scale by the same factor. A larger one (×2.7 / ×4.5) falls out of comparing the predecessor's Mac figures to these, but those are Ollama/Q4_K_M/CPU against ANEMLL/LUT6/ANE — that ratio measures the change of stack, not the change of machine.

Three further results worth carrying forward:

- **Memory was the wrong argument all along.** With all 1.8 GB loaded: **3,090 MB of jetsam headroom left, footprint 284 MB.** Core ML maps ANE weights instead of allocating them. The pre-registered 1.2 GB ceiling, D1's correction of it, and the "does 1.9 GB fit alongside Parakeet" table all priced a quantity that does not bind. If this is ever reopened, that page of reasoning should not be reopened with it.
- **Sustained ANE inference throttles the phone.** A first run that began at `thermal=fair` crossed to `serious` within ninety seconds; decode fell from 13.5 to 7.0 tok/s and the call reached **33.9 s**. DictusApp stays warm between dictations by design, which is the pattern that produces this curve.
- **The converted build barely polishes — and the reason widens the gap.** You spotted it: on `3-long` it returns the input almost unchanged. Measured, it is **one character** different (a final full stop), byte-identical on Mac and phone. LUT6 is the obvious suspect and probably not the culprit: the Ollama comparison reasoned for 1,800–2,500 characters before answering, the ANE run had reasoning suppressed, and re-running the ANE build with reasoning **on** shows it reasoning coherently and on-task. What blocks it is the window — 1,676 tokens of prompt in a 2,048 context leaves 372, and its reasoning needs 500–700. **The mode that polishes does not fit.** Getting quality would need a bigger context, which means more prefill on a call already 2.8× over budget.

## The decision

Against the rule written before the measurement, this is the negative branch: **#268 should be closed.**

The report states what a reopening would have to show, in the two forms that need no assumption:

| | Measured | Needed for a 5 s call |
| --- | --- | --- |
| Whole pipeline scaled uniformly (13,834 → 5,000 ms) | prefill 375 tok/s, decode 17.3 tok/s | prefill ~1,040 tok/s, decode ~48 tok/s — **×2.8 on both** |
| Decode alone, prefill unchanged (4,476 ms leaves 524 ms) | decode 17.3 tok/s | decode **~309 tok/s — ×18** |

**Correction, and it was public.** An earlier draft and the closing comment on #268 quoted ~55 tok/s of decode as the bar. That was wrong: 162 tokens at 55 tok/s is 2.95 s, plus an unchanged 4.48 s prefill = 7.43 s, still 1.5× over. It only worked if prefill improved by the same factor, which was never stated. Fixed in all three places in the report; the lead has posted the correction on the issue.

I have not closed the issue — that is yours.

**On `rev unknown` in the export:** the harness is not a target of `Dictus.xcodeproj`, so the build-info phase never runs for it and `PersistentLog.codeRevision` correctly declines to guess. The binary on the phone was built from the tree that became **`eba99cf`**, and nothing under `tools/ane-harness/App/` changed between that commit and the run.

## Review

CodeRabbit raised 8 findings. All eight are addressed in `bd2a85f`; none of them changes a measured number, and the report says which harness edits landed after the device run and why they do not affect it.

The one that mattered is the reopening bar above — it was wrong, and wrong in the direction that understates the requirement. The rest were ways a bad run could have looked like a good one: the run continued when the audio keep-alive failed (it now aborts — without the keep-alive iOS suspends the app, so the result would not be a background measurement); a mistyped `--compute-units` fell through to the ANE and labelled itself the control; `allIterationsBackgrounded` read `false` on every Mac run, indistinguishable from a device run that measured the wrong thing; `decodeMs` was clamped with `max(0,…)`, which would print a plausible number for a run whose clocks disagree; `--json` swallowed encode failures and exited 0; and `RunError.notLoaded` was thrown for an OS-version failure.

Two on provenance: `setup.sh` pinned the model to a mutable `main` and now pins an immutable revision, verifies the eight paths the runner loads, and records the revision in the report; the `[source]` labels in Findings 1 and 6 promised a URL or named path and now give one.

One declined: **localizing the harness's strings into an xcstrings catalog.** The repo rule exists because user-facing copy ships in French and English. This is a diagnostic target in `tools/`, in no app, seen by nobody but whoever runs the measurement, and deleted with the branch. Localizing it would add a catalog to maintain for text that has no user.

Last: the `prompt` command and the harness both assumed `.natural`. Two of fourteen fixtures resolve to `.repair`, whose instructions are less than half the length. `3-long` resolves to `.natural`, **so no measurement changes** — but a tool whose whole job is "print exactly what the engine sends" was not doing it.

## What changed

Ten commits, all throwaway or documentation. No app target is touched.

- **`polish-harness prompt`** — prints the exact two strings the polish engine sends for a fixture. The measurement is only worth taking on the real prompt, and the user-turn framing was built inline in two places and is now built in one.
- **`tools/ane-harness/`** — the apparatus. Its own xcodegen project; a SwiftPM kit shared between a macOS CLI (`ane-bench`) and an iOS app. Self-running: it loads in the foreground, waits to be backgrounded rather than counting down at whoever is holding the phone, then runs on its own. Every reading carries the lifecycle state it was taken in.
- **`docs/research/268-ane-background-llm.md`** — the findings, in the predecessor's house style with the same evidence labels.

## Acceptance criteria

The issue has no checklist; its "Scope — in scope" list of five is the contract.

| # | Criterion | Status | Evidence |
| --- | --- | --- | --- |
| 1 | Convert a ~1.7B model for the ANE | **Deviated, deliberately** | Used `anemll/anemll-Qwen-Qwen3-1.7B-ctx2048_0.3.5` — same toolchain, same version, conversion parameters recorded in its `meta.yaml`. No toolchain failure to report: it loaded and ran. |
| 2 | Load it on a physical iPhone | **Done** | `modelLoadMs=118501` first time, `2079` after, on `iPhone16,2`. |
| 3 | Feed it `PolishNaturalPromptFR` + `3-long`, ~1,704 tokens of prefill | **Done** | `promptTokens=1680`, built from DictusCore at runtime, EOS stop, coherent French. |
| 4 | Time prefill and decode **backgrounded** | **Done** | `prefillMs=4463–4947`, `decodeMs=9337–9480`, `allIterationsBackgrounded=true`. |
| 5 | Record footprint and jetsam headroom via `os_proc_available_memory()` | **Done** | `available=3090–3091MB`, `footprint=284–285MB`, flat across three iterations. |

## What I am not comfortable with

- **One device, one thermal state, three consecutive calls.** The budget is written as a p50 and this is not one. The margin is wide enough (14 s against 5 s) that it survives, but the numbers are one `iPhone16,2`'s.
- **That LUT6 is *why* the output is near-identical.** The reasoning-on control rules that reading out rather than confirming it. What is established is that this build, in the only mode its window allows, does not transform the text. Whether a 4K-context LUT6 build would polish acceptably is untested, and so is whether LUT6 costs anything against the predecessor's 66/72.
- **One fixture.** Finding 7 is `3-long`, the largest shipping one. The 72-check suite was not run against this build.
- **A correction the predecessor should carry:** on Ollama 0.32.6 with `qwen3:1.7b`, *neither* `reasoning_effort: none` nor `chat_template_kwargs` suppresses reasoning — it moved to a separate `message.thinking` field, so it is invisible from the answer. Quality scores are unaffected (`LocalHTTPPolishEngine` reads `content`); the latency figures for that model include reasoning believed to be suppressed.
- **17.3 tok/s is one open-source runtime's number**, not the Neural Engine's ceiling. Apple runs its own model on this silicon and does not publish how.
- **The thermal curve is one run**, with an uncontrolled starting state. It shows that this duty cycle reaches `serious` and that decode roughly halves when it does; recovery time and a realistic dictation cadence were not measured.
- **Second deliberate deviation:** #268 asked for results to come out through the App Group and the persistent-log export. Signing refuses that entitlement for a new bundle id on this machine (`No Accounts: Add a new account in Accounts settings`). Results left through the app's Documents instead — which in practice cost you less, since the whole run was driven from the Mac and the only human act in it was unlocking the phone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an iOS benchmark app and command-line tool for measuring Apple Neural Engine model performance.
  * Added configurable execution modes, optional reasoning, telemetry capture, JSON export, and result sharing.
  * Added prompt inspection with fixture selection, language detection, and optional file output.
  * Added compute-plan analysis and background execution status reporting.

* **Documentation**
  * Added setup, usage, workflow, and reproducibility documentation.
  * Expanded research findings and benchmark results.

* **Chores**
  * Added setup automation and repository ignore rules for benchmark resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->