### PR TITLE
Raise the extension probe burst to twenty calls (refs #361)

### DIFF
--- a/DictusKeyboard/AppleFMExtensionProbe.swift
+++ b/DictusKeyboard/AppleFMExtensionProbe.swift
@@ -62,10 +62,18 @@ enum AppleFMExtensionProbe {
     /// specific to the density — and would need the slower, once-a-minute
     /// protocol before concluding.
     ///
-    /// Ten is enough to land inside the refusal regime measured on the app (the
+    /// Ten was enough to land inside the refusal regime measured on the app (the
     /// 2026-08-13 capture refused 55 of 133 calls) while keeping the run under
     /// about a minute, which is as long as a human will hold a keyboard open.
-    private static let burstSize = 10
+    ///
+    /// Raised to twenty for #361, which needs the stronger reading. Ten
+    /// successes are consistent with an extension that escapes the limit *and*
+    /// with a process that simply had budget left, and the app latches after
+    /// roughly twelve calls — so a burst that clears twelve without degrading is
+    /// what separates the two. The run now takes about ninety seconds at the
+    /// four-to-five second latency measured on 2026-08-23, which is still a
+    /// keyboard a human will hold open.
+    private static let burstSize = 20
 
     /// Fixed synthetic input, never the user's text.
     ///


### PR DESCRIPTION
One line, plus the reasoning in the comment above it.

## Why

The 2026-08-23 device run answered #361's memory question and left its escape question open.

```
10:07:00  started   availability=available  memBeforeMB=39  burst=10
10:07:45  finished  memBeforeMB=39  memPeakMB=48  memAfterMB=42   (10/10 success)
```

Peak 48 MB against the 70 MB stop threshold registered on #361, from a **warm** keyboard at 39 MB rather than #357's cold 15 MB. That is the risk that could have killed the work, and it passed with margin.

But the escape reading is ambiguous. Ten successes are consistent with an extension that is not subject to the background rate limit, and equally with a process that simply had budget left. That run was the second case: iOS killed the backgrounded app at 10:06:20, it relaunched with a fresh budget at 10:06:30, and the probe fired at 10:07:00 against an app that was succeeding again.

The app latches after roughly twelve calls. A burst that clears twelve without degrading separates the two readings. Ten cannot.

## To test by hand

This is the instrument for the next measurement, so testing it *is* running that measurement. Protocol on #361.

Sanity check only: the probe must still be inert when disarmed and one-shot when armed, both unchanged by this commit.

## Verification

- `swiftlint lint --strict` clean.
- No test: the probe is debug-only, throwaway, and deleted by #361's definition of done.