### PR TITLE
Stop calling a refusing polish engine, and say so (refs #315)

### DIFF
--- a/.out-of-scope/foreground-the-app-for-polish.md
+++ b/.out-of-scope/foreground-the-app-for-polish.md
@@ -1,0 +1,15 @@
+# Foregrounding the App to Escape the Apple FM Rate Limit
+
+Dictus will not bring DictusApp to the foreground in order to run a polish or Smart Mode call. Not per dictation, not periodically, not automatically.
+
+## Why this is out of scope
+
+Apple documents that `rateLimited` only occurs for apps running in the background, and a controlled test on 2026-08-13 (#315) showed the rule is applied per call: the same process, seconds apart, is refused backgrounded and served in the foreground. So foregrounding does work. It is rejected on cost, not on effect.
+
+DictusApp is backgrounded by design. The keyboard extension holds the screen, the app records and transcribes behind it, and the user never sees DictusApp during normal use. The one moment the product does foreground the app — cold-start dictation — is the worst moment in it, and it has three open issues to itself (#23 no API exists to return the user, #264 the home-screen flash, #311 the stranded dictation on an early swipe-back). Doing that after every dictation would apply the product's worst interaction to its most common one.
+
+A periodic variant was considered — foreground every twenty or thirty minutes to reset the budget — and fails on its own terms: the test showed a foreground visit does not refund the budget at all. Only a process restart does, and an app cannot restart itself.
+
+## What is in scope instead
+
+Moving the call to a process that is already in the foreground: the keyboard extension. Measured separately. Failing that, honest degradation, and a backend not subject to foreground priority (#268, #351).

--- a/DictusApp/Polish/PolishCoordinator.swift
+++ b/DictusApp/Polish/PolishCoordinator.swift
@@ -35,6 +35,15 @@ public final class PolishCoordinator {
     private let metricsRing = PolishMetricsRing()
     private var inflight: Task<PolishPipeline.Result, Never>?
 
+    /// Whether polish is still calling its engine (#315).
+    ///
+    /// Deliberately in memory and nowhere else. Apple's background rate limit is
+    /// only refunded by a fresh process, so "reset on a fresh process" and "do not
+    /// persist" are the same instruction, and this property is the whole of the
+    /// implementation. Anything that re-armed it — a timer, a foreground
+    /// observer, a retry — would be theatre against the measurements on #315.
+    private var availabilityGate = PolishAvailabilityGate()
+
     private init() {
         self.defaults = AppGroup.defaults
         #if canImport(FoundationModels)
@@ -46,6 +55,12 @@ public final class PolishCoordinator {
         #else
         self.appleFMEngine = nil
         #endif
+        // The fresh-process reset, on the flag the other process reads (#315).
+        // Done from the same object that owns `availabilityGate` above, so what
+        // is on disk and what is in memory cannot describe different states.
+        // This singleton is created from `DictusApp.init()`, so "fresh process"
+        // and "this line ran" are the same moment.
+        PolishAvailabilityChannel.clear()
     }
 
     /// Resolve the engine for this call. Re-checked on every `polish()` so a
@@ -326,14 +341,16 @@ public final class PolishCoordinator {
         // delegated to `PolishPipeline` so the eval harness runs identical code.
         let preprocessMs = Int(Date().timeIntervalSince(methodStart) * 1000)
 
+        let gate = availabilityGate
         let task = Task {
             await PolishPipeline.transform(
-                preprocessed: preprocessed, engine: currentEngine, target: target, mode: mode
+                preprocessed: preprocessed, engine: currentEngine, target: target, mode: mode, gate: gate
             )
         }
         inflight = task
 
         let bundle = await task.value
+        recordAvailability(bundle, engine: currentEngine)
         // True total, methodStart → here. Any gap vs (pre+engine+post) is
         // Swift Task scheduling / actor-hop overhead — itself worth seeing.
         let totalMs = Int(Date().timeIntervalSince(methodStart) * 1000)
@@ -441,14 +458,17 @@ public final class PolishCoordinator {
         announceEngineStage(currentEngine, to: onEngineWillRun)
         // Pre-engine work in auto mode: detection + detected-language pre-pass.
         let preprocessMs = Int(Date().timeIntervalSince(methodStart) * 1000)
+        let gate = availabilityGate
         let task = Task {
             await PolishPipeline.transform(
-                preprocessed: preprocessed, engine: currentEngine, target: contextLanguage, mode: .auto
+                preprocessed: preprocessed, engine: currentEngine, target: contextLanguage,
+                mode: .auto, gate: gate
             )
         }
         inflight = task
 
         let bundle = await task.value
+        recordAvailability(bundle, engine: currentEngine)
         let totalMs = Int(Date().timeIntervalSince(methodStart) * 1000)
         let returned = PolishPipeline.resolvedOutput(
             bundle, preprocessed: preprocessed, target: contextLanguage, mode: .auto
@@ -512,9 +532,39 @@ public final class PolishCoordinator {
     /// worth announcing (#267). Both polish paths reach the engine by different
     /// routes and each has to make this call; the check lives here so neither can
     /// make it differently.
+    ///
+    /// The availability gate (#315) is read here for the same reason it is read
+    /// inside the transform: while polish is unavailable there is no wait to
+    /// announce — the transform returns in about a millisecond without touching
+    /// the engine — and a `.processing` stage raised for it would flash a label
+    /// and a new animation for a single frame. Both decisions come off the one
+    /// gate value, so they cannot drift apart.
     private func announceEngineStage(_ engine: PolishEngineProtocol, to callback: (() -> Void)?) {
+        guard availabilityGate.allowsCall(engine: engine.identifier) else { return }
         guard engine.announcesProcessingStage else { return }
         callback?()
+    }
+
+    /// Feed one completed transform outcome to the availability gate (#315), and
+    /// on the single call that flips it, say so where both the user and a future
+    /// capture can see it.
+    ///
+    /// Both polish paths call this with the result they just got, so the rule
+    /// runs once per engine-facing dictation whichever route it took.
+    private func recordAvailability(_ bundle: PolishPipeline.Result,
+                                    engine: PolishEngineProtocol) {
+        let becameUnavailable = availabilityGate.record(
+            outcome: bundle.outcome,
+            reason: bundle.failureReason,
+            engine: engine.identifier
+        )
+        guard becameUnavailable else { return }
+        PersistentLog.log(.polishEngineUnavailable(
+            engine: engine.identifier,
+            reason: bundle.failureReason?.slug ?? "-",
+            consecutiveRefusals: PolishAvailabilityGate.consecutiveRefusalsBeforeUnavailable
+        ))
+        PolishAvailabilityChannel.markUnavailable()
     }
 
     /// Log one metrics event and append it to the debug ring.

--- a/DictusApp/Polish/PolishDebugExporter.swift
+++ b/DictusApp/Polish/PolishDebugExporter.swift
@@ -139,7 +139,7 @@ enum PolishDebugExporter {
         var outcomes: [String: Int] = [
             "success": 0, "rejectedGuardrail": 0, "skipped": 0,
             "skippedShort": 0, "skippedAutoMode": 0, "cancelled": 0, "engineFailed": 0,
-            "exceededContextBudget": 0
+            "engineUnavailable": 0, "exceededContextBudget": 0
         ]
         var failureReasons: [String: Int] = [:]
         for e in entries {

--- a/DictusApp/Polish/PolishDebugView.swift
+++ b/DictusApp/Polish/PolishDebugView.swift
@@ -340,7 +340,7 @@ private struct PolishExportShareSheet: UIViewControllerRepresentable {
 private extension PolishMetrics.Outcome {
     static var allDisplayCases: [PolishMetrics.Outcome] {
         [.success, .rejectedGuardrail, .skipped, .skippedShort, .skippedAutoMode,
-         .cancelled, .engineFailed, .exceededContextBudget]
+         .cancelled, .engineFailed, .engineUnavailable, .exceededContextBudget]
     }
 
     var shortLabel: String {
@@ -352,6 +352,7 @@ private extension PolishMetrics.Outcome {
         case .skippedAutoMode: return "auto"
         case .cancelled: return "cancelled"
         case .engineFailed: return "failed"
+        case .engineUnavailable: return "unavailable"
         case .exceededContextBudget: return "too long"
         }
     }
@@ -363,7 +364,11 @@ private extension PolishMetrics.Outcome {
         // engine was never called and the user still got their text (#270).
         case .rejectedGuardrail, .skipped, .skippedShort, .skippedAutoMode,
              .exceededContextBudget: return .orange
-        case .cancelled, .engineFailed: return .red
+        // Red, with the failures rather than with the refusals above (#315):
+        // nothing failed on this dictation, but the feature is off for the rest
+        // of the process, which is the worst state on this list and the one that
+        // has to be findable at a glance in a long export.
+        case .cancelled, .engineFailed, .engineUnavailable: return .red
         }
     }
 }

--- a/DictusCore/Sources/DictusCore/LogEvent.swift
+++ b/DictusCore/Sources/DictusCore/LogEvent.swift
@@ -237,6 +237,17 @@ public enum LogEvent: Sendable {
     /// insertion — and only this log has all of them on one page.
     case polishEngineFailed(reason: String, engine: String, mode: String, engineMs: Int)
 
+    /// Issue #315: polish stopped calling its engine for the rest of this process,
+    /// after `consecutiveRefusals` `rateLimited` results in a row.
+    ///
+    /// Emitted once, on the transition. Every dictation after it records
+    /// `outcome = engineUnavailable` in the polish debug export, so the count of
+    /// what a single outage cost is already answerable there; a line per skipped
+    /// call here would only repeat it. What this log has that the export does not
+    /// is everything else the app was doing, which is what says whether the user
+    /// was told and what the keyboard was showing at the time.
+    case polishEngineUnavailable(engine: String, reason: String, consecutiveRefusals: Int)
+
     // MARK: - Computed Properties
 
     /// The subsystem this event belongs to, derived from the case.
@@ -295,7 +306,7 @@ public enum LogEvent: Sendable {
         // Polish is the stage after the STT result and before the App Group
         // write, so it reads with the transcription stream rather than as a
         // subsystem of its own (#315).
-        case .polishEngineFailed:
+        case .polishEngineFailed, .polishEngineUnavailable:
             return .transcription
         }
     }
@@ -373,7 +384,12 @@ public enum LogEvent: Sendable {
         // Warning, not error: the user still gets their text (the deterministic
         // floor), only the polish is lost — but silently, which is the failure
         // worth finding in a log (#315).
-        case .polishEngineFailed:
+        //
+        // The same level for the unavailable transition, and for the same reason:
+        // an enabled feature has stopped running. It is the more serious of the
+        // two — it holds for the rest of the process — but not an error either,
+        // because nothing broke and no text was lost.
+        case .polishEngineFailed, .polishEngineUnavailable:
             return .warning
         }
     }
@@ -475,6 +491,7 @@ public enum LogEvent: Sendable {
         case .modelDownloadProgress: return "modelDownloadProgress"
         case .modelDownloadStalled: return "modelDownloadStalled"
         case .polishEngineFailed: return "polishEngineFailed"
+        case .polishEngineUnavailable: return "polishEngineUnavailable"
         case .userDictionaryWordLearned: return "userDictionaryWordLearned"
         case .userDictionaryEvicted: return "userDictionaryEvicted"
         case .userDictionaryReset: return "userDictionaryReset"
@@ -708,6 +725,8 @@ public enum LogEvent: Sendable {
         // Polish (#315)
         case .polishEngineFailed(let reason, let engine, let mode, let engineMs):
             return "reason=\(reason) engine=\(engine) mode=\(mode) engineMs=\(engineMs)"
+        case .polishEngineUnavailable(let engine, let reason, let consecutiveRefusals):
+            return "engine=\(engine) reason=\(reason) consecutiveRefusals=\(consecutiveRefusals)"
         }
     }
 

--- a/DictusCore/Sources/DictusCore/Polish/AppleFoundationModelsPolishEngine.swift
+++ b/DictusCore/Sources/DictusCore/Polish/AppleFoundationModelsPolishEngine.swift
@@ -56,8 +56,8 @@ public final class AppleFoundationModelsPolishEngine: PolishEngineProtocol, Send
         )
         // A session lives exactly one polish call. `prewarm()` (fired at
         // recording start) leaves a fresh, warmed session in the cache; we use
-        // it here on a cache hit, or create one if no prewarm ran. The `defer`
-        // drops it afterward so the NEXT call never inherits this turn.
+        // it here on a cache hit, or create one if no prewarm ran, and drop it
+        // afterward so the NEXT call never inherits this turn.
         //
         // WHY this matters: `LanguageModelSession` is stateful — every
         // `respond()` is appended to a transcript the session re-prefills on
@@ -69,7 +69,6 @@ public final class AppleFoundationModelsPolishEngine: PolishEngineProtocol, Send
             for: key,
             instructions: resolvedInstructions(mode: mode, language: targetLanguage)
         )
-        defer { Task { await cache.drop(key) } }
         // Wrap the input with explicit Input/Output framing. Without this Apple
         // FM treats the raw as a conversational turn and emits chat-reply
         // acknowledgements ("I'll polish it for you") instead of the polished
@@ -83,8 +82,23 @@ public final class AppleFoundationModelsPolishEngine: PolishEngineProtocol, Send
 
         Polished output:
         """
-        let response = try await session.respond(to: prompt)
-        return response.content.trimmingCharacters(in: .whitespacesAndNewlines)
+        // The drop is awaited on both exits rather than deferred into an
+        // unstructured `Task` (#315). A detached task is ordered against
+        // nothing, and the captures on that issue show two dictations chaining
+        // inside a single second: `polish` A takes session S1, the next
+        // recording's `prewarm()` drops S1 and installs a warmed S2, then A's
+        // deferred task fires and drops S2. The next call gets a cache miss and
+        // builds a cold session, so the prewarm is wasted on every chained
+        // dictation. Awaiting here means the drop cannot outlive the call that
+        // owns it.
+        do {
+            let response = try await session.respond(to: prompt)
+            await cache.drop(key)
+            return response.content.trimmingCharacters(in: .whitespacesAndNewlines)
+        } catch {
+            await cache.drop(key)
+            throw error
+        }
     }
 
     /// Create a FRESH session for `(mode, targetLanguage)` and prewarm it.

--- a/DictusCore/Sources/DictusCore/Polish/PolishAvailabilityChannel.swift
+++ b/DictusCore/Sources/DictusCore/Polish/PolishAvailabilityChannel.swift
@@ -1,0 +1,51 @@
+// DictusCore/Sources/DictusCore/Polish/PolishAvailabilityChannel.swift
+// Whether polish is still calling its engine, shared across the two processes (#315).
+import Foundation
+
+/// Says whether polish has given up on its engine for the rest of the app's
+/// process, so a surface in the other process can tell the user.
+///
+/// WHY a named contract rather than three `UserDefaults` calls, same argument as
+/// `DictationErrorChannel`: the rule is not in the key, it is in *when the key is
+/// cleared*, and that is the part a future reader would otherwise have to
+/// reconstruct. Stated once here:
+///
+/// **Only a fresh DictusApp process clears this.** No timer, no re-arm on
+/// foreground, no retry. That is not a simplification — it is the measured
+/// behaviour of the thing being reported. Apple's background rate limit is not
+/// refunded by waiting (calls three minutes apart on 61-character inputs were
+/// still refused instantly) and not refunded by a foreground visit (twenty
+/// seconds of foreground changed nothing; the very next backgrounded call was
+/// refused). Every capture on #315 that recovered did so across a process
+/// restart and nothing else.
+///
+/// The clear therefore belongs to the object that owns the in-memory
+/// `PolishAvailabilityGate` — `PolishCoordinator`, at its `init` — so the flag
+/// on disk and the gate in memory can never describe different states.
+///
+/// The keyboard extension only reads. It has its own process lifetime, and
+/// nothing it does can restore the app's budget.
+public enum PolishAvailabilityChannel {
+
+    /// Whether polish has stopped calling its engine. False when nothing was
+    /// recorded, which is the available state.
+    public static var isUnavailable: Bool {
+        AppGroup.defaults.bool(forKey: SharedKeys.polishUnavailable)
+    }
+
+    /// Record that polish has stopped calling its engine. Called once, on the
+    /// transition.
+    public static func markUnavailable() {
+        let defaults = AppGroup.defaults
+        defaults.set(true, forKey: SharedKeys.polishUnavailable)
+        defaults.synchronize()
+    }
+
+    /// Return to the available state. Called from `PolishCoordinator.init()`, and
+    /// from nowhere else — see the rule above.
+    public static func clear() {
+        let defaults = AppGroup.defaults
+        defaults.removeObject(forKey: SharedKeys.polishUnavailable)
+        defaults.synchronize()
+    }
+}

--- a/DictusCore/Sources/DictusCore/Polish/PolishAvailabilityGate.swift
+++ b/DictusCore/Sources/DictusCore/Polish/PolishAvailabilityGate.swift
@@ -1,0 +1,93 @@
+// DictusCore/Sources/DictusCore/Polish/PolishAvailabilityGate.swift
+import Foundation
+
+/// When to stop calling a polish engine that is refusing us (#315).
+///
+/// WHY this exists: `rateLimited` is not a flake. Apple documents it as a
+/// refusal applied to apps running in the background, and DictusApp is
+/// backgrounded for every polish call by design — the keyboard holds the screen.
+/// A controlled test on 2026-08-13 showed the refusal is decided per call: the
+/// same process, seconds apart, was refused backgrounded and served in the
+/// foreground. So there is nothing to wait for and nothing to retry. Once the
+/// refusals start, every further call costs a round trip and returns nothing.
+///
+/// WHY two and not three: every `rateLimited` run captured on #315 arrives in a
+/// run of at least two, and a single isolated one has never been observed. Two
+/// is the smallest threshold that cannot fire on a one-off.
+///
+/// WHY there is no reset rule: only a fresh process restores the budget. Twenty
+/// seconds of foreground did not refund it, and no amount of wall-clock ever has
+/// in any capture on that issue. A fresh process gets a fresh value of this
+/// type, which *is* the reset — so the correct implementation is to have no
+/// timer, no re-arm and no retry, and this type deliberately offers none.
+public struct PolishAvailabilityGate: Sendable, Equatable {
+
+    /// How many consecutive `rateLimited` refusals put polish into its
+    /// unavailable state.
+    public static let consecutiveRefusalsBeforeUnavailable = 2
+
+    /// The engine that is being held unavailable, or `nil` while polish is
+    /// available. Exposed so a caller can name it in a log line.
+    public private(set) var unavailableEngine: String?
+
+    /// The engine the current refusal run belongs to. A run is per engine: the
+    /// backend can change mid-process (Apple Intelligence toggled off drops the
+    /// coordinator to the passthrough engine), and refusals from one say nothing
+    /// about another.
+    private var refusingEngine: String?
+
+    /// Length of the current refusal run, reset by any verdict that proves the
+    /// engine served the call.
+    private var consecutiveRefusals = 0
+
+    /// A fresh gate is available. This is the whole of the reset rule.
+    public init() {}
+
+    /// Whether `engine` may be called at all.
+    public func allowsCall(engine: String) -> Bool {
+        unavailableEngine != engine
+    }
+
+    /// Feed one completed transform outcome.
+    ///
+    /// Returns `true` on the single call that flips the gate to unavailable, and
+    /// `false` on every other, so the caller can announce and log the transition
+    /// exactly once without tracking the edge itself.
+    @discardableResult
+    public mutating func record(outcome: PolishMetrics.Outcome,
+                                reason: PolishFailureReason?,
+                                engine: String) -> Bool {
+        guard unavailableEngine == nil else { return false }
+
+        switch outcome {
+        case .engineFailed where reason == .rateLimited:
+            // A run belongs to one engine; a refusal from a different backend
+            // starts a new one rather than continuing the old count.
+            if refusingEngine != engine {
+                refusingEngine = engine
+                consecutiveRefusals = 0
+            }
+            consecutiveRefusals += 1
+            guard consecutiveRefusals >= Self.consecutiveRefusalsBeforeUnavailable else { return false }
+            unavailableEngine = engine
+            return true
+
+        case .success, .rejectedGuardrail, .engineFailed:
+            // The engine took the call and came back with a verdict — it ran, or
+            // it refused for a reason that is not the rate limit (a guardrail
+            // violation is a real generation that was rejected). Either way the
+            // run is broken.
+            refusingEngine = nil
+            consecutiveRefusals = 0
+            return false
+
+        case .cancelled, .exceededContextBudget, .engineUnavailable,
+             .skipped, .skippedShort, .skippedAutoMode:
+            // No evidence either way: the engine was never reached, or the call
+            // was cut short before it could answer. Leaving the run untouched is
+            // what lets a flash dictation in the middle of a refusal run avoid
+            // hiding it.
+            return false
+        }
+    }
+}

--- a/DictusCore/Sources/DictusCore/Polish/PolishMetrics.swift
+++ b/DictusCore/Sources/DictusCore/Polish/PolishMetrics.swift
@@ -46,6 +46,17 @@ public struct PolishMetrics: Sendable, Codable {
         case skippedAutoMode
         case cancelled
         case engineFailed
+        /// The engine was not called because polish is in its unavailable state
+        /// (#315). Reached when two consecutive `rateLimited` refusals have shown
+        /// that this process is on the wrong side of Apple's background rate
+        /// limit; every dictation after that takes the deterministic floor
+        /// without paying for a call that will be refused.
+        ///
+        /// Deliberately distinct from `engineFailed`: nothing failed here, we
+        /// declined to ask. Keeping the two apart is what lets an export say how
+        /// many dictations a single outage cost, rather than folding them into
+        /// the failure count and inflating it.
+        case engineUnavailable
         /// Refused BEFORE the engine call (#270): the estimated token cost of
         /// the resolved instructions + input + output reserve exceeds the
         /// backend's context window. Deliberately distinct from

--- a/DictusCore/Sources/DictusCore/Polish/PolishPipeline.swift
+++ b/DictusCore/Sources/DictusCore/Polish/PolishPipeline.swift
@@ -52,10 +52,24 @@ public enum PolishPipeline {
     /// CJK full-width punctuation must survive untouched), and the language
     /// guardrail compares the output's detected language against the INPUT's
     /// detected language instead of a target — the runtime never-translate check.
+    ///
+    /// `gate` (#315) is the caller's polish-availability state. It defaults to a
+    /// fresh gate, which allows everything, so a caller with no such state — the
+    /// off-device eval harness — is unaffected.
     public static func transform(preprocessed: String,
                                  engine: PolishEngineProtocol,
                                  target: SupportedLanguage,
-                                 mode: PolishMode) async -> Result {
+                                 mode: PolishMode,
+                                 gate: PolishAvailabilityGate = PolishAvailabilityGate()) async -> Result {
+        // Polish is in its unavailable state for this engine (#315): two
+        // consecutive `rateLimited` refusals said this process is on the wrong
+        // side of Apple's background rate limit, and only a fresh process
+        // changes that. Exit before the newline encode and before the context
+        // guard — the point is to pay nothing at all — and let `resolvedOutput`
+        // hand back the same deterministic floor a guardrail rejection gets.
+        guard gate.allowsCall(engine: engine.identifier) else {
+            return Result(engineOutput: nil, outcome: .engineUnavailable, engineMs: 0, postprocessMs: 0)
+        }
         // Encode newlines as a marker so the model can't "naturalise" them into
         // ", " + capital — see `PolishPostpass`. Sub-millisecond, kept out of the
         // engine timing below.
@@ -142,7 +156,8 @@ public enum PolishPipeline {
     /// The string the user actually receives, given a transform `Result` and the
     /// deterministic pre-pass output. On `.success` it's the accepted engine
     /// output; on EVERY other outcome (gibberish-skip, engine failure, guardrail
-    /// rejection, cancellation, context overflow) it's the deterministic floor —
+    /// rejection, cancellation, context overflow, polish unavailable) it's the
+    /// deterministic floor —
     /// the pre-pass text with newline markers decoded and target-language
     /// typography applied.
     ///

--- a/DictusCore/Sources/DictusCore/SharedKeys.swift
+++ b/DictusCore/Sources/DictusCore/SharedKeys.swift
@@ -104,6 +104,14 @@ public enum SharedKeys {
     /// Whether the polish layer runs between STT final output and App Group write, default false.
     /// Off by default — round 1 is opt-in measurement. See ADR 0002.
     public static let polishEnabled = "dictus.polishEnabled"
+    /// Bool: whether polish has stopped calling its engine for the rest of this app
+    /// process (#315). Written only by DictusApp, read by whichever surface has to
+    /// say so — the keyboard toolbar today. Absent reads false, which is the
+    /// available state, so no registration and no migration are needed.
+    ///
+    /// Read and written only through `PolishAvailabilityChannel`, which is where
+    /// the rule about clearing it lives.
+    public static let polishUnavailable = "dictus.polishUnavailable"
 
     // Audio heartbeat (added for background waveform reliability)
     /// Double (timeIntervalSince1970): written directly from the audio thread at ~1Hz

--- a/DictusCore/Tests/DictusCoreTests/Polish/PolishAvailabilityGateTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/Polish/PolishAvailabilityGateTests.swift
@@ -1,0 +1,312 @@
+// DictusCore/Tests/DictusCoreTests/Polish/PolishAvailabilityGateTests.swift
+import XCTest
+@testable import DictusCore
+
+/// Coverage of decision 14 on #315: stop calling an engine that is refusing us.
+///
+/// The rule (when to stop), the effect (the engine is not called and the call
+/// costs nothing), and the two things this must NOT have changed — what the user
+/// receives, and the decodability of events written before the outcome existed.
+final class PolishAvailabilityGateTests: XCTestCase {
+
+    private let apple = "apple-fm"
+
+    // MARK: - The rule
+
+    /// A fresh gate is the whole of the reset rule: a new process starts
+    /// available because it starts with a new value of this type.
+    func testFreshGateAllowsTheCall() {
+        XCTAssertTrue(PolishAvailabilityGate().allowsCall(engine: apple))
+        XCTAssertNil(PolishAvailabilityGate().unavailableEngine)
+    }
+
+    /// One refusal is not enough. Every `rateLimited` run captured on #315
+    /// arrives in a run of at least two, so a single one must not cost the user
+    /// their polish for the rest of the process.
+    func testOneRefusalDoesNotStopTheEngine() {
+        var gate = PolishAvailabilityGate()
+        XCTAssertFalse(gate.record(outcome: .engineFailed, reason: .rateLimited, engine: apple))
+        XCTAssertTrue(gate.allowsCall(engine: apple))
+    }
+
+    /// Two, not three — and the transition is reported exactly once, so the
+    /// caller can log and announce it without tracking the edge itself.
+    func testTwoConsecutiveRefusalsStopTheEngine() {
+        var gate = PolishAvailabilityGate()
+        XCTAssertFalse(gate.record(outcome: .engineFailed, reason: .rateLimited, engine: apple))
+        XCTAssertTrue(gate.record(outcome: .engineFailed, reason: .rateLimited, engine: apple),
+                      "the second refusal is the transition")
+        XCTAssertFalse(gate.allowsCall(engine: apple))
+        XCTAssertEqual(gate.unavailableEngine, apple)
+
+        XCTAssertFalse(gate.record(outcome: .engineFailed, reason: .rateLimited, engine: apple),
+                       "the transition must be reported once, not on every further refusal")
+    }
+
+    /// Consecutive means consecutive. A polish that ran between two refusals is
+    /// proof the engine is serving this process, and the count starts over.
+    func testASuccessBetweenTwoRefusalsResetsTheRun() {
+        var gate = PolishAvailabilityGate()
+        gate.record(outcome: .engineFailed, reason: .rateLimited, engine: apple)
+        gate.record(outcome: .success, reason: nil, engine: apple)
+        XCTAssertFalse(gate.record(outcome: .engineFailed, reason: .rateLimited, engine: apple))
+        XCTAssertTrue(gate.allowsCall(engine: apple), "the run was broken by the success")
+    }
+
+    /// A guardrail violation is a real generation the model ran and Apple then
+    /// rejected — the opposite of the instant refusal this gate watches for. It
+    /// breaks the run like a success does.
+    func testAnotherFailureReasonResetsTheRun() {
+        for reason in [PolishFailureReason.guardrailViolation, .unsupportedLanguageOrLocale] {
+            var gate = PolishAvailabilityGate()
+            gate.record(outcome: .engineFailed, reason: .rateLimited, engine: apple)
+            gate.record(outcome: .engineFailed, reason: reason, engine: apple)
+            XCTAssertFalse(gate.record(outcome: .engineFailed, reason: .rateLimited, engine: apple),
+                           "\(reason.slug) must have broken the run")
+            XCTAssertTrue(gate.allowsCall(engine: apple))
+        }
+        var rejected = PolishAvailabilityGate()
+        rejected.record(outcome: .engineFailed, reason: .rateLimited, engine: apple)
+        rejected.record(outcome: .rejectedGuardrail, reason: nil, engine: apple)
+        XCTAssertFalse(rejected.record(outcome: .engineFailed, reason: .rateLimited, engine: apple))
+        XCTAssertTrue(rejected.allowsCall(engine: apple))
+    }
+
+    /// Outcomes where the engine was never reached, or was cut off before it
+    /// could answer, carry no evidence either way — they must neither count nor
+    /// reset. A flash dictation in the middle of a refusal run would otherwise
+    /// hide the run.
+    func testOutcomesThatNeverReachedTheEngineLeaveTheRunAlone() {
+        let inert: [PolishMetrics.Outcome] = [
+            .cancelled, .exceededContextBudget, .skipped, .skippedShort,
+            .skippedAutoMode, .engineUnavailable
+        ]
+        for outcome in inert {
+            var gate = PolishAvailabilityGate()
+            gate.record(outcome: .engineFailed, reason: .rateLimited, engine: apple)
+            XCTAssertFalse(gate.record(outcome: outcome, reason: nil, engine: apple))
+            XCTAssertTrue(gate.record(outcome: .engineFailed, reason: .rateLimited, engine: apple),
+                          "\(outcome.rawValue) must not have reset the run")
+        }
+    }
+
+    /// The run belongs to one backend. Apple Intelligence being switched off
+    /// mid-process drops the coordinator to the passthrough engine, and refusals
+    /// from the model it left say nothing about the one it moved to.
+    func testTheGateIsScopedToTheEngineThatRefused() {
+        var gate = PolishAvailabilityGate()
+        gate.record(outcome: .engineFailed, reason: .rateLimited, engine: apple)
+        gate.record(outcome: .engineFailed, reason: .rateLimited, engine: apple)
+        XCTAssertFalse(gate.allowsCall(engine: apple))
+        XCTAssertTrue(gate.allowsCall(engine: "passthrough"))
+    }
+
+    /// Two refusals from two different backends are not a run.
+    func testRefusalsFromDifferentEnginesDoNotAccumulate() {
+        var gate = PolishAvailabilityGate()
+        XCTAssertFalse(gate.record(outcome: .engineFailed, reason: .rateLimited, engine: "other-engine"))
+        XCTAssertFalse(gate.record(outcome: .engineFailed, reason: .rateLimited, engine: apple))
+        XCTAssertTrue(gate.allowsCall(engine: apple))
+        XCTAssertTrue(gate.allowsCall(engine: "other-engine"))
+    }
+
+    /// The threshold is a documented number, not an accident of the loop above.
+    func testThresholdIsTwo() {
+        XCTAssertEqual(PolishAvailabilityGate.consecutiveRefusalsBeforeUnavailable, 2)
+    }
+
+    // MARK: - The effect on the transform
+
+    /// The point of the whole change: while unavailable the engine is not
+    /// invoked at all. The stub fails the test if it is.
+    func testTransformDoesNotCallAnUnavailableEngine() async {
+        let result = await PolishPipeline.transform(
+            preprocessed: "une dictée parfaitement ordinaire qu'il faudrait polir",
+            engine: MustNotRunEngine(),
+            target: .french,
+            mode: .natural,
+            gate: blockedGate(for: MustNotRunEngine().identifier)
+        )
+        XCTAssertEqual(result.outcome, .engineUnavailable)
+        XCTAssertEqual(result.engineMs, 0)
+        XCTAssertEqual(result.postprocessMs, 0)
+        XCTAssertNil(result.engineOutput)
+    }
+
+    /// Nothing failed, so nothing named a reason. `engineUnavailable` and
+    /// `engineFailed` have to stay separable in an export: one counts outages,
+    /// the other counts failures, and folding them would inflate the failure
+    /// rate this issue has been tracking since 2026-08-05.
+    func testUnavailableCarriesNoFailureReason() async {
+        let result = await PolishPipeline.transform(
+            preprocessed: "une dictée parfaitement ordinaire qu'il faudrait polir",
+            engine: MustNotRunEngine(),
+            target: .french,
+            mode: .natural,
+            gate: blockedGate(for: MustNotRunEngine().identifier)
+        )
+        XCTAssertNil(result.failureReason)
+    }
+
+    /// "Latency on that path should drop to roughly zero." Measured against the
+    /// same engine on the same input, with the gate as the only difference: a
+    /// 300 ms backend is waited for when polish is available and not waited for
+    /// when it is not.
+    func testUnavailablePathCostsNothingComparedToACall() async {
+        let input = "une dictée parfaitement ordinaire qu'il faudrait polir"
+        let engine = SlowEngine()
+
+        let openStart = Date()
+        let served = await PolishPipeline.transform(
+            preprocessed: input, engine: engine, target: .french, mode: .natural
+        )
+        let openMs = Date().timeIntervalSince(openStart) * 1000
+        XCTAssertEqual(served.outcome, .success)
+        XCTAssertGreaterThan(openMs, 250, "the control arm must actually have waited for the engine")
+
+        let blockedStart = Date()
+        let skipped = await PolishPipeline.transform(
+            preprocessed: input, engine: engine, target: .french, mode: .natural,
+            gate: blockedGate(for: engine.identifier)
+        )
+        let blockedMs = Date().timeIntervalSince(blockedStart) * 1000
+        XCTAssertEqual(skipped.outcome, .engineUnavailable)
+        XCTAssertLessThan(blockedMs, 50, "the skip must not wait for anything")
+    }
+
+    // MARK: - What must NOT have changed
+
+    /// The user gets the deterministic floor, exactly as on a guardrail
+    /// rejection: the pre-pass output with target typography, never the literal
+    /// raw. The pre-pass has already turned the spoken "virgule" into a comma
+    /// here, and French NBSP goes on top.
+    func testUnavailableStillReturnsTheDeterministicFloor() async {
+        let preprocessed = "Ok, petit test ?"
+        let result = await PolishPipeline.transform(
+            preprocessed: preprocessed,
+            engine: MustNotRunEngine(),
+            target: .french,
+            mode: .natural,
+            gate: blockedGate(for: MustNotRunEngine().identifier)
+        )
+        let out = PolishPipeline.resolvedOutput(
+            result, preprocessed: preprocessed, target: .french, mode: .natural
+        )
+        XCTAssertEqual(out, "Ok, petit test\u{00A0}?")
+    }
+
+    /// Auto mode keeps its own floor — the pre-pass output with no typography,
+    /// so a placeholder target cannot leak French NBSP onto another language.
+    func testUnavailableAutoModeReturnsTheAutoFloor() async {
+        let preprocessed = "ça va ?"
+        let result = await PolishPipeline.transform(
+            preprocessed: preprocessed,
+            engine: MustNotRunEngine(),
+            target: .french,
+            mode: .auto,
+            gate: blockedGate(for: MustNotRunEngine().identifier)
+        )
+        XCTAssertEqual(result.outcome, .engineUnavailable)
+        let out = PolishPipeline.resolvedOutput(
+            result, preprocessed: preprocessed, target: .french, mode: .auto
+        )
+        XCTAssertEqual(out, preprocessed)
+    }
+
+    /// A default-constructed gate is what the harness and every pre-existing
+    /// call site get, and it must change nothing.
+    func testTheDefaultGateLeavesTheTransformUntouched() async {
+        let input = "this is a perfectly normal english sentence about testing things"
+        let result = await PolishPipeline.transform(
+            preprocessed: input, engine: PassthroughPolishEngine(), target: .english, mode: .natural
+        )
+        XCTAssertEqual(result.outcome, .success)
+        XCTAssertEqual(result.engineOutput, input)
+    }
+
+    // MARK: - The record of it
+
+    /// The outcome is a wire value: it lands in the polish debug export and gets
+    /// compared across builds.
+    func testOutcomeSlugIsStable() {
+        XCTAssertEqual(PolishMetrics.Outcome.engineUnavailable.rawValue, "engineUnavailable")
+    }
+
+    func testOutcomeSurvivesTheMetricJSONRoundTrip() throws {
+        let metric = PolishMetrics(
+            engine: "apple-fm", mode: .natural, targetLanguage: .french,
+            detectedLanguage: "fr", rawCharCount: 61, polishedCharCount: 61,
+            latencyMs: 1, outcome: .engineUnavailable,
+            timings: PolishTimings(preprocessMs: 1, engineMs: 0, postprocessMs: 0)
+        )
+        let data = try JSONEncoder().encode(metric)
+        let decoded = try JSONDecoder().decode(PolishMetrics.self, from: data)
+        XCTAssertEqual(decoded.outcome, .engineUnavailable)
+        XCTAssertNil(decoded.failureReason)
+        XCTAssertEqual(decoded.timings?.engineMs, 0)
+    }
+
+    /// The seven-day ring holds events written by whatever build was installed at
+    /// the time. Adding an outcome must not have broken any of them — this
+    /// payload is shaped like one written by 1.8.0 (26).
+    func testEventsFromShippedBuildsStillDecode() throws {
+        let shipped = """
+        {"engine":"apple-fm","mode":"natural","targetLanguage":"fr","detectedLanguage":"fr",\
+        "rawCharCount":354,"polishedCharCount":354,"latencyMs":20,"outcome":"engineFailed",\
+        "failureReason":"rateLimited","sttEngine":"PK","sttModelID":"parakeet-tdt-0.6b-v3",\
+        "timings":{"preprocessMs":16,"engineMs":4,"postprocessMs":0}}
+        """
+        let decoded = try JSONDecoder().decode(PolishMetrics.self, from: XCTUnwrap(shipped.data(using: .utf8)))
+        XCTAssertEqual(decoded.outcome, .engineFailed)
+        XCTAssertEqual(decoded.failureReason, .rateLimited)
+    }
+
+    /// The persistent log line a future capture is read against. Pinned because
+    /// it is what a grep will look for.
+    func testUnavailableLogLineNamesTheEngineAndTheReason() {
+        let event = LogEvent.polishEngineUnavailable(
+            engine: "apple-fm", reason: "rateLimited", consecutiveRefusals: 2
+        )
+        XCTAssertEqual(event.name, "polishEngineUnavailable")
+        XCTAssertEqual(event.subsystem, .transcription)
+        XCTAssertEqual(event.level, .warning)
+        XCTAssertEqual(event.message, "engine=apple-fm reason=rateLimited consecutiveRefusals=2")
+    }
+
+    // MARK: - Helpers
+
+    /// A gate that has already seen the two refusals, i.e. the state the device
+    /// reaches after a `rateLimited` run.
+    private func blockedGate(for engine: String) -> PolishAvailabilityGate {
+        var gate = PolishAvailabilityGate()
+        gate.record(outcome: .engineFailed, reason: .rateLimited, engine: engine)
+        gate.record(outcome: .engineFailed, reason: .rateLimited, engine: engine)
+        XCTAssertFalse(gate.allowsCall(engine: engine))
+        return gate
+    }
+}
+
+// MARK: - Stubs
+
+/// Fails the test if the pipeline calls it. "Do not invoke the engine" is the
+/// behaviour under test, and the only way to assert it is to make the call
+/// itself an error.
+private struct MustNotRunEngine: PolishEngineProtocol {
+    let identifier = "must-not-run"
+
+    func polish(raw: String, targetLanguage: SupportedLanguage, mode: PolishMode) async throws -> String {
+        XCTFail("the engine must not be called while polish is unavailable")
+        return raw
+    }
+}
+
+/// Slow enough that waiting for it is measurable — the control arm of the
+/// latency assertion.
+private struct SlowEngine: PolishEngineProtocol {
+    let identifier = "slow-engine"
+
+    func polish(raw: String, targetLanguage: SupportedLanguage, mode: PolishMode) async throws -> String {
+        try await Task.sleep(nanoseconds: 300_000_000)
+        return raw
+    }
+}

--- a/DictusKeyboard/KeyboardRootView.swift
+++ b/DictusKeyboard/KeyboardRootView.swift
@@ -124,6 +124,7 @@ struct KeyboardRootView: View {
             statusMessage: state.statusMessage,
             messageProbeRootViewID: instanceID,
             messageProbeControllerID: controllerID,
+            showsPolishUnavailable: state.polishUnavailable,
             suggestions: [],
             suggestionMode: .idle,
             onSuggestionTap: { _ in },
@@ -255,6 +256,7 @@ struct KeyboardRootView: View {
                     statusMessage: state.statusMessage,
                     messageProbeRootViewID: instanceID,
                     messageProbeControllerID: controllerID,
+                    showsPolishUnavailable: state.polishUnavailable,
                     suggestions: suggestionState.suggestions,
                     suggestionMode: suggestionState.mode,
                     onSuggestionTap: { index in

--- a/DictusKeyboard/KeyboardState.swift
+++ b/DictusKeyboard/KeyboardState.swift
@@ -209,6 +209,22 @@ class KeyboardState: ObservableObject {
     /// on a `dictationMessageCleared` line means nobody could have read it.
     private var statusMessageDisplayCount = 0
 
+    /// Whether DictusApp has stopped calling the polish engine for the rest of its
+    /// process (#315).
+    ///
+    /// WHY it is not a `statusMessage`: that path carries a three-second timer
+    /// (the one behind #342), and this condition can last the whole app process —
+    /// twelve minutes of unbroken refusals were measured on device. A state that
+    /// outlives its own announcement is not a message. So this is a second display
+    /// path: no timer, no dismissal, just a value read from the App Group and
+    /// rendered whenever the toolbar has room. #313 owns making that layer
+    /// coherent; nothing here waits on it.
+    ///
+    /// Read on every refresh rather than observed: the flag only ever changes
+    /// during a dictation, and `refreshFromDefaults()` runs on the `statusChanged`
+    /// that dictation posts, and again whenever a controller appears.
+    @Published private(set) var polishUnavailable = false
+
     @Published var waveformEnergy: [Float] = []
     @Published var recordingElapsed: Double = 0
 
@@ -580,6 +596,12 @@ class KeyboardState: ObservableObject {
     /// Starts/stops the watchdog timer based on the new status.
     func refreshFromDefaults() {
         logProbe("refreshFromDefaults", details: "storedStatus=\(defaults.string(forKey: SharedKeys.dictationStatus) ?? "nil") visible=\(isKeyboardVisible) \(sessionDetails())")
+
+        // Read BEFORE the reconcile guard below (#315): that guard returns early
+        // on an abandoned dictation, and the polish state has nothing to do with
+        // whether this one was abandoned. A state that can last the whole app
+        // process must not be skipped by an unrelated exit.
+        polishUnavailable = PolishAvailabilityChannel.isUnavailable
 
         // Before adopting what the App Group says, check that somebody is still
         // writing it (#261). This is the read a rebuilt extension performs from its

--- a/DictusKeyboard/Localizable.xcstrings
+++ b/DictusKeyboard/Localizable.xcstrings
@@ -133,6 +133,17 @@
         }
       }
     },
+    "Polish is temporarily unavailable." : {
+      "comment" : "Toolbar state shown when polish has stopped calling its engine for the rest of the app process (issue #315).",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le polissage est temporairement indisponible."
+          }
+        }
+      }
+    },
     "Processing..." : {
       "comment" : "Recording overlay caption while the LLM stage runs on the transcript (issue #267).",
       "localizations" : {

--- a/DictusKeyboard/Views/ToolbarView.swift
+++ b/DictusKeyboard/Views/ToolbarView.swift
@@ -34,6 +34,14 @@ struct ToolbarView: View {
     /// site that does not care is unaffected; both current call sites supply them.
     var messageProbeRootViewID: String = "unknown"
     var messageProbeControllerID: String = "unknown"
+
+    /// Whether polish has stopped calling its engine for the rest of DictusApp's
+    /// process (#315). Declared next to `statusMessage` because it is the bar's
+    /// other way of saying something went wrong, and the opposite kind of thing:
+    /// a state, not a message. It carries no timer, is not dismissed, and goes
+    /// away only when a fresh app process clears it.
+    var showsPolishUnavailable: Bool = false
+
     var suggestions: [String] = []
     var suggestionMode: SuggestionMode = .idle
     var onSuggestionTap: ((Int) -> Void)?
@@ -104,6 +112,14 @@ struct ToolbarView: View {
     /// has typed nothing, so whatever the bar is showing was predicted from text
     /// that was just dictated — worth little, and worth less than a control that
     /// expires in seconds and is the only alternative to holding backspace.
+    ///
+    /// WHY the polish-unavailable notice sits LAST, beside the hamburger rather
+    /// than instead of anything (#315): it is the only occupant of this bar that
+    /// can last the whole app process. Above the suggestions it would suppress
+    /// completions and corrections for that entire time, which is the keyboard's
+    /// core job; in place of the hamburger it would make the panel unreachable
+    /// for the same duration. Sharing the slot costs visibility while the user is
+    /// mid-word, and that is the cheapest of the three prices.
     private var dictationBar: some View {
         HStack {
             if let message = statusMessage {
@@ -137,7 +153,11 @@ struct ToolbarView: View {
             } else if suggestions.isEmpty {
                 hamburgerButton
 
-                Spacer()
+                if showsPolishUnavailable {
+                    polishUnavailableNotice
+                } else {
+                    Spacer()
+                }
             } else {
                 SuggestionBarView(
                     suggestions: suggestions,
@@ -246,6 +266,31 @@ struct ToolbarView: View {
         }
         .buttonStyle(GlassPressStyle())
         .accessibilityLabel(Text("Undo dictation insertion"))
+    }
+
+    /// Polish is not running, and will not run again until DictusApp restarts (#315).
+    ///
+    /// WHY secondary and not the red of `statusMessage`: nothing failed for the
+    /// user. The dictation still arrives, as the deterministic floor it already
+    /// takes when a guardrail rejects the model's output — what is missing is the
+    /// polish on top. Red is this bar's colour for a dictation that did not
+    /// happen, and reusing it here would say something untrue.
+    ///
+    /// The copy names the state and stops. No cause, no remedy, no "try again
+    /// later": Apple's background rate limit is only refunded by a fresh app
+    /// process, so there is no action to offer, and an offer that does not work
+    /// is worse than none.
+    private var polishUnavailableNotice: some View {
+        Text("Polish is temporarily unavailable.")
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            // The sentence is fixed and must not truncate; on the narrowest
+            // supported width it gives up a little size instead. Single line
+            // either way, so the bar keeps its 52 pt (#166 and family).
+            .minimumScaleFactor(0.75)
+            .padding(.leading, 6)
+            .frame(maxWidth: .infinity)
     }
 
     private var closeButton: some View {


### PR DESCRIPTION
Closes decision 14 of #315. Written as `refs #315` in the commits: the issue stays open until the maintainer closes it by hand.

## What this was for

Polish silently stops working. Apple's `rateLimited` is a per-call refusal applied to apps running in the background, and DictusApp is backgrounded for every polish call by design — the keyboard holds the screen. Once the refusals start, nothing brings polish back short of a fresh app process: the 2026-08-13 experiment showed twenty seconds of foreground did not refund the budget, and no amount of wall-clock ever has in any capture on the issue. The measured result is up to twelve minutes at a stretch where every dictation loses its punctuation and repair, the app keeps calling a dead engine, and the user is told nothing.

This PR does decision 14 and nothing else: **stop calling a refusing engine, and say so.** No recovery action, no button, no retry, no backoff — decision 7 killed the mechanism they would have relied on.

## To test by hand

Everything below needs a physical iPhone with Apple Intelligence and polish enabled. The keyboard extension cannot be enabled in any simulator (`docs/agents/simulator.md` §7), so the visible state is manual by construction.

1. Settings → polish **on**. Force-quit DictusApp, relaunch it once, then leave it. This is the fresh process the reset depends on. **Expect:** polish works normally, no notice in the keyboard toolbar.
2. Dictate normally from the keyboard, one dictation every one to two minutes, for about twenty-five minutes. That is the density that reproduced the refusals twice on 2026-08-13. Long dictations arm it faster than short ones.
3. Watch for the moment two dictations in a row come back unpolished. **Expect:** from the third dictation on, the text appears **noticeably faster** than a polished one — the engine is no longer being called at all, so the wait drops from seconds to nothing.
4. Look at the keyboard toolbar with the cursor idle (no word half-typed, no undo chip showing). **Expect:** to the right of the hamburger, in grey, `Le polissage est temporairement indisponible.` Nothing else — no cause, no remedy, no button.
5. Type a word. **Expect:** the suggestion bar takes the slot back and the notice steps aside. Stop typing and let the bar go idle. **Expect:** the notice returns. It has no timer; it is a state.
6. Tap the hamburger. **Expect:** the panel still opens — the notice shares the slot with it rather than replacing it.
7. Keep dictating for several more minutes. **Expect:** the notice never expires and never comes back on its own. This is the difference from a `statusMessage`, which would have vanished after three seconds.
8. Watch the recording overlay during one of these dictations. **Expect:** it goes straight from `Transcription...` to done. It must **not** flash `Traitement...` — no engine runs, so no processing stage is announced.
9. Force-quit DictusApp and relaunch it. Dictate again. **Expect:** polish works, and the notice is gone. This is the only reset there is.
10. Export the polish debug JSON from the hidden debug screen. **Expect:** `"outcomes"` contains `"engineUnavailable": N`, one per dictation skipped in step 3 onward, and those events carry no `failureReason` (nothing failed — we declined to ask). The two `rateLimited` that armed it are still there as `engineFailed`.
11. Export the persistent log. **Expect:** exactly one line `polishEngineUnavailable engine=apple-fm reason=rateLimited consecutiveRefusals=2`, at the transition, and none after it.

## What changed

**Detect** — `PolishAvailabilityGate` (DictusCore). Two consecutive `rateLimited` results from one engine flip it. Two, not three: every `rateLimited` run captured on the issue arrives in a run of at least two, and a single isolated one has never been observed. A run is broken by any verdict proving the engine served the call — a success, a guardrail rejection, a failure naming another reason. Outcomes where the engine was never reached or was cut short (cancelled, context overflow, the skips) neither count nor reset, so a flash dictation in the middle of a run cannot hide it. The gate is scoped to the engine that refused, so Apple Intelligence being switched off mid-process does not carry the block onto the passthrough backend.

The rule lives in DictusCore because DictusApp has no test bundle. The **state** lives on `PolishCoordinator`, which already owns every other per-process polish concern.

**Stop calling** — `PolishPipeline.transform` takes the gate and exits before the newline encode and before the context guard, returning the new `engineUnavailable` outcome. `resolvedOutput` already hands back the deterministic floor for every non-success, so what the user receives is unchanged. `announceEngineStage` reads the same gate value, so no `.processing` stage is raised for a call that is not happening.

**Reset** — a fresh process, and nothing else. There is no timer, no foreground observer and no retry anywhere in the new code; the gate is a plain value on the coordinator, and a new process gets a new one. The App Group flag the keyboard reads is cleared in `PolishCoordinator.init()` — the same object that owns the gate, so what is on disk and what is in memory cannot describe different states.

**Say so** — a second display path beside `statusMessage`, not a change to it. That path carries a three-second timer (the one behind #342) and this condition can last the whole app process. The notice sits beside the hamburger, in the toolbar's centre slot, shown only when that slot is otherwise idle. Above the suggestions it would suppress completions and corrections for the whole process, which is the keyboard's core job; in place of the hamburger it would make the panel unreachable for the same duration. Sharing the slot costs visibility while the user is mid-word, and that is the cheapest of the three prices. Secondary grey rather than the red of `statusMessage`: nothing failed for the user, the dictation still arrives. Single line inside the existing 52 pt bar — no height constraint touched (#166 and family).

**Record it** — a new `engineUnavailable` outcome, deliberately distinct from `engineFailed`: nothing failed, we declined to ask, and folding the two would inflate the failure rate this issue has been tracking since 2026-08-05. Plus one `polishEngineUnavailable` log line on the transition. No new metric *field*, so events persisted by shipped builds decode unchanged.

**Engine defect 1** — `polish()` ended with `defer { Task { await cache.drop(key) } }`. The drop now happens on both explicit exits *and* names the session it is removing (`SessionCache.dropIfStillCurrent`). Awaiting alone was not enough: the window is the unconditional key-based removal, which spans the whole 4-5 s `respond()` suspension, so a `prewarm()` for the next recording can install a warmed replacement under the same key while the first call is still suspended. Identity comparison is what closes it. `prewarm()` keeps its unconditional drop, since it is deliberately displacing whatever is there. **No automated coverage:** `SessionCache` is file-private and a real `LanguageModelSession` needs the FoundationModels SDK, so testing the identity behaviour would mean widening its visibility for the test alone.

**Engine defect 2** — `prewarm()` measured, see below. Not removed.

## Acceptance criteria

| Criterion | Status | Evidence |
| --- | --- | --- |
| Two consecutive `rateLimited` from `apple-fm` → unavailable | ✅ | `testTwoConsecutiveRefusalsStopTheEngine`, `testOneRefusalDoesNotStopTheEngine`, `testThresholdIsTwo` |
| Consecutive means consecutive | ✅ | `testASuccessBetweenTwoRefusalsResetsTheRun`, `testAnotherFailureReasonResetsTheRun`, `testOutcomesThatNeverReachedTheEngineLeaveTheRunAlone` |
| While unavailable the engine is not invoked | ✅ | `testTransformDoesNotCallAnUnavailableEngine` — the stub calls `XCTFail` if reached |
| Latency drops to roughly zero | ✅ | `testUnavailablePathCostsNothingComparedToACall`: same 300 ms engine, same input; available arm > 250 ms, unavailable arm < 50 ms |
| Deterministic floor unchanged | ✅ | `testUnavailableStillReturnsTheDeterministicFloor` (FR NBSP applied), `testUnavailableAutoModeReturnsTheAutoFloor` |
| Reset on a fresh process only, no timer / re-arm / retry | ✅ | `testFreshGateAllowsTheCall`; `grep -rnE "Timer\|asyncAfter\|Task.sleep\|didBecomeActive\|willEnterForeground"` over both new files → no match |
| Visible as a persistent state, exact copy, FR + EN | ⚠️ manual | `Localizable.xcstrings` entry added; the rendering is manual steps 4-7 above |
| Visible in the polish debug export | ⚠️ partly | `engineUnavailable` seeded in the `outcomes` block and in the debug screen's outcome list; the export itself is manual step 10 |
| Visible in the persistent log | ✅ | `testUnavailableLogLineNamesTheEngineAndTheReason` pins name, subsystem, level and the whole line |
| Persisted events from shipped builds still decode | ✅ | `testEventsFromShippedBuildsStillDecode`, `testOutcomeSurvivesTheMetricJSONRoundTrip` |
| `cd DictusCore && swift test` green | ✅ | `Executed 992 tests, with 0 failures (0 unexpected)` |
| `swiftlint lint --strict` clean | ✅ | `Done linting! Found 0 violations, 0 serious in 186 files.` |
| Three targets build | ✅ | `DictusApp` and `DictusKeyboard` schemes, `** BUILD SUCCEEDED **`; DictusCore via `swift build` and as the app's local package |

## The `prewarm()` measurement

The brief expected this to be unmeasurable headlessly. It is not: the iOS Simulator reports `SystemLanguageModel.default.availability == available` and real generations run.

Six alternated rounds, same French input (~200 chars), 1.5 s gap before each call — the prewarmed arm does exactly what the app does (prewarm at recording start, polish ~1.5 s later), the cold arm calls `polish()` with no prewarm:

```
round 0: warmed=2013 ms  cold=2071 ms
round 1: warmed=2003 ms  cold=2041 ms
round 2: warmed=1958 ms  cold=2031 ms
round 3: warmed=2020 ms  cold=2085 ms
round 4: warmed=1995 ms  cold=2021 ms
round 5: warmed=2084 ms  cold=2021 ms

warmed median = 2013 ms   range [1958, 2084]
cold   median = 2041 ms   range [2021, 2085]
```

**`prewarm()` buys about 28 ms on a 2 s call — 1.4%, inside the spread of the two arms.**

Read this with its limits. It ran in the Simulator, which proxies Apple Intelligence from the host Mac rather than using the phone's ANE, and the test process is in the **foreground** — which is precisely the condition Apple's caveat excludes (*"particularly if your app is running in the background"*). So this is prewarm's **best case**, and even there it is worth 1.4%. It cannot prove prewarm does nothing on a backgrounded phone, but it is hard to argue it does more there than here.

The removal decision is the maintainer's; nothing was removed. If it is worth a field confirmation, the phone version is two builds — `develop`, and `develop` with the `session.prewarm()` line commented out — ten dictations of similar length each, comparing median `engineMs` from the debug export.

## Not comfortable with / worth knowing

- **A stale notice window.** The gate is in memory and resets with the process, as specified. The App Group flag that the keyboard *displays* is cleared by the next DictusApp launch. So if iOS kills the backgrounded app while polish is unavailable, the flag stays true until the app next launches — which is the next dictation. During that gap the keyboard shows a notice for a budget that has already been refunded. It self-heals on the next dictation and I chose not to add machinery for it, because every fix I could see (a timer, a foreground observer, a process token) is either the re-arm the brief forbids or belongs to #313.
- **The toolbar slot is contested.** The notice loses to suggestions and to the undo chip, which means it is hidden in the seconds right after a dictation — the moment it is most relevant. Deliberate, and the reasoning is in the code and above, but it is the judgement call in this PR most worth disagreeing with.
- **Nothing contradicted the issue.** The brief matched the code as found.
- **Two review fixes landed after the maintainer's device validation** (`ac0451c`, `ac87740`), both listed above. Neither touches the gate, the skip path, the notice, the log line or the export, so nothing validated on `b375cea` changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safeguards that temporarily disable polish after repeated engine rate-limit refusals.
  - Added a visible “Polish is temporarily unavailable.” notice in the dictation toolbar.
  - Added shared availability status between the app and keyboard.
  - Added unavailable-engine outcomes to polish diagnostics and logs.

- **Bug Fixes**
  - Improved cleanup after successful or failed polish requests.
  - Prevented unnecessary polish calls when the engine is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
