### PR TITLE
docs(agents): the Dictus keyboard renders in a simulator — rewrite the keyboard recipe (refs #381)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Pierre travaille sur cette machine : toute fenêtre qui s'ouvre lui vole le focu
 - La suite de tests n'a besoin d'aucun simulateur (`cd DictusCore && swift test`). Seuls les builds d'app en demandent un.
 - Ne jamais mettre une fenêtre Simulator au premier plan : `open -a Simulator` est interdit. `open -g -a Simulator` ne l'est pas, et il est requis pour piloter l'UI (`axe` ne peut taper que si Simulator.app est attaché au device booté). Mesuré : `-g` ne change pas l'app au premier plan.
 - Un agent ne peut pas valider sur device physique : ce qui l'exige part dans la liste de validation manuelle, avec les étapes exactes.
-- Le simulateur se pilote au tap, au clavier et par l'arbre d'accessibilité avec `axe`. Le clavier Dictus **peut** y être activé (via Réglages, au tap) ; ce qui reste non résolu, c'est son rendu à l'écran. La recette complète est dans `docs/agents/simulator.md`, qui fait autorité sur ce que le simulateur sait faire.
+- Le simulateur se pilote au tap, au clavier et par l'arbre d'accessibilité avec `axe`. Le clavier Dictus **s'y affiche**, y prend le Full Access et y déclenche toute la chaîne clavier → app. On l'atteint en **appuyant longuement** sur le globe puis en le choisissant dans le menu : un tap simple fait défiler les claviers et saute les claviers tiers. La recette complète est dans `docs/agents/simulator.md`, qui fait autorité sur ce que le simulateur sait faire.
 
 ## Contexte utilisateur
 

--- a/docs/agents/simulator.md
+++ b/docs/agents/simulator.md
@@ -243,6 +243,28 @@ axe tap -x 201 -y 815 --udid <udid>    # Models tab
 
 Verified end to end on 2026-08-22: installing DictusApp, tapping through the onboarding pages by label, and reaching the Models and Settings tabs by coordinate. The frontmost application stayed the terminal throughout.
 
+**A long press needs one HID session, which means `batch`.** A held press is what opens iOS's own menus — the globe key's keyboard picker above all — and `axe` holds the press only inside a single batch:
+
+```bash
+axe batch --udid <udid> \
+  --step "touch -x 42 -y 840 --down" \
+  --step "sleep 1.8" \
+  --step "touch -x 42 -y 840 --up"
+```
+
+Those coordinates are this device's globe key. Read the real one from `describe-ui` rather than trusting them: the globe is labelled `Clavier suivant`, and its `AXFrame` gives the centre to press.
+
+A menu opened that way **stays open after the release**, so there is no race — read it, then tap the row by label:
+
+```bash
+axe describe-ui --udid <udid>
+axe tap --label "Dictus, français" --udid <udid>
+```
+
+**Never tap the globe to change keyboard.** A tap cycles through the enabled keyboards and skips the third-party ones, so it never lands on Dictus. That single mistake is what produced the wrong conclusion this file carried until 2026-08-23 (section 8).
+
+**A control missing from the accessibility tree needs `--tap-style physical`.** With the default `automatic` style, `axe` falls back to a simulator tap and such a control does not react. Measured 2026-08-23 on the Full Access switch, which `describe-ui` does not report at all (section 8); expect the same wherever a control you can see in a screenshot has no element in the tree.
+
 Xcode 27 replaces this attachment dance with Device Hub and drops the Simulator.app requirement, per AXe's own compatibility notes. Until this machine moves to it, `open -g -a Simulator` is the price of a tap.
 
 ## 6. Control the frame
@@ -286,6 +308,12 @@ xcrun simctl boot <udid>
 ```
 
 Two traps here, both observed while writing this file. `defaults write` from the host against a plist inside a device's data directory silently does not stick — the host `cfprefsd` owns the write and it never reaches the file. `plutil -replace` fails on a key the file does not have yet. Editing the plist with `plistlib` while the device is shut down is what works.
+
+**`plutil -extract` rewrites the file it reads.** Reading one key out of a plist looks like a read and is not: `plutil -extract <keypath> json <file>` writes the extracted value back over `<file>` unless `-o -` sends it to stdout instead. Observed 2026-08-23, on a built `Info.plist` it destroyed; the keys that then appeared to be missing looked like a build bug and were not. Whatever you are inspecting, pass `-o -`:
+
+```bash
+plutil -extract <keypath> json -o - <file>
+```
 
 Put the device back the way you found it. This one is `fr_FR` with `AppleLanguages = (fr-FR, en-GB)`.
 

--- a/docs/agents/simulator.md
+++ b/docs/agents/simulator.md
@@ -339,9 +339,11 @@ xcrun simctl shutdown <udid>
 
 **Tapping and typing are no longer on this list.** They were, until 2026-08-22, on the grounds that `simctl` has no touch injection. That is still true of `simctl` and was never true of the machine: see section 5. Do not re-derive the old limit from the `simctl` man page.
 
-**The Dictus keyboard CAN be enabled in a simulator.** This file said the opposite until 2026-08-23. It was wrong. Enabling it takes taps, and section 5 taps: Settings → Général → Clavier → Claviers → Ajouter un clavier → Dictus. Read each screen with `describe-ui` and tap the row centre from the reported `AXFrame` — these rows carry labels but no identifiers, so coordinates are what work.
+**The Dictus keyboard renders in a simulator, takes Full Access, and drives the whole dictation chain.** This file said the rendering was unresolved until 2026-08-23. It was wrong, and the reason was in how the keyboard was being reached: the globe key was being *tapped*, and a tap cycles past the third-party keyboards. Long-press it and pick Dictus from the menu — section 5 has the sequence, `axe batch` included.
 
-The extension does register on install, which was never the question:
+Measured end to end on 2026-08-23. The keyboard draws its own AZERTY layout, with the `espace` bar, the hamburger panel button and the mic button.
+
+**Registering.** The extension registers on install, which was never the question:
 
 ```bash
 xcrun simctl spawn <udid> pluginkit -m -v -p com.apple.keyboard-service
@@ -351,28 +353,39 @@ xcrun simctl spawn <udid> pluginkit -m -v -p com.apple.keyboard-service
      com.pivi.dictus.keyboard(1.8.0)	657D5A4D-…	/Users/…/DictusApp.app/PlugIns/DictusKeyboard.appex
 ```
 
-After the taps, the device's own keyboard list carries it:
+`pkd` logs `Created plugin` for `com.pivi.dictus.keyboard(1.8.0)`, and SpringBoard lists it under `com.apple.keyboard-service`.
+
+**Enabling, without tapping through Settings.** The device's keyboard list is `AppleKeyboards` in its `.GlobalPreferences.plist`, and a third-party keyboard is a bare bundle identifier there, not the `locale@sw=` shape the built-ins use. Write it with `plistlib` while the device is shut down — section 6's technique:
+
+```python
+d['AppleKeyboards'] = [
+    'fr_FR@sw=AZERTY-French;hw=Automatic',
+    'en_US@sw=QWERTY;hw=Automatic',
+    'emoji@sw=Emoji',
+    'com.pivi.dictus.keyboard',
+]
+```
+
+Then boot, attach Simulator.app (section 5), install, and open any text field. Tapping through Settings → Général → Clavier → Claviers → Ajouter un clavier → Dictus reaches the same state and also works. `defaults write` from the host does not land, and neither does the `com.apple.Preferences` domain — `AppleKeyboards` does not live there; the version of this file before #378 made both mistakes at once and concluded from them that the keyboard could not be enabled at all.
+
+**Full Access.** Granted by tap, in Réglages → Général → Clavier → Claviers → Dictus. The switch is not in the accessibility tree, so `axe`'s default `automatic` style falls back to a simulator tap and the toggle does not move; `--tap-style physical` moves it:
 
 ```bash
-xcrun simctl spawn <udid> defaults read -g AppleKeyboards
+axe tap -x 337 -y 161 --tap-style physical --udid <udid>   # the Full Access switch
+axe tap --label "Autoriser" --udid <udid>                  # the confirmation alert
 ```
 
+The log then carries `fullAccess=true`.
+
+**What the extension then gives you.** It runs, and it writes: `<KBD> diagnosticProbe` lines carrying `inputBounds`, `keyboardFrame`, `hostingConst`, `heightConst`, `memMB`, `status`, `mode` and `coldStart`. Tapping the mic fires the whole keyboard → app dictation chain, which on a device with no model installed ends where it should:
+
 ```
-(
-    "fr_FR@sw=AZERTY-French;hw=Automatic",
-    "en_US@sw=QWERTY;hw=Automatic",
-    "emoji@sw=Emoji",
-    "com.pivi.dictus.keyboard"
-)
+dictationFailed error=No model downloaded
+statusChanged from=idle to=failed
+dictationMessageCleared reason=appError-timeout
 ```
 
-Note the format: a third-party keyboard is a bare bundle identifier, not the `locale@sw=` shape the built-ins use. That is the entry to write if you want to skip the tapping. `AppleKeyboards` lives in the device's `.GlobalPreferences.plist`, and editing it with `plistlib` while the device is shut down lands — section 6's technique. Writing it from the host with `defaults write` does not, and neither does the `com.apple.Preferences` domain; the previous version of this file made both mistakes at once and concluded from them that the keyboard could not be enabled.
-
-iOS loads the extension too. `pkd` logs `Created plugin` for `com.pivi.dictus.keyboard(1.8.0)`, and SpringBoard lists it under `com.apple.keyboard-service`.
-
-**What is not proven is the keyboard rendering.** With it enabled, tapping the globe key cycled French → English → French and never reached Dictus, and `dictus_debug.log` gained no `<KBD>` line, so the extension's own code never ran. Undiagnosed: it may want Full Access, it may need selecting from the globe long-press picker rather than the cycle, or it may be failing to launch. Start there, with the log open.
-
-Enabling is solved. Rendering is the open question. Neither is impossible.
+That is most of the keyboard surface this repo debugs, reachable without a device.
 
 **The software keyboard appears, and `Connect Hardware Keyboard` did not stop it.** A widely repeated claim says a connected hardware keyboard suppresses the on-screen one and that this is why keyboard testing fails in simulators. Measured here with `ConnectHardwareKeyboard = 1`: tapping Safari's address bar brought up the full AZERTY keyboard, globe key included. The setting is real and headless-controllable —
 
@@ -382,7 +395,7 @@ defaults write com.apple.iphonesimulator ConnectHardwareKeyboard -bool false
 
 — but on Xcode 26.4.1 / iOS 26.5 it is not what stands between an agent and a software keyboard. Check section 5's attachment first.
 
-**Even a rendering keyboard would not give you the numbers.** Memory and timing are device figures. Dead zones, the declared height constraint and the keyboard-to-app handoff still need a physical iPhone.
+**The keyboard renders and still does not give you the numbers.** Memory and timing are device figures. `memMB=50` was observed for the extension in this run; simulator memory is not device memory and no verdict belongs in that number. Dead zones, the declared height constraint and the keyboard-to-app handoff still need a physical iPhone.
 
 **Custom-scheme URLs prompt.** `simctl openurl` raises a confirmation the user must accept — though section 5 can now accept it:
 
@@ -392,14 +405,14 @@ xcrun simctl openurl <udid> "dictus://dictate?source=keyboard"
 
 exits 0 and raises an `Ouvrir dans « Dictus » ?` confirmation alert, which needs a tap. It behaves the same whether Dictus is frontmost or the device is on the Home screen.
 
-**Microphone and dictation were not exercised, and the reason is structural.** The audio session does configure:
+**The dictation chain runs; the capture at the end of it does not.** Tapping the keyboard's mic reaches DictusApp and comes back with the `No model downloaded` failure quoted in the keyboard entry above. Past that point nothing was exercised, and the reason is structural. The audio session does configure:
 
 ```
 […] INFO    [audio] <APP> audioSessionConfigured category=playAndRecord
 […] WARNING [audio] <APP> engineWarmUpFailed context=didBecomeActive error=modelReady=false
 ```
 
-No transcription model is installed, and installing one means the Models tab — a tap — plus a download. Recording never starts, so nothing was proven about capture. `xcrun simctl privacy <udid> grant microphone com.pivi.dictus` exits 0, but it was never put to use.
+No transcription model is installed, and installing one means the Models tab — a tap — plus a download. Recording never starts, so nothing is proven about capture. `xcrun simctl privacy <udid> grant microphone com.pivi.dictus` exits 0, but it was never put to use.
 
 Two things to know before trying: the simulator captures the **Mac's** input device, so a recording started here records the room Pierre is sitting in; and transcription runs on Mac silicon, so any timing measured in a simulator says nothing about the phone.
 


### PR DESCRIPTION
> **Do not merge until the TestFlight cut on `develop` is done.** This branch never touched `develop` and does not need to be merged in a hurry.

## What this was for

`docs/agents/simulator.md` told an agent that the Dictus keyboard could be *enabled* in a simulator but did not *render*, and filed that as an open question. It renders. The wrong conclusion came from tapping the globe key, which cycles between keyboards and skips the third-party ones — the keyboard is reached by long-pressing the globe and picking it from the menu.

The practical consequence is what this PR is for: an agent debugging the keyboard no longer has to wait for Pierre's phone to see the keyboard draw, take Full Access, emit its probe lines, or carry a mic tap through the whole keyboard → app dictation chain. The doc now carries the recipe instead of the question.

Every command and output written here comes from the measurement recorded in #381 (2026-08-23, Xcode 26.4.1 / iOS 26.5 / iPhone 17). Nothing was added from memory.

## To test by hand

Documentation only, so the test is whether the recipe reproduces. On a booted simulator, from this branch:

1. Follow §2–§3 to build and install DictusApp, then §6's shut-down `plistlib` technique to append `com.pivi.dictus.keyboard` to `AppleKeyboards` in the device's `.GlobalPreferences.plist`. Boot again → `xcrun simctl spawn <udid> defaults read -g AppleKeyboards` lists the bundle id, with no tapping through Settings.
2. Follow §5 to attach Simulator.app (`open -g -a Simulator`, after `bootstatus`), open any text field, and run the `axe batch` long-press on the globe. Expect: the keyboard picker menu opens and **stays open** after the touch is released.
3. `axe describe-ui`, then `axe tap --label "Dictus, français"`. Expect: the Dictus keyboard draws its own AZERTY layout, `espace` bar, hamburger button and mic button.
4. Grant Full Access per §8, with `--tap-style physical`. Expect: the toggle actually moves (it does not with the default `automatic` style), and `dictus_debug.log` carries `fullAccess=true`.
5. Tap the mic. Expect, with no transcription model installed: `dictationFailed error=No model downloaded`, `statusChanged from=idle to=failed`, `dictationMessageCleared reason=appError-timeout`.
6. Read the prose against your own run and reject any sentence that overstates it.

Nothing here needs a physical device.

## What changed, and why

Three commits.

- **§5 "Drive the UI"** gains the two `axe` techniques the keyboard work needed and that nothing else in the file covered: a held press survives only inside one `axe batch` HID session, and the menu it opens stays open after release, so it is read with `describe-ui` and tapped by label. The globe is located by its `Clavier suivant` label rather than by a coordinate, and the rule that a tap on it cycles past third-party keyboards is stated where an agent will read it before making the same mistake. Also added: a control absent from the accessibility tree needs `--tap-style physical` (flagged as an extrapolation from the one control it was measured on).
- **§6** gains the `plutil -extract` trap on its own line: it writes the extracted value back over the file it read unless `-o -` is passed. It destroyed a built `Info.plist` during the investigation and sent the author chasing a build bug that did not exist.
- **§8** — the keyboard block is rewritten around the recipe: enabling without tapping (bare bundle id into `AppleKeyboards` via `plistlib` on a shut-down device), Full Access by physical tap, and what the extension logs once it runs (`<KBD> diagnosticProbe` with `inputBounds`, `keyboardFrame`, `hostingConst`, `heightConst`, `memMB`, `status`, `mode`, `coldStart`). `memMB=50` is recorded with the warning attached that simulator memory is not device memory. The "even a rendering keyboard would not give you the numbers" entry keeps its point — dead zones, the declared height constraint and the handoff are still device figures — and the microphone entry is reconciled with the new one: the chain runs, the capture at the end of it stays unproven because no model is installed.
- **`CLAUDE.md`** — the keyboard line no longer says the rendering is unresolved, and carries the one operational fact worth having at that altitude: long-press the globe, never tap it.

`AGENTS.md` carries no claim about the keyboard or the simulator beyond a pointer to `docs/agents/simulator.md`, so it needed no edit.

## Verification

- `cd DictusCore && swift test` → **1015 tests, 0 failures**.
- `swiftlint lint --strict` → **0 violations, 0 serious in 187 files**.
- Both are regression guards only. This change touches no Swift, so **an app build is not a meaningful gate and was not run** — and no simulator was booted for it.
- Acceptance checked by re-reading the final text line by line against #381: every command, coordinate, log line and figure in the diff is traceable to a measurement recorded in that issue, to what the file already carried, or is a placeholder (`<udid>`, `<keypath>`).

## Anything uncomfortable

- The coordinates (`-x 42 -y 840` for the globe, `-x 337 -y 161` for the Full Access switch) are one device's geometry on one iOS version. The text says so and tells the reader to read the real frame from `describe-ui`, but a reader who copy-pastes on another device will get a miss.
- "A control missing from the accessibility tree needs `--tap-style physical`" is a generalization from a single control. It is written as an expectation, not a measurement.
- Whether Full Access is *required* for the mic tap to reach the app was not isolated — it was granted before that step. The doc does not claim either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated simulator guidance for selecting and testing the Dictus keyboard, including long-press controls and Full Access setup.
  * Documented keyboard-to-app dictation testing and clarified simulator limitations around transcription and audio capture.
  * Added troubleshooting notes for keyboard registration, configuration commands, and observed “No model downloaded” failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->