### PR TITLE
docs(agents): a simulator can fake the device identifier, never the RAM

### DIFF
--- a/docs/agents/simulator.md
+++ b/docs/agents/simulator.md
@@ -47,6 +47,52 @@ xcrun simctl bootstatus <udid>
 
 On an already-booted device it prints `Device already booted, nothing to do.`
 
+### The device type decides the identifier, and the Mac decides the RAM
+
+Two things a simulator reports about "the device" behave in opposite ways, and getting them the wrong way round has cost this project two issues.
+
+**The model identifier is yours to choose.** A device type and a runtime are different things: `iPhone 11` is a stock *device type* that pairs with whatever runtime is installed, so an A13 device exists here even though no iOS 13 runtime does.
+
+```bash
+xcrun simctl create "Dictus A13 iPhone 11" \
+  com.apple.CoreSimulator.SimDeviceType.iPhone-11 \
+  com.apple.CoreSimulator.SimRuntime.iOS-26-5
+```
+
+The device type has to exist, and this one does:
+
+```bash
+xcrun simctl list devicetypes | grep -i "iPhone-11"
+```
+
+```
+iPhone 11 Pro (com.apple.CoreSimulator.SimDeviceType.iPhone-11-Pro)
+iPhone 11 Pro Max (com.apple.CoreSimulator.SimDeviceType.iPhone-11-Pro-Max)
+iPhone 11 (com.apple.CoreSimulator.SimDeviceType.iPhone-11)
+```
+
+Once created and booted, the device names itself:
+
+```bash
+xcrun simctl getenv <udid> SIMULATOR_MODEL_IDENTIFIER
+```
+
+```
+iPhone12,1
+```
+
+The runtime sets that variable itself, which is why **overriding it does not work**: `SIMCTL_CHILD_SIMULATOR_MODEL_IDENTIFIER=iPhone12,1` loses to the value the runtime writes. Issue #362 concluded from that loss that the device tier was unreachable. It was reachable, one command away, by creating the device instead of arguing with it. Delete it when you are done — see section 7.
+
+**The RAM is the Mac's and cannot be moved.** `DeviceCapabilities.readPhysicalMemoryGB()` reads `ProcessInfo.processInfo.physicalMemory`, which inside a simulator returns the host's memory. On this machine every simulator claims 24 GB, whatever it says it is:
+
+```
+[…] INFO [lifecycle] <APP> deviceCapabilitySnapshot model=iPhone12,1 ramGB=24 availableMB=0 thermal=nominal
+```
+
+That snapshot is a simulated iPhone 11 — 4 GB in the real world — reporting 24.
+
+**So split any device-tier question in two before you answer it.** Anything keyed on the identifier (`isA12OrA13iPhone`, the incompatibility branches, per-model gating) renders here and an agent can settle it. Anything keyed on memory — the `>= 6 GB` Turbo gate, the `insufficientMemory` reason — never fires, and no amount of driving the UI will make it. Section 8 has the rest of that list.
+
 ## 2. Build for that simulator
 
 A fresh worktree resolves its packages from zero, so all three steps are needed the first time:
@@ -394,6 +440,8 @@ defaults write com.apple.iphonesimulator ConnectHardwareKeyboard -bool false
 ```
 
 — but on Xcode 26.4.1 / iOS 26.5 it is not what stands between an agent and a software keyboard. Check section 5's attachment first.
+
+**A device tier keyed on memory is unreachable, however the device is labelled.** Section 1 has the measurement: `physicalMemory` returns the Mac's RAM, so the `>= 6 GB` Turbo gate and the `insufficientMemory` incompatibility reason never fire here. The identifier half of the same feature does render, on a device you create.
 
 **The keyboard renders and still does not give you the numbers.** Memory and timing are device figures. `memMB=50` was observed for the extension in this run; simulator memory is not device memory and no verdict belongs in that number. Dead zones, the declared height constraint and the keyboard-to-app handoff still need a physical iPhone.
 


### PR DESCRIPTION
## What this is for

Two issues reached the wrong conclusion about what a simulator can stand in for, a day apart.

#362 tried to reproduce an A12/A13 iPhone, found that `SIMCTL_CHILD_SIMULATOR_MODEL_IDENTIFIER=iPhone12,1` did not win, and concluded the device tier was unreachable here — "no iPhone 11 runtime is installed either". It was reachable the whole time, one command away, because `iPhone 11` is a **device type**, not a runtime, and it pairs with the iOS 26.5 runtime already on this machine. #369 then verified both of its remaining acceptance criteria on exactly such a device.

The opposite mistake is just as available: the RAM cannot be faked at all. `DeviceCapabilities.readPhysicalMemoryGB()` reads `ProcessInfo.processInfo.physicalMemory`, which inside a simulator is the **host Mac's** memory, so every simulator here reports 24 GB whatever device it claims to be.

Nothing in `docs/agents/simulator.md` said either thing. This adds it, so the next agent splits a device-tier question the right way instead of re-deriving it.

## What changed

- **Section 1** gains `### The device type decides the identifier, and the Mac decides the RAM`: the `simctl create` recipe, why the environment-variable override loses, the `ramGB=24` snapshot from a simulated `iPhone12,1`, and the rule that follows — identifier-keyed branches render, memory-keyed branches never fire.
- **Section 8** gains one line for the memory half, pointing back to section 1.

Documentation only. No code, no target, no test touched.

## Verified

Both commands in the new section were run on this machine before being written down, per this file's own standard:

- `xcrun simctl list devicetypes | grep -i "iPhone-11"` — output pasted verbatim, three device types including `com.apple.CoreSimulator.SimDeviceType.iPhone-11`
- `xcrun simctl list runtimes` — `iOS 26.5 (26.5 - 23F77)`, the runtime the recipe pairs with

The `SIMULATOR_MODEL_IDENTIFIER=iPhone12,1` and `ramGB=24` outputs come from the #369 verification run earlier today, on a created iPhone 11 device since deleted.

## To test by hand

Nothing. This is a Markdown file; SwiftLint and the build do not read it, and the two commands it adds were run before it was written.

refs #369, refs #362, refs #370