### PR TITLE
Announce the download size the repository actually serves (refs #372, #374)

### DIFF
--- a/DictusApp/Models/ModelRepoDownloader.swift
+++ b/DictusApp/Models/ModelRepoDownloader.swift
@@ -165,6 +165,7 @@ final class ModelRepoDownloader {
         // sizes (verified: Encoder weight.bin = 445187200), so byte weighting is
         // accurate. Unknown sizes (-1) count as 0, same as FluidAudio.
         let totalBytes: Int64 = files.reduce(0) { $0 + Int64(max(0, $1.size)) }
+        Self.logSizeMismatchIfAny(modelName: modelName, measuredBytes: totalBytes)
         let reporter = ProgressReporter(
             totalBytes: totalBytes,
             totalFiles: files.count,
@@ -219,6 +220,30 @@ final class ModelRepoDownloader {
                 throw DownloadError.missingRequiredFile(requiredPath)
             }
         }
+    }
+
+    // MARK: - Catalogue size reconciliation (issue #372)
+
+    /// Compares the size `ModelInfo` promised on the model card against the total
+    /// the repository just told us, and logs the pair when they disagree.
+    ///
+    /// WHY here: this is the only moment in the app where both numbers exist. The
+    /// card cannot compute the real total (it would need this network round trip),
+    /// so the announced size has to stay a hand-written constant — and it will
+    /// drift again the next time a repository is repacked. One line at download
+    /// time turns that drift from silent into something a log reader catches for
+    /// free. `ModelInfo.sizeHasDrifted(fromMeasured:)` owns the threshold.
+    ///
+    /// Nothing downstream reads this: it is diagnostics only, the download proceeds
+    /// on the measured total exactly as before.
+    private static func logSizeMismatchIfAny(modelName: String, measuredBytes: Int64) {
+        guard let model = ModelInfo.forIdentifier(modelName),
+              model.sizeHasDrifted(fromMeasured: measuredBytes) else { return }
+        PersistentLog.log(.modelDownloadSizeMismatch(
+            name: modelName,
+            catalogMB: Int(model.sizeBytes / 1_000_000),
+            actualMB: Int(measuredBytes / 1_000_000)
+        ))
     }
 
     // MARK: - File listing (HuggingFace tree API)

--- a/DictusCore/Sources/DictusCore/LogEvent.swift
+++ b/DictusCore/Sources/DictusCore/LogEvent.swift
@@ -98,6 +98,10 @@ public enum LogEvent: Sendable {
     case modelLoadStateChanged(from: String, to: String, reason: String)
     case modelDownloadProgress(name: String, percent: Int, mbDownloaded: Int, mbTotal: Int)
     case modelDownloadStalled(name: String, path: String, timeoutSeconds: Int, attempt: Int)
+    /// The catalogue promised one size and the repository serves another (issue #372).
+    /// Emitted once per download, only past the tolerance, so its presence in a log
+    /// is itself the signal that a hardcoded size has drifted.
+    case modelDownloadSizeMismatch(name: String, catalogMB: Int, actualMB: Int)
 
     // MARK: Keyboard
     case keyboardDidAppear
@@ -309,7 +313,7 @@ public enum LogEvent: Sendable {
              .modelSelected, .modelCompilationStarted, .modelCompilationCompleted,
              .modelDeleted, .modelDeleteFailed, .modelPrewarmStarted, .modelCleanupPerformed,
              .modelPrewarmPeakMemory, .modelPrewarmTimeout, .modelLoadStateChanged,
-             .modelDownloadProgress, .modelDownloadStalled:
+             .modelDownloadProgress, .modelDownloadStalled, .modelDownloadSizeMismatch:
             return .model
         case .keyboardDidAppear, .keyboardDidDisappear, .keyboardMicTapped, .keyboardTextInserted,
              .overlayShown, .overlayHidden, .rapidTapRejected,
@@ -376,7 +380,8 @@ public enum LogEvent: Sendable {
              .waveformStall, .waveformTimelineNotFiring,
              .coldStartDarwinFallback, .coldStartStranded, .modelPrewarmTimeout,
              .audioInterruptionBegan, .audioMediaServicesReset,
-             .modelDownloadStalled, .audioHapticsAllowanceFailed:
+             .modelDownloadStalled, .audioHapticsAllowanceFailed,
+             .modelDownloadSizeMismatch:
             return .warning
 
         // Info (normal operations: starts, completes, selections, configs)
@@ -541,6 +546,7 @@ public enum LogEvent: Sendable {
         case .modelLoadStateChanged: return "modelLoadStateChanged"
         case .modelDownloadProgress: return "modelDownloadProgress"
         case .modelDownloadStalled: return "modelDownloadStalled"
+        case .modelDownloadSizeMismatch: return "modelDownloadSizeMismatch"
         case .polishEngineFailed: return "polishEngineFailed"
         case .polishEngineUnavailable: return "polishEngineUnavailable"
         case .polishHandoff: return "polishHandoff"
@@ -632,6 +638,8 @@ public enum LogEvent: Sendable {
             return "name=\(name) percent=\(percent) downloaded=\(mbDownloaded)MB total=\(mbTotal)MB"
         case .modelDownloadStalled(let name, let path, let timeoutSeconds, let attempt):
             return "name=\(name) path=\(path) timeout=\(timeoutSeconds)s attempt=\(attempt)"
+        case .modelDownloadSizeMismatch(let name, let catalogMB, let actualMB):
+            return "name=\(name) catalog=\(catalogMB)MB actual=\(actualMB)MB"
 
         // Keyboard (no content parameters -- privacy)
         case .keyboardDidAppear, .keyboardDidDisappear,

--- a/DictusCore/Sources/DictusCore/ModelInfo.swift
+++ b/DictusCore/Sources/DictusCore/ModelInfo.swift
@@ -26,8 +26,23 @@ public struct ModelInfo: Identifiable {
 
     public let identifier: String
     public let displayName: String
-    public let sizeLabel: String
+
+    /// Total bytes the downloader will pull for this model. See the measurement
+    /// note above `allIncludingDeprecated` for where these numbers come from.
     public let sizeBytes: Int64
+
+    /// The size shown on the model card and the onboarding download page.
+    ///
+    /// WHY computed rather than a second stored constant (issue #372):
+    /// the label and the byte count used to be two hand-written values that
+    /// nothing reconciled, so they could drift apart from each other as well as
+    /// from the repository. One number, one place to correct.
+    ///
+    /// WHY truncating division by 1 000 000: it is exactly what
+    /// `ModelManager.updateDownloadProgress` does for the `mbTotal` it logs and
+    /// for the MB counter under the progress bar, so the size promised on the
+    /// card and the total counted during the download print the same number.
+    public var sizeLabel: String { "~\(sizeBytes / 1_000_000) MB" }
 
     /// Speech-to-text engine this model uses (WhisperKit or Parakeet).
     public let engine: SpeechEngine
@@ -88,12 +103,30 @@ public struct ModelInfo: Identifiable {
 
     /// All known models including deprecated ones. Used for backward compatibility
     /// so already-downloaded Tiny/Base models still resolve and function.
+    ///
+    /// SIZES — measured 2026-08-23 against the repositories, issue #372.
+    ///
+    /// Every `sizeBytes` below is the exact sum of the files `ModelRepoDownloader`
+    /// selects for that model: the recursive contents of `<identifier>/` in
+    /// `argmaxinc/whisperkit-coreml` for WhisperKit, and the four required
+    /// `.mlmodelc` folders plus root-level `.json`/`.txt` in
+    /// `FluidInference/parakeet-tdt-0.6b-v3-coreml` for Parakeet. That is the
+    /// number the user's connection actually has to carry, and it is what the
+    /// progress bar counts down from.
+    ///
+    /// The previous values understated the download by up to 2.04x — Small
+    /// announced 250 MB and pulled 486 MB. They were the sizes of OpenAI's
+    /// PyTorch checkpoints (39/74/244/769 MB), not of the Core ML bundles Argmax
+    /// serves, so nothing about them was ever measured here.
+    ///
+    /// `ModelCatalogueSizeAuditTests` re-measures these on demand; a divergence
+    /// that appears in the field is logged by `ModelRepoDownloader` as
+    /// `modelDownloadSizeMismatch`.
     public static let allIncludingDeprecated: [ModelInfo] = [
         ModelInfo(
             identifier: "openai_whisper-tiny",
             displayName: "Tiny",
-            sizeLabel: "~40 MB",
-            sizeBytes: 40_000_000,
+            sizeBytes: 76_635_397,
             engine: .whisperKit,
             accuracyScore: 0.3,
             speedScore: 1.0,
@@ -103,8 +136,7 @@ public struct ModelInfo: Identifiable {
         ModelInfo(
             identifier: "openai_whisper-base",
             displayName: "Base",
-            sizeLabel: "~75 MB",
-            sizeBytes: 75_000_000,
+            sizeBytes: 146_719_453,
             engine: .whisperKit,
             accuracyScore: 0.4,
             speedScore: 0.9,
@@ -118,8 +150,7 @@ public struct ModelInfo: Identifiable {
         ModelInfo(
             identifier: "openai_whisper-small",
             displayName: "Small",
-            sizeLabel: "~250 MB",
-            sizeBytes: 250_000_000,
+            sizeBytes: 486_487_465,
             engine: .whisperKit,
             accuracyScore: 0.6,
             speedScore: 0.95,
@@ -129,8 +160,8 @@ public struct ModelInfo: Identifiable {
         ModelInfo(
             identifier: "openai_whisper-small_216MB",
             displayName: "Small (Quantized)",
-            sizeLabel: "~216 MB",
-            sizeBytes: 216_000_000,
+            // 217 MB measured against a name that says 216 MB — the name holds.
+            sizeBytes: 217_350_763,
             engine: .whisperKit,
             accuracyScore: 0.55,
             speedScore: 0.95,
@@ -140,8 +171,7 @@ public struct ModelInfo: Identifiable {
         ModelInfo(
             identifier: "openai_whisper-medium",
             displayName: "Medium",
-            sizeLabel: "~750 MB",
-            sizeBytes: 750_000_000,
+            sizeBytes: 1_529_654_233,
             engine: .whisperKit,
             accuracyScore: 0.8,
             speedScore: 0.55,
@@ -151,8 +181,8 @@ public struct ModelInfo: Identifiable {
         ModelInfo(
             identifier: "parakeet-tdt-0.6b-v3",
             displayName: "Parakeet v3",
-            sizeLabel: "~800 MB",
-            sizeBytes: 800_000_000,
+            // The one entry that OVERSTATED: 800 MB announced, 483 MB served.
+            sizeBytes: 483_254_686,
             engine: .parakeet,
             accuracyScore: 0.85,
             speedScore: 0.85,
@@ -175,8 +205,13 @@ public struct ModelInfo: Identifiable {
         ModelInfo(
             identifier: "openai_whisper-large-v3_turbo_954MB",
             displayName: "Turbo",
-            sizeLabel: "~954 MB",
-            sizeBytes: 954_000_000,
+            // 1052 MB measured against a name that says 954 MB, and both are right:
+            // TextDecoder + AudioEncoder + their `.mil` files come to ~954 MB, which
+            // is the model. The folder also ships TextDecoderContextPrefill.mlmodelc
+            // (98 MB), which `directoryPatterns: ["<variant>/"]` pulls even though
+            // `requiredPaths` does not require it. The name describes the model; this
+            // constant describes the download.
+            sizeBytes: 1_052_848_880,
             engine: .whisperKit,
             accuracyScore: 0.9,
             speedScore: 0.2,
@@ -184,6 +219,29 @@ public struct ModelInfo: Identifiable {
             visibility: .available
         )
     ]
+
+    // MARK: - Announced size vs. served size (issue #372)
+
+    /// How far a declared size may sit from what the repository actually serves
+    /// before it counts as drift.
+    ///
+    /// Generous on purpose: a repository gaining a metadata file is not news, a
+    /// repack that doubles the payload is. Declared here rather than at either
+    /// call site so the download-time check and the audit test cannot disagree
+    /// about what "correct" means.
+    public static let sizeTolerance = 0.05
+
+    /// Whether the announced size has drifted from what the repository serves.
+    ///
+    /// The real total is only knowable after a network round trip the model card
+    /// does not make, so `sizeBytes` has to stay a hand-written constant and will
+    /// drift again the next time a repository is repacked. This predicate is how
+    /// that drift gets noticed: `ModelRepoDownloader` calls it the moment it has
+    /// both numbers, and `ModelCatalogueSizeAuditTests` calls it on demand.
+    public func sizeHasDrifted(fromMeasured measuredBytes: Int64) -> Bool {
+        guard sizeBytes > 0, measuredBytes > 0 else { return false }
+        return abs(Double(measuredBytes - sizeBytes)) / Double(sizeBytes) > Self.sizeTolerance
+    }
 
     /// Set of all supported model identifiers for quick lookup.
     /// Uses allIncludingDeprecated so downloaded Tiny/Base models still resolve.

--- a/DictusCore/Tests/DictusCoreTests/ModelCatalogueSizeAuditTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/ModelCatalogueSizeAuditTests.swift
@@ -1,0 +1,145 @@
+// DictusCore/Tests/DictusCoreTests/ModelCatalogueSizeAuditTests.swift
+// Re-measures every catalogue size against the repository that serves it (issue #372).
+import XCTest
+@testable import DictusCore
+
+/// The audit that keeps `ModelInfo.sizeBytes` honest.
+///
+/// WHY it is opt-in rather than part of the suite:
+/// it talks to huggingface.co. `swift test` is the repo's only suite, it runs on
+/// every change, and it is offline and deterministic — a network call would make
+/// an unrelated change fail on a hotel connection or on a HuggingFace outage. So
+/// this file is skipped unless it is asked for:
+///
+///     DICTUS_MODEL_SIZE_AUDIT=1 swift test --filter ModelCatalogueSizeAuditTests
+///
+/// Run it when a catalogue size is touched, when the WhisperKit or FluidAudio
+/// dependency is bumped, or when a `modelDownloadSizeMismatch` line shows up in a
+/// user's log. In the field that log line is what catches drift; this is what says
+/// by how much and for which models.
+final class ModelCatalogueSizeAuditTests: XCTestCase {
+
+    /// Where a model's files come from, mirroring `ModelRepoDownloader.Configuration`.
+    ///
+    /// WHY the values are transcribed instead of imported: `Configuration` lives in
+    /// DictusApp and its Parakeet case reads `Repo.parakeet` / `ModelNames.ASR` from
+    /// FluidAudio, which DictusCore does not depend on. If a FluidAudio bump moves
+    /// the repository or renames a required model, this transcription is what has to
+    /// be updated — the audit would otherwise measure the wrong tree.
+    private struct RepoSource {
+        let repoPath: String
+        /// Repo-relative directory prefixes (trailing "/") walked recursively.
+        let directoryPatterns: [String]
+        /// Whether root-level `.json`/`.txt` files are downloaded too.
+        let includesRootMetadata: Bool
+
+        static func whisperKit(variant: String) -> RepoSource {
+            RepoSource(
+                repoPath: "argmaxinc/whisperkit-coreml",
+                directoryPatterns: ["\(variant)/"],
+                includesRootMetadata: false
+            )
+        }
+
+        /// Mirrors `Configuration.parakeet()`: FluidAudio's `Repo.parakeet.remotePath`
+        /// and the four folders in `ModelNames.ASR.requiredModels`.
+        static func parakeet() -> RepoSource {
+            RepoSource(
+                repoPath: "FluidInference/parakeet-tdt-0.6b-v3-coreml",
+                directoryPatterns: [
+                    "Decoder.mlmodelc/",
+                    "Encoder.mlmodelc/",
+                    "JointDecision.mlmodelc/",
+                    "Preprocessor.mlmodelc/"
+                ],
+                includesRootMetadata: true
+            )
+        }
+
+        static func forModel(_ model: ModelInfo) -> RepoSource {
+            switch model.engine {
+            case .whisperKit: return .whisperKit(variant: model.identifier)
+            case .parakeet: return .parakeet()
+            }
+        }
+    }
+
+    private struct TreeItem: Decodable {
+        let path: String
+        let type: String
+        let size: Int?
+    }
+
+    func testDeclaredSizesMatchWhatTheRepositoriesServe() async throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["DICTUS_MODEL_SIZE_AUDIT"] == "1",
+            "Network audit — set DICTUS_MODEL_SIZE_AUDIT=1 to run it"
+        )
+
+        var failures: [String] = []
+        for model in ModelInfo.allIncludingDeprecated {
+            let measured = try await measuredBytes(for: model)
+            let declaredMB = model.sizeBytes / 1_000_000
+            let measuredMB = measured / 1_000_000
+            let ratio = Double(measured) / Double(model.sizeBytes)
+            // Printed for every entry, passing or not: the point of running this is
+            // to read the numbers, not only to learn that they were acceptable.
+            print(String(format: "%@: declared %ld MB, served %ld MB (%.2fx)",
+                         model.identifier, declaredMB, measuredMB, ratio))
+            if model.sizeHasDrifted(fromMeasured: measured) {
+                failures.append("\(model.identifier): declares \(declaredMB) MB, "
+                    + "repository serves \(measuredMB) MB")
+            }
+        }
+
+        XCTAssertTrue(
+            failures.isEmpty,
+            "Catalogue sizes have drifted beyond \(Int(ModelInfo.sizeTolerance * 100))% — "
+                + "correct ModelInfo.sizeBytes:\n" + failures.joined(separator: "\n")
+        )
+    }
+
+    // MARK: - Repository walk
+
+    /// Sums the files the downloader would fetch, walking the tree the same way
+    /// `ModelRepoDownloader.listRequiredFiles()` does — directory by directory,
+    /// descending only into the required prefixes. A flat recursive listing would
+    /// disagree for Parakeet, where the root-metadata rule would otherwise sweep up
+    /// `.json` files sitting in folders the real walk never enters.
+    private func measuredBytes(for model: ModelInfo) async throws -> Int64 {
+        let source = RepoSource.forModel(model)
+        var total: Int64 = 0
+        var pendingDirectories = [""]
+
+        while let directory = pendingDirectories.first {
+            pendingDirectories.removeFirst()
+            for item in try await fetchTree(repoPath: source.repoPath, path: directory) {
+                if item.type == "directory" {
+                    let isRequired = source.directoryPatterns.contains {
+                        item.path.hasPrefix($0) || $0.hasPrefix(item.path + "/")
+                    }
+                    if isRequired { pendingDirectories.append(item.path) }
+                } else if item.type == "file", shouldInclude(item.path, source) {
+                    total += Int64(max(0, item.size ?? 0))
+                }
+            }
+        }
+        return total
+    }
+
+    private func shouldInclude(_ filePath: String, _ source: RepoSource) -> Bool {
+        if source.directoryPatterns.contains(where: { filePath.hasPrefix($0) }) { return true }
+        guard source.includesRootMetadata else { return false }
+        return filePath.hasSuffix(".json") || filePath.hasSuffix(".txt")
+    }
+
+    private func fetchTree(repoPath: String, path: String) async throws -> [TreeItem] {
+        let apiPath = path.isEmpty ? "tree/main" : "tree/main/\(path)"
+        let urlString = "https://huggingface.co/api/models/\(repoPath)/\(apiPath)"
+        let url = try XCTUnwrap(URL(string: urlString), "Cannot build \(urlString)")
+        let (data, response) = try await URLSession.shared.data(from: url)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+        XCTAssertTrue((200..<300).contains(statusCode), "HTTP \(statusCode) for \(urlString)")
+        return try JSONDecoder().decode([TreeItem].self, from: data)
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/ModelInfoTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/ModelInfoTests.swift
@@ -351,4 +351,42 @@ final class ModelInfoTests: XCTestCase {
             XCTAssertFalse(model.sizeLabel.isEmpty, "\(model.identifier) has empty sizeLabel")
         }
     }
+
+    // MARK: - Announced size (issue #372)
+
+    /// The label and the byte count can no longer disagree, because there is only
+    /// one number. This pins the rendering so the card keeps printing the same MB
+    /// figure the download progress counts down from.
+    func testSizeLabelIsDerivedFromSizeBytes() {
+        for model in ModelInfo.allIncludingDeprecated {
+            XCTAssertEqual(model.sizeLabel, "~\(model.sizeBytes / 1_000_000) MB",
+                           "\(model.identifier) label and byte count disagree")
+        }
+        XCTAssertEqual(ModelInfo.forIdentifier("openai_whisper-small")?.sizeLabel, "~486 MB")
+    }
+
+    /// A zero or negative size would render as "~0 MB" on the card and would make
+    /// the download-time reconciliation in `ModelRepoDownloader` skip the entry.
+    func testEveryCatalogueEntryDeclaresAPositiveSize() {
+        for model in ModelInfo.allIncludingDeprecated {
+            XCTAssertGreaterThan(model.sizeBytes, 0, "\(model.identifier) declares no size")
+        }
+    }
+
+    /// The predicate behind the `modelDownloadSizeMismatch` log line. The 250 MB case
+    /// is the bug this issue was filed for: that was the announced size while the
+    /// repository served 486 MB, and it has to read as drift.
+    func testSizeDriftIsJudgedAgainstTheAnnouncedSize() {
+        guard let small = ModelInfo.forIdentifier("openai_whisper-small") else {
+            XCTFail("openai_whisper-small is missing from the catalogue")
+            return
+        }
+        XCTAssertFalse(small.sizeHasDrifted(fromMeasured: small.sizeBytes))
+        XCTAssertFalse(small.sizeHasDrifted(fromMeasured: Int64(Double(small.sizeBytes) * 1.04)))
+        XCTAssertFalse(small.sizeHasDrifted(fromMeasured: Int64(Double(small.sizeBytes) * 0.96)))
+        XCTAssertTrue(small.sizeHasDrifted(fromMeasured: Int64(Double(small.sizeBytes) * 1.10)))
+        XCTAssertTrue(small.sizeHasDrifted(fromMeasured: 250_000_000))
+        // A repository that reports no sizes is a missing measurement, not drift.
+        XCTAssertFalse(small.sizeHasDrifted(fromMeasured: 0))
+    }
 }

--- a/DictusCore/Tests/DictusCoreTests/ModelInfoTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/ModelInfoTests.swift
@@ -99,10 +99,12 @@ final class ModelInfoTests: XCTestCase {
         // iPhone 12 / iPhone SE tier: 4 GB RAM — Turbo must not be runnable.
         // Issue #369: it stays LISTED, disabled with a reason, instead of vanishing.
         let iphone12 = makeCapabilities(ramGB: 4, model: "iPhone13,2")
-        let turbo = ModelInfo.forIdentifier("openai_whisper-large-v3_turbo_954MB")
-        XCTAssertNotNil(turbo)
-        XCTAssertFalse(turbo!.isSupported(on: iphone12))
-        XCTAssertEqual(turbo!.incompatibilityReason(on: iphone12), .insufficientMemory(requiredGB: 6))
+        guard let turbo = ModelInfo.forIdentifier("openai_whisper-large-v3_turbo_954MB") else {
+            XCTFail("openai_whisper-large-v3_turbo_954MB is missing from the catalogue")
+            return
+        }
+        XCTAssertFalse(turbo.isSupported(on: iphone12))
+        XCTAssertEqual(turbo.incompatibilityReason(on: iphone12), .insufficientMemory(requiredGB: 6))
         XCTAssertTrue(ModelInfo.available(on: iphone12).map(\.identifier).contains("openai_whisper-large-v3_turbo_954MB"))
     }
 
@@ -110,14 +112,20 @@ final class ModelInfoTests: XCTestCase {
         // iPhone 14 Pro / iPhone 15 tier: 6 GB — passes the quantized Turbo gate.
         // Argmax lists iPhone14/15/16/17 families as supported for `_954MB`.
         let iphone15 = makeCapabilities(ramGB: 6, model: "iPhone15,4")
-        let turbo = ModelInfo.forIdentifier("openai_whisper-large-v3_turbo_954MB")!
+        guard let turbo = ModelInfo.forIdentifier("openai_whisper-large-v3_turbo_954MB") else {
+            XCTFail("openai_whisper-large-v3_turbo_954MB is missing from the catalogue")
+            return
+        }
         XCTAssertTrue(turbo.isSupported(on: iphone15))
     }
 
     func testTurboAvailableOnEightGBDevices() {
         // iPhone 15 Pro Max / iPhone 16: 8 GB — well above the bar.
         let iphone15ProMax = makeCapabilities(ramGB: 8, model: "iPhone16,2")
-        let turbo = ModelInfo.forIdentifier("openai_whisper-large-v3_turbo_954MB")!
+        guard let turbo = ModelInfo.forIdentifier("openai_whisper-large-v3_turbo_954MB") else {
+            XCTFail("openai_whisper-large-v3_turbo_954MB is missing from the catalogue")
+            return
+        }
         XCTAssertTrue(turbo.isSupported(on: iphone15ProMax))
         XCTAssertTrue(ModelInfo.available(on: iphone15ProMax).map(\.identifier).contains("openai_whisper-large-v3_turbo_954MB"))
 
@@ -236,8 +244,14 @@ final class ModelInfoTests: XCTestCase {
     func testIncompatibilityReasonNamesTheRightConstraint() {
         let iphone11 = makeCapabilities(ramGB: 4, model: "iPhone12,1")
         let a14 = makeCapabilities(ramGB: 4, model: "iPhone13,2")
-        let small = ModelInfo.forIdentifier("openai_whisper-small")!
-        let turbo = ModelInfo.forIdentifier("openai_whisper-large-v3_turbo_954MB")!
+        guard let small = ModelInfo.forIdentifier("openai_whisper-small") else {
+            XCTFail("openai_whisper-small is missing from the catalogue")
+            return
+        }
+        guard let turbo = ModelInfo.forIdentifier("openai_whisper-large-v3_turbo_954MB") else {
+            XCTFail("openai_whisper-large-v3_turbo_954MB is missing from the catalogue")
+            return
+        }
 
         // Old chip, not memory: an iPhone 11 has the RAM, it lacks the generation.
         XCTAssertEqual(small.incompatibilityReason(on: iphone11), .hardwareGeneration)


### PR DESCRIPTION
Fixes the announced download sizes (#372) and removes the force-unwrapped catalogue lookups from the tests (#374).

## What this was for

The model card promises a download size before the user decides whether to start the download at all. It was promising 250 MB for Whisper Small and pulling 486 MB. The report came from someone on a weak connection who gave up: at 250 MB the wait is acceptable, at 486 MB it is not, and they were never given the information to make that call. The same screen is on the onboarding path, where a first-run user has no reason yet to extend the app any patience.

#374 is adjacent housekeeping in the same test file: a missing catalogue identifier crashed the whole test run instead of failing one test with a usable message.

## To test by hand

Everything below needs a device or a human eye. The build, the test suite, the lint run and the size measurements themselves are already covered — see *Verification* at the bottom.

1. Open **Settings → Models**. Read the size on each card. Expect `~486 MB` (Small), `~217 MB` (Small Quantized), `~1529 MB` (Medium), `~483 MB` (Parakeet v3), `~1052 MB` (Turbo). None of them should be the old value (250 / 216 / 750 / 800 / 954).
2. On the same screen, check the **layout** of the size row on the widest label, Medium at `~1529 MB`. It sits left of a `Spacer()` with the status indicator on the right — expect no truncation, no wrapping, no collision with the status text. This is the only visual risk in the change: labels grew by up to two characters.
3. Delete a model you already have and **start downloading Small**. Expect the size announced on the card (`~486 MB`) to match the `X MB / 486 MB` counter under the progress bar as soon as it appears. Before this change the card said 250 and the counter said 486.
4. Let that download finish. Expect no visible change to speed, stalling, or resume behaviour — the downloader itself is untouched.
5. **Onboarding path**: delete and reinstall the app, walk to the model download page. Expect the size shown there to be the same number as in step 1 for the model your device is recommended.
6. Export the debug log after step 3 and grep it. Expect `modelDownloadStarted name=openai_whisper-small size=486MB`, and expect **no** `modelDownloadSizeMismatch` line — its absence is the check passing. (To see the line fire you would need a repository to change under you; it is only emitted past a 5% divergence.)
7. On an **A12/A13 iPhone** if one is reachable (iPhone 11 / XS, the #362 tier): Base is the recommended model there and its label is the first number those users ever see. Expect `~146 MB`, not `~75 MB`.

## The measurement

Taken 2026-08-23 by walking each repository exactly the way `ModelRepoDownloader.listRequiredFiles()` selects files — directory by directory, descending only into the required prefixes, with the same `shouldRecurse` / `shouldInclude` predicates and the same `Configuration` values.

| Identifier | Declared before | Served (bytes) | Served | Ratio |
| --- | --- | --- | --- | --- |
| `openai_whisper-tiny` | 40 MB | 76 635 397 | 76 MB | 1.92x |
| `openai_whisper-base` | 75 MB | 146 719 453 | 146 MB | 1.96x |
| `openai_whisper-small` | 250 MB | 486 487 465 | 486 MB | 1.95x |
| `openai_whisper-small_216MB` | 216 MB | 217 350 763 | 217 MB | 1.01x |
| `openai_whisper-medium` | 750 MB | 1 529 654 233 | 1529 MB | 2.04x |
| `parakeet-tdt-0.6b-v3` | 800 MB | 483 254 686 | 483 MB | 0.60x |
| `openai_whisper-large-v3_turbo_954MB` | 954 MB | 1 052 848 880 | 1052 MB | 1.10x |

**The walk is faithful**: Small measures 486 487 465 bytes → 486 MB, which is exactly the `total=486MB` in the device log on the issue. That equality is what validates the method for the other six.

**Where the wrong numbers came from**: 40 / 75 / 250 / 750 are OpenAI's published PyTorch checkpoint sizes (39 / 74 / 244 / 769 MB), not the Core ML bundles Argmax serves. They were never a measurement of this repository.

**Parakeet was the one entry that overstated** — 800 MB announced, 483 MB served. Worth knowing when reading the table: six understated, one overstated.

**The quantized variants, against their own names**, as the issue asked:
- `_216MB` measures 217 MB. The name holds.
- `_954MB` measures 1052 MB, and both numbers are right. TextDecoder (590.7 MB) + AudioEncoder (353.9 MB) + their `.mil` files come to ~954 MB — that is the model. The folder *also* ships `TextDecoderContextPrefill.mlmodelc` (98.3 MB), which `directoryPatterns: ["<variant>/"]` pulls even though `requiredPaths` does not require it. The name describes the model; the constant now describes the download. Nothing was silently changed on either side.

One methodology note worth recording: a flat `?recursive=true` listing agrees with the walk for every WhisperKit variant, but **disagrees for Parakeet** (483 289 190 vs 483 254 686). The root-metadata rule matches any `.json`/`.txt`, and a flat listing hands it files sitting in folders the real walk never enters. The audit test reproduces the walk, not the shortcut.

## What changed and why

**Correcting seven constants by hand would leave them on exactly the footing that let them drift.** The announced size cannot be derived at render time — the real total is only knowable after a network round trip the model card does not make — so it has to stay a constant. Three changes make the next drift visible instead of silent:

- **`sizeLabel` is now computed from `sizeBytes`** rather than being a second hand-written string. They were two values that nothing reconciled, so they could drift from each other as well as from the repository. The format is `"~\(sizeBytes / 1_000_000) MB"` — truncating division, matching `ModelManager.updateDownloadProgress` exactly, so the size on the card and the total the progress bar counts down from print the same number.
- **`ModelInfo.sizeHasDrifted(fromMeasured:)` + `ModelInfo.sizeTolerance` (5%)** hold the policy in DictusCore, so the runtime check and the audit test cannot disagree about what "correct" means.
- **`ModelRepoDownloader` logs `modelDownloadSizeMismatch`** when the repository's total diverges from the announced size past the tolerance. This is the only moment in the app where both numbers exist. Logged once, only past tolerance, so the line's presence in a log is itself the signal.
- **`ModelCatalogueSizeAuditTests`** re-measures all seven against the live repositories.

**On the audit test's placement** — the issue flagged this as a judgement call. It is opt-in, skipped unless `DICTUS_MODEL_SIZE_AUDIT=1`:

```
DICTUS_MODEL_SIZE_AUDIT=1 swift test --filter ModelCatalogueSizeAuditTests
```

`swift test` is the repo's only suite and runs on every change; a network call in it would fail on a hotel connection or a HuggingFace outage, for reasons having nothing to do with the change under test. Gated off, it stays offline and deterministic. No build phase and no CI job was added — neither was asked for. In the field the log line is what catches drift; the audit is what says by how much and for which models.

## Acceptance criteria

**#372**

| Criterion | Status | Evidence |
| --- | --- | --- |
| All seven measured, recorded in the PR | Done | Table above |
| Every declared size within a stated tolerance | Done | Tolerance stated as 5% (`ModelInfo.sizeTolerance`); audit reports all seven at 1.00x |
| `openai_whisper-base` verified explicitly | Done | 146 719 453 B; own row above, own line in the audit output |
| `sizeLabel` and `sizeBytes` agree for every entry | Done | Structural — one is computed from the other. Plus `testSizeLabelIsDerivedFromSizeBytes` |
| Divergence visible in the log at download time | Done | New `modelDownloadSizeMismatch(name:catalogMB:actualMB:)`, warning level, `.model` subsystem |
| No behaviour change to the downloader itself | Done | The diff in `ModelRepoDownloader` is one call and one private logging function. File selection, progress, retry, stall handling, verification all untouched |

**#374**

| Criterion | Status | Evidence |
| --- | --- | --- |
| No force unwrap left in `ModelInfoTests.swift` | Done | Six sites replaced with `guard let … else { XCTFail(…); return }`; `grep ')!'` and `grep '!\.'` both empty |
| Missing identifier fails its own test, naming it | Done | Each `XCTFail` names the identifier |
| `swift test` still passes with the same test count | Done | 1075 → 1075 for the #374 commit alone (no tests added there). See below for the final count |

## Verification

- `xcodebuild build -scheme DictusApp -destination 'generic/platform=iOS Simulator'` → **BUILD SUCCEEDED** (builds the embedded keyboard, widgets and core).
- `cd DictusCore && swift test` → **1079 tests, 1 skipped, 0 failures**. The skip is the network audit. Baseline before this branch was 1075; +3 offline tests, +1 gated.
- `swiftlint lint --strict` → **0 violations in 197 files**.
- `DICTUS_MODEL_SIZE_AUDIT=1 swift test --filter ModelCatalogueSizeAuditTests` → **passed in 10.9 s**, all seven at 1.00x against the live repositories:

```
openai_whisper-tiny: declared 76 MB, served 76 MB (1.00x)
openai_whisper-base: declared 146 MB, served 146 MB (1.00x)
openai_whisper-small: declared 486 MB, served 486 MB (1.00x)
openai_whisper-small_216MB: declared 217 MB, served 217 MB (1.00x)
openai_whisper-medium: declared 1529 MB, served 1529 MB (1.00x)
parakeet-tdt-0.6b-v3: declared 483 MB, served 483 MB (1.00x)
openai_whisper-large-v3_turbo_954MB: declared 1052 MB, served 1052 MB (1.00x)
```

Not verified by any of the above, hence the manual list: how the longer labels lay out on a real screen, and that a real download's counter now agrees with the card.

## Things I am not comfortable leaving unsaid

- **The audit test transcribes Parakeet's repository path and folder names.** `Configuration.parakeet()` reads them from FluidAudio (`Repo.parakeet.remotePath`, `ModelNames.ASR.requiredModels`), and DictusCore does not depend on FluidAudio, so the test cannot import them. A FluidAudio bump that moves the repository would leave the audit measuring the wrong tree while still passing. There is a comment saying so at the transcription. The alternative — putting the audit in DictusApp, which has no test bundle — was worse.
- **The audit only runs when someone runs it.** That is the cost of keeping `swift test` offline. The `modelDownloadSizeMismatch` log line is the part that works unattended.
- **`sizeLabel` is not localized** and never was: it renders `MB` in the French UI, while the onboarding fallback string next to it is `"~500 Mo"`. This change does not make that worse — it reproduces the existing format exactly — but the inconsistency is now in one place instead of seven, if it is ever worth fixing.
- **Medium reads `~1529 MB` rather than `~1.5 GB`.** I kept pure MB deliberately: it matches the unit the progress counter uses, so the two numbers are directly comparable, and it avoids introducing a decimal separator that would need French localization. If `1.5 GB` reads better to you, that is a one-line change in `sizeLabel` plus a localization decision.
