### PR TITLE
Drop the polish session by identity, and read the gate when the task starts (refs #315)

### DIFF
--- a/DictusApp/Polish/PolishCoordinator.swift
+++ b/DictusApp/Polish/PolishCoordinator.swift
@@ -341,10 +341,15 @@ public final class PolishCoordinator {
         // delegated to `PolishPipeline` so the eval harness runs identical code.
         let preprocessMs = Int(Date().timeIntervalSince(methodStart) * 1000)
 
-        let gate = availabilityGate
         let task = Task {
+            // Read inside the task, not snapshotted above (#315): a polish call
+            // that overlaps this one can flip the gate between the two, and a
+            // snapshot taken at creation time would send one more request to an
+            // engine already known to be refusing. Whether two polish calls
+            // should overlap at all is #361's question, not this one.
             await PolishPipeline.transform(
-                preprocessed: preprocessed, engine: currentEngine, target: target, mode: mode, gate: gate
+                preprocessed: preprocessed, engine: currentEngine, target: target,
+                mode: mode, gate: self.availabilityGate
             )
         }
         inflight = task
@@ -458,11 +463,12 @@ public final class PolishCoordinator {
         announceEngineStage(currentEngine, to: onEngineWillRun)
         // Pre-engine work in auto mode: detection + detected-language pre-pass.
         let preprocessMs = Int(Date().timeIntervalSince(methodStart) * 1000)
-        let gate = availabilityGate
         let task = Task {
+            // Read inside the task rather than snapshotted — same reason as the
+            // per-language path above (#315).
             await PolishPipeline.transform(
                 preprocessed: preprocessed, engine: currentEngine, target: contextLanguage,
-                mode: .auto, gate: gate
+                mode: .auto, gate: self.availabilityGate
             )
         }
         inflight = task

--- a/DictusCore/Sources/DictusCore/Polish/AppleFoundationModelsPolishEngine.swift
+++ b/DictusCore/Sources/DictusCore/Polish/AppleFoundationModelsPolishEngine.swift
@@ -82,21 +82,24 @@ public final class AppleFoundationModelsPolishEngine: PolishEngineProtocol, Send
 
         Polished output:
         """
-        // The drop is awaited on both exits rather than deferred into an
-        // unstructured `Task` (#315). A detached task is ordered against
-        // nothing, and the captures on that issue show two dictations chaining
-        // inside a single second: `polish` A takes session S1, the next
-        // recording's `prewarm()` drops S1 and installs a warmed S2, then A's
-        // deferred task fires and drops S2. The next call gets a cache miss and
-        // builds a cold session, so the prewarm is wasted on every chained
-        // dictation. Awaiting here means the drop cannot outlive the call that
-        // owns it.
+        // The drop names the session it is dropping (#315). `respond()` suspends
+        // for four to five seconds, and the captures on that issue show two
+        // dictations chaining inside a single second — so the next recording's
+        // `prewarm()` can install a warmed replacement under this same key while
+        // this call is still suspended. Dropping by key alone on resume would
+        // evict that replacement and waste the prewarm on every chained
+        // dictation. See `SessionCache.dropIfStillCurrent`.
+        //
+        // It is also awaited on both exits rather than deferred into an
+        // unstructured `Task`, so the drop cannot outlive the call that owns it.
+        // That part is ordering; the identity check above is what closes the
+        // window, and neither substitutes for the other.
         do {
             let response = try await session.respond(to: prompt)
-            await cache.drop(key)
+            await cache.dropIfStillCurrent(key, session: session)
             return response.content.trimmingCharacters(in: .whitespacesAndNewlines)
         } catch {
-            await cache.drop(key)
+            await cache.dropIfStillCurrent(key, session: session)
             throw error
         }
     }
@@ -252,14 +255,36 @@ private actor SessionCache {
         return session
     }
 
-    /// Remove the session for `key` (if any). Used to enforce the one-session-
-    /// per-call lifecycle: `polish()` drops after `respond()`, `prewarm()` drops
-    /// before recreating. Freeing a session releases only its small instruction
-    /// KV-cache — the model weights stay resident in memory, shared across
-    /// sessions, so re-creating a session when the model is already warm is cheap.
+    /// Remove the session for `key` (if any), whatever it is. Used by
+    /// `prewarm()`, which is deliberately installing a replacement and so has no
+    /// reason to care what it displaces. Freeing a session releases only its
+    /// small instruction KV-cache — the model weights stay resident in memory,
+    /// shared across sessions, so re-creating a session when the model is
+    /// already warm is cheap.
     func drop(_ key: SessionKey) {
         sessions.removeValue(forKey: key)
         lru.removeAll { $0 == key }
+    }
+
+    /// Remove the session for `key` only while it is still `session`.
+    ///
+    /// WHY this exists (#315): `polish()` suspends inside `respond()` for four
+    /// to five seconds, and the captures on that issue show two dictations
+    /// chaining inside a single second. So the next recording's `prewarm()` can
+    /// drop S1 and install a warmed S2 under the same key *while the first call
+    /// is still suspended*. An unconditional drop on resume then evicts S2, the
+    /// next call takes a cache miss and builds a cold session, and the prewarm
+    /// is wasted on every chained dictation.
+    ///
+    /// Ordering the drop does not help: the window is the removal itself, not
+    /// when it is scheduled. Only checking what is being removed does.
+    ///
+    /// Identity, not equality: `LanguageModelSession` is a class, and two
+    /// sessions built from the same instructions are equally valid and still
+    /// distinct objects — which is exactly the case that has to be told apart.
+    func dropIfStillCurrent(_ key: SessionKey, session: LanguageModelSession) {
+        guard sessions[key] === session else { return }
+        drop(key)
     }
 
     private func touch(_ key: SessionKey) {


### PR DESCRIPTION
Follow-up to #373, which merged before these two review fixes landed on the branch. Both come from the CodeRabbit review on that PR. `refs #315`.

## What this was for

#373 shipped decision 14 of #315: stop calling a polish engine that is refusing us, and say so. It was device-validated on `b375cea` and reproduced end to end ([evidence](https://github.com/getdictus/dictus-ios/pull/373#issuecomment-5384901305)). The review then found that one of the two engine defects that PR claimed to fix was not actually fixed.

## The session-drop race was still open

#373 replaced `defer { Task { await cache.drop(key) } }` with an awaited `cache.drop(key)`. That orders the drop against the detached task, but the race described in the issue brief survives it unchanged:

1. `polish` A takes session S1 and suspends in `await session.respond(to:)` for four to five seconds.
2. The next recording starts, and `prewarm()` drops S1 and installs a warmed S2 under the same key.
3. A resumes and removes whatever is under the key, which is now S2.

The window was never the `defer`. It is the unconditional key-based removal, and it spans the whole of `respond()` — far longer than the detached-task window ever was.

`SessionCache.dropIfStillCurrent(_:session:)` removes the entry only while it is identical to the session this call captured. `LanguageModelSession` is a class, so identity is the right test: two sessions built from the same instructions are equally valid and still distinct objects. `prewarm()` keeps its unconditional drop, since it is deliberately displacing whatever is there.

The comment at the call site was rewritten too. As merged it explained the wrong mechanism.

**No automated coverage.** `SessionCache` is file-private and constructing a real `LanguageModelSession` needs the FoundationModels SDK, so reaching the identity behaviour from a test would mean widening its visibility for the test's sake alone. Stated rather than papered over.

## The availability gate was read too early

Both `PolishCoordinator` call sites took `let gate = availabilityGate` before creating the `Task`, so a task starting after another call's `recordAvailability` flipped the gate would still run against a stale snapshot. The gate is now read inside the closure.

Impact is one extra request to an engine already known to be refusing, roughly 9 ms, and it needs two overlapping polish calls to occur at all. Fixed because it is a one-line move. Whether two polish calls should overlap at all is #361's question and is decided there.

## Not changed

The review also flagged the toolbar notice as a hardcoded English literal. It is not: `Text("literal")` in SwiftUI takes a `LocalizedStringKey`, the literal is the key, `DictusKeyboard/Localizable.xcstrings` carries the French translation, and the device screenshot on #373 shows it rendering in French. Left alone deliberately.

## To test by hand

**Nothing.** Neither change can alter what was validated on device for #373.

- The session fix only changes *which* cached session is evicted after a call. The engine, the prompt, the output and every polish outcome are untouched, so the gate, the skip path, the notice, the log line and the debug export all behave exactly as they did on `b375cea`. Its only observable effect is that a chained dictation now keeps its warmed session instead of rebuilding a cold one, and prewarm was measured at 1.4% of a 2 s call, inside the noise.
- The gate fix removes at most one 9 ms request in a scenario that needs two overlapping polish calls, which the #373 validation run never produced.

If you want a confirmation anyway, the cheapest one is the #373 manual list re-run in full, but there is no criterion in it that these commits could move.

## Verification

- `cd DictusCore && swift test` — `Executed 992 tests, with 0 failures (0 unexpected)`. CI does not run the tests.
- `swiftlint lint --strict` — `Found 0 violations, 0 serious in 186 files.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved polish processing when multiple requests overlap, ensuring the latest availability state is used.
  * Prevented active replacement sessions from being removed during cleanup of an earlier polish request.
  * Ensured session cleanup occurs consistently after both successful and failed polish operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->