### PR TITLE
Say what the completions ordering does, in the comment and in the name (refs #365)

### DIFF
--- a/DictusCore/Sources/DictusCore/FrequencyDictionary.swift
+++ b/DictusCore/Sources/DictusCore/FrequencyDictionary.swift
@@ -1,5 +1,5 @@
 // DictusCore/Sources/DictusCore/FrequencyDictionary.swift
-// Loads word frequency rankings from JSON and provides rank-based lookup.
+// Loads word frequency counts from JSON and provides count-based lookup.
 import Foundation
 
 /// A dictionary that maps words to frequency counts (higher count = more common).
@@ -29,8 +29,8 @@ public struct FrequencyDictionary {
         do {
             let decoded = try JSONDecoder().decode([String: Int].self, from: data)
             // Keep only the top N most frequent words to save memory.
-            // Words not in this dictionary get rank 0 (lowest priority in sorting),
-            // which is the correct behavior for rare words.
+            // Words not in this dictionary get a count of 0 (lowest priority in
+            // sorting), which is the correct behavior for rare words.
             if decoded.count > Self.maxWords {
                 let top = decoded.sorted { $0.value > $1.value }.prefix(Self.maxWords)
                 counts = [:]
@@ -68,7 +68,11 @@ public struct FrequencyDictionary {
     /// Returns the word frequency count (higher = more common).
     /// Returns 0 if the word is not in the dictionary.
     /// Lookup is case-insensitive.
-    public func rank(of word: String) -> Int {
+    ///
+    /// WHY not `frequency(of:)`: `FrequencyProvider.frequency(of:)` answers with
+    /// the AOSP trie's log-normalized `UInt16`, a different number from a
+    /// different source. Two names for one word would invite mixing them.
+    public func frequencyCount(of word: String) -> Int {
         return counts[word.lowercased()] ?? 0
     }
 

--- a/DictusCore/Sources/DictusCore/FrequencyDictionary.swift
+++ b/DictusCore/Sources/DictusCore/FrequencyDictionary.swift
@@ -76,6 +76,19 @@ public struct FrequencyDictionary {
         return counts[word.lowercased()] ?? 0
     }
 
+    /// Returns `words` ordered most common first.
+    ///
+    /// WHY the ordering lives here and not at the call site: the direction is the
+    /// whole contract, and it used to be a bare `>` in a closure sitting under a
+    /// comment that described it backwards (#365). Spelled out once, in a name
+    /// that says which way it goes, it can be read without reading the count's
+    /// documentation — and the only test suite the repo has can reach it.
+    ///
+    /// Words the dictionary does not know count 0 and therefore land last.
+    public func sortedMostCommonFirst(_ words: [String]) -> [String] {
+        return words.sorted { frequencyCount(of: $0) > frequencyCount(of: $1) }
+    }
+
     /// Returns the top N most frequent words, sorted by count descending.
     /// Used as fallback when n-gram predictions return no results.
     ///

--- a/DictusCore/Tests/DictusCoreTests/FrequencyDictionaryTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/FrequencyDictionaryTests.swift
@@ -54,4 +54,28 @@ final class FrequencyDictionaryTests: XCTestCase {
         XCTAssertEqual(dict.frequencyCount(of: "de"), 1)
         XCTAssertTrue(dict.frequencyCount(of: "le") < dict.frequencyCount(of: "anticonstitutionnellement"))
     }
+
+    // MARK: - Ordering
+
+    func testSortedMostCommonFirstPutsTheMostCommonWordFirst() {
+        // The suggestion bar's contract, pinned (#365): typing "le" must offer
+        // "les" before "lesparre". UITextChecker hands its completions over in
+        // alphabetical order, so this ordering is the whole value we add.
+        var dict = FrequencyDictionary()
+        let json = #"{"les": 9000, "lesparre": 3}"#
+        dict.load(from: json.data(using: .utf8)!)
+        XCTAssertEqual(dict.sortedMostCommonFirst(["lesparre", "les"]), ["les", "lesparre"])
+    }
+
+    func testSortedMostCommonFirstSinksWordsTheDictionaryDoesNotKnow() {
+        // Only the top 10K words are kept in memory, so a rare completion counts
+        // 0 and must land last rather than wherever the caller passed it.
+        var dict = FrequencyDictionary()
+        let json = #"{"les": 9000, "lesparre": 3}"#
+        dict.load(from: json.data(using: .utf8)!)
+        XCTAssertEqual(
+            dict.sortedMostCommonFirst(["lesquiller", "lesparre", "les"]),
+            ["les", "lesparre", "lesquiller"]
+        )
+    }
 }

--- a/DictusCore/Tests/DictusCoreTests/FrequencyDictionaryTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/FrequencyDictionaryTests.swift
@@ -4,43 +4,43 @@ import XCTest
 
 final class FrequencyDictionaryTests: XCTestCase {
 
-    func testRankReturnsCorrectValueForKnownWord() {
+    func testFrequencyCountReturnsCorrectValueForKnownWord() {
         var dict = FrequencyDictionary()
         let json = #"{"de": 1, "la": 2, "le": 3, "bonjour": 500}"#
         dict.load(from: json.data(using: .utf8)!)
-        XCTAssertEqual(dict.rank(of: "de"), 1)
-        XCTAssertEqual(dict.rank(of: "bonjour"), 500)
+        XCTAssertEqual(dict.frequencyCount(of: "de"), 1)
+        XCTAssertEqual(dict.frequencyCount(of: "bonjour"), 500)
     }
 
-    func testRankReturnsZeroForUnknownWord() {
-        // `rank(of:)` returns the raw frequency count (higher = more common),
-        // and 0 when the word is not in the dictionary.
+    func testFrequencyCountReturnsZeroForUnknownWord() {
+        // `frequencyCount(of:)` returns the raw frequency count (higher = more
+        // common), and 0 when the word is not in the dictionary.
         var dict = FrequencyDictionary()
         let json = #"{"de": 1}"#
         dict.load(from: json.data(using: .utf8)!)
-        XCTAssertEqual(dict.rank(of: "xylophone"), 0)
+        XCTAssertEqual(dict.frequencyCount(of: "xylophone"), 0)
     }
 
-    func testRankIsCaseInsensitive() {
+    func testFrequencyCountIsCaseInsensitive() {
         var dict = FrequencyDictionary()
         let json = #"{"bonjour": 42}"#
         dict.load(from: json.data(using: .utf8)!)
-        XCTAssertEqual(dict.rank(of: "Bonjour"), 42)
-        XCTAssertEqual(dict.rank(of: "BONJOUR"), 42)
+        XCTAssertEqual(dict.frequencyCount(of: "Bonjour"), 42)
+        XCTAssertEqual(dict.frequencyCount(of: "BONJOUR"), 42)
     }
 
     func testLoadFromInvalidDataProducesEmptyDict() {
         var dict = FrequencyDictionary()
         dict.load(from: "not json".data(using: .utf8)!)
         // Empty dict → unknown words return 0.
-        XCTAssertEqual(dict.rank(of: "de"), 0)
+        XCTAssertEqual(dict.frequencyCount(of: "de"), 0)
     }
 
-    func testCommonWordsRankHigherThanUncommon() {
+    func testCommonWordsHaveHigherCountsThanUncommon() {
         var dict = FrequencyDictionary()
         let json = #"{"de": 1, "la": 2, "anticonstitutionnellement": 9999}"#
         dict.load(from: json.data(using: .utf8)!)
-        XCTAssertTrue(dict.rank(of: "de") < dict.rank(of: "anticonstitutionnellement"))
+        XCTAssertTrue(dict.frequencyCount(of: "de") < dict.frequencyCount(of: "anticonstitutionnellement"))
     }
 
     func testLoadFromFixtureFile() {
@@ -51,7 +51,7 @@ final class FrequencyDictionaryTests: XCTestCase {
         }
         var dict = FrequencyDictionary()
         dict.load(from: data)
-        XCTAssertEqual(dict.rank(of: "de"), 1)
-        XCTAssertTrue(dict.rank(of: "le") < dict.rank(of: "anticonstitutionnellement"))
+        XCTAssertEqual(dict.frequencyCount(of: "de"), 1)
+        XCTAssertTrue(dict.frequencyCount(of: "le") < dict.frequencyCount(of: "anticonstitutionnellement"))
     }
 }

--- a/DictusCore/Tests/DictusCoreTests/FrequencyDictionaryTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/FrequencyDictionaryTests.swift
@@ -7,7 +7,7 @@ final class FrequencyDictionaryTests: XCTestCase {
     func testFrequencyCountReturnsCorrectValueForKnownWord() {
         var dict = FrequencyDictionary()
         let json = #"{"de": 1, "la": 2, "le": 3, "bonjour": 500}"#
-        dict.load(from: json.data(using: .utf8)!)
+        dict.load(from: Data(json.utf8))
         XCTAssertEqual(dict.frequencyCount(of: "de"), 1)
         XCTAssertEqual(dict.frequencyCount(of: "bonjour"), 500)
     }
@@ -17,21 +17,21 @@ final class FrequencyDictionaryTests: XCTestCase {
         // common), and 0 when the word is not in the dictionary.
         var dict = FrequencyDictionary()
         let json = #"{"de": 1}"#
-        dict.load(from: json.data(using: .utf8)!)
+        dict.load(from: Data(json.utf8))
         XCTAssertEqual(dict.frequencyCount(of: "xylophone"), 0)
     }
 
     func testFrequencyCountIsCaseInsensitive() {
         var dict = FrequencyDictionary()
         let json = #"{"bonjour": 42}"#
-        dict.load(from: json.data(using: .utf8)!)
+        dict.load(from: Data(json.utf8))
         XCTAssertEqual(dict.frequencyCount(of: "Bonjour"), 42)
         XCTAssertEqual(dict.frequencyCount(of: "BONJOUR"), 42)
     }
 
     func testLoadFromInvalidDataProducesEmptyDict() {
         var dict = FrequencyDictionary()
-        dict.load(from: "not json".data(using: .utf8)!)
+        dict.load(from: Data("not json".utf8))
         // Empty dict → unknown words return 0.
         XCTAssertEqual(dict.frequencyCount(of: "de"), 0)
     }
@@ -39,7 +39,7 @@ final class FrequencyDictionaryTests: XCTestCase {
     func testCommonWordsHaveHigherCountsThanUncommon() {
         var dict = FrequencyDictionary()
         let json = #"{"de": 1, "la": 2, "anticonstitutionnellement": 9999}"#
-        dict.load(from: json.data(using: .utf8)!)
+        dict.load(from: Data(json.utf8))
         XCTAssertTrue(dict.frequencyCount(of: "de") < dict.frequencyCount(of: "anticonstitutionnellement"))
     }
 
@@ -63,7 +63,7 @@ final class FrequencyDictionaryTests: XCTestCase {
         // alphabetical order, so this ordering is the whole value we add.
         var dict = FrequencyDictionary()
         let json = #"{"les": 9000, "lesparre": 3}"#
-        dict.load(from: json.data(using: .utf8)!)
+        dict.load(from: Data(json.utf8))
         XCTAssertEqual(dict.sortedMostCommonFirst(["lesparre", "les"]), ["les", "lesparre"])
     }
 
@@ -72,7 +72,7 @@ final class FrequencyDictionaryTests: XCTestCase {
         // 0 and must land last rather than wherever the caller passed it.
         var dict = FrequencyDictionary()
         let json = #"{"les": 9000, "lesparre": 3}"#
-        dict.load(from: json.data(using: .utf8)!)
+        dict.load(from: Data(json.utf8))
         XCTAssertEqual(
             dict.sortedMostCommonFirst(["lesquiller", "lesparre", "les"]),
             ["les", "lesparre", "lesquiller"]

--- a/DictusKeyboard/TextPrediction/TextPredictionEngine.swift
+++ b/DictusKeyboard/TextPrediction/TextPredictionEngine.swift
@@ -158,7 +158,8 @@ class TextPredictionEngine {
     ///
     /// HOW IT WORKS:
     /// 1. UITextChecker.completions() returns all possible completions from the system dictionary
-    /// 2. We sort those completions by our frequency dictionary (lower rank = more common = first)
+    /// 2. We order those completions by our frequency dictionary, most common first
+    ///    (the dictionary answers with a frequency count: higher = more common)
     /// 3. LearnedWordCompletions gives one word the user taught us the first slot (#346)
     /// 4. We return only the top 3 to fill the suggestion bar's 3 slots
     ///
@@ -185,7 +186,9 @@ class TextPredictionEngine {
             language: language
         ) ?? []
 
-        let ranked = completions.sorted { frequencyDict.rank(of: $0) > frequencyDict.rank(of: $1) }
+        let ranked = completions.sorted {
+            frequencyDict.frequencyCount(of: $0) > frequencyDict.frequencyCount(of: $1)
+        }
         return LearnedWordCompletions.merge(
             typedPrefix: partialWord,
             learnedWords: UserDictionary.shared.learnedWordsByLastUsed,

--- a/DictusKeyboard/TextPrediction/TextPredictionEngine.swift
+++ b/DictusKeyboard/TextPrediction/TextPredictionEngine.swift
@@ -186,9 +186,7 @@ class TextPredictionEngine {
             language: language
         ) ?? []
 
-        let ranked = completions.sorted {
-            frequencyDict.frequencyCount(of: $0) > frequencyDict.frequencyCount(of: $1)
-        }
+        let ranked = frequencyDict.sortedMostCommonFirst(completions)
         return LearnedWordCompletions.merge(
             typedPrefix: partialWord,
             learnedWords: UserDictionary.shared.learnedWordsByLastUsed,


### PR DESCRIPTION
## What this was for

The comment above `TextPredictionEngine.suggestions(for:)` said the opposite of what
`FrequencyDictionary.rank(of:)` returns. The code was right; the comment was wrong. An automated
reviewer read the comment instead of the implementation on PR #360 and proposed flipping the
comparator — a change that would have shipped the rarest completions first, so that typing "le"
offers "lesparre" before "les". The finding was withdrawn, but the trap stayed in the file.

## To test by hand

Nothing. This is a comment, a rename and a behaviour-identical move of one comparator; there is no
user-visible change to look at, and the suggestion bar orders completions exactly as before.

What covered it instead:

1. `cd DictusCore && swift test` — 1077 tests, 0 failures (2 of them new).
2. `swiftlint lint --strict` — 0 violations in 197 files.
3. `xcodebuild build -scheme DictusApp -destination 'generic/platform=iOS Simulator'` — **BUILD
   SUCCEEDED** (app, keyboard, widgets and core).
4. The new tests were checked against the regression they exist for: flipping the comparator to `<`
   on purpose makes both fail, and putting it back makes them pass.

## What changed

**1 — The comment says what happens** (`TextPredictionEngine.swift`). "lower rank = more common =
first" becomes "most common first (the dictionary answers with a frequency count: higher = more
common)".

**2 — `rank(of:)` → `frequencyCount(of:)`.** The name was the other half of the root cause: `rank`
names a position and the function returns a count. Renaming was in scope — the whole blast radius
is one production call site and the `FrequencyDictionary` tests. Not `frequency(of:)`:
`FrequencyProvider.frequency(of:)` answers with the AOSP trie's log-normalized `UInt16`, a
different number from a different source, and one name for the two would invite mixing them.

**3 — The ordering moved into `FrequencyDictionary.sortedMostCommonFirst(_:)`.** The comparator
lived as a bare `>` inside a closure in the keyboard extension, and the keyboard has no test
target — DictusCore's suite is the only one in the repo, so nothing could catch a flip there. That
is why fixing only the comment leaves the same trap for the next reader. In `DictusCore` the
direction is in the name rather than in a comment, and two tests pin it.

No behaviour change anywhere: same lookup, same comparator, same order.

refs #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUUyDpuVjZnLoXMdB2Ynn4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added frequency-count lookup for dictionary words.
  * Added sorting that orders words from most to least common, placing unknown words last.

* **Improvements**
  * Updated text prediction to use frequency-based ordering.
  * Improved handling and documentation for words with no recorded frequency.
  * Clarified that words without recorded data have a frequency count of zero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->