### PR TITLE
Only the highlighted Smart Mode fan row is blue (refs #399)

### DIFF
--- a/DictusKeyboard/Views/SmartModeFanView.swift
+++ b/DictusKeyboard/Views/SmartModeFanView.swift
@@ -103,7 +103,7 @@ struct SmartModeFanView: View {
                 .font(.system(size: 17, weight: isHighlighted ? .semibold : .regular))
                 .lineLimit(1)
         }
-        .foregroundColor(isEnabled ? .dictusAccent : .secondary)
+        .foregroundColor(foreground(isHighlighted: isHighlighted, isEnabled: isEnabled))
         .padding(.horizontal, 20)
         .frame(maxWidth: .infinity)
         .frame(height: rowHeight)
@@ -123,6 +123,27 @@ struct SmartModeFanView: View {
             .dictusGlass(in: Capsule())
             .padding(.horizontal, 8)
             .padding(.vertical, 3)
+    }
+
+    /// The colour of a row's glyph and label.
+    ///
+    /// ### Why only the highlighted row is blue
+    ///
+    /// Between #79's visual pass and #399 every enabled row was accent blue. The
+    /// commit that did it was getting the Smart Mode purple out of the keyboard,
+    /// which was right; it took `.primary` with it, which was not. Three blue rows
+    /// on three pale capsules read as three chosen things, and the highlight was
+    /// left saying "this one" against two neighbours wearing its own colour.
+    ///
+    /// ### Why the resting rows are `.primary` rather than a near-black literal
+    ///
+    /// The fan stands in for the keys, so its resting rows should read as key
+    /// glyphs — and those invert: the vendored theme paints them black on a light
+    /// keyboard and white on a dark one. `.primary` is that pair, already resolved
+    /// by the environment; a literal would be right in one appearance only.
+    private func foreground(isHighlighted: Bool, isEnabled: Bool) -> Color {
+        guard isEnabled else { return .secondary }
+        return isHighlighted ? .dictusAccent : .primary
     }
 
     /// Normal is named here rather than on the entry: DictusCore ships no string


### PR DESCRIPTION
## What this was for

The long-press Smart Mode fan had gone entirely blue: every row, not just the one
under the finger. Three blue rows on three pale capsules read as three selected
things, and the highlight — a washed accent capsule plus a semibold weight — was
left saying "this one" against two neighbours wearing its own colour. Pierre, on
device, 2026-08-24: *"je trouve que ça fait un peu trop bleu."*

Only the row under the finger is blue now. The others take `.primary`, the colour
the keyboard's own key glyphs already have. The capsules are untouched — they are
what stopped the host app's text reading through the fan, and this is a text and
icon colour change only.

## To test by hand

The three visual criteria were all captured in the simulator (see the evidence
below), so what is left is a device confirmation that the colour reads right on
real hardware, plus the one state a simulator cannot produce.

1. Install this branch on the iPhone, open any text field, switch to the Dictus
   keyboard, and long-press the mic pill without letting go. **Expect:** the fan
   opens, the row your finger is on is accent blue with a washed blue capsule, and
   every other row is near-black on a pale glass capsule.
2. Still holding, drag down through the rows. **Expect:** exactly one row is blue
   at any moment and it follows the finger — the blue never accumulates.
3. Release below the last row (nothing happens, silently), then repeat step 1 with
   the phone in dark mode. **Expect:** the resting rows are now white, not black;
   the highlighted one is still blue.
4. On an iPhone with Apple Intelligence switched off (Réglages → Apple
   Intelligence), long-press the mic. **Expect:** the mode rows draw dimmed grey
   with the explanation sentence under them, exactly as before this change — the
   disabled branch is untouched, but it cannot be produced in the simulator, where
   Apple Intelligence reports available.
5. Judgement call, only a human eye settles it: compare the resting rows against
   the letter keys around them. **Expect:** they read as the same ink.

## What changed and why

One file, `DictusKeyboard/Views/SmartModeFanView.swift`. `row(_:isHighlighted:)`
resolved its foreground with `isEnabled ? .dictusAccent : .secondary` — two states
where the design has three. It now goes through a small private helper:

- highlighted → `.dictusAccent`
- resting, enabled → `.primary`
- disabled → `.secondary` (unchanged, and the existing `.opacity(0.4)` still applies)

`.primary` rather than a near-black literal because the fan stands in for the keys
and key glyphs invert: the vendored theme paints them black on a light keyboard and
white on a dark one (`DictusKeyboard/Vendored/Models/Theme.swift:385,426`).

The single-branch line arrived in `98edc07`, the commit that took the Smart Mode
purple out of the keyboard. Removing the purple was what was wanted; dropping the
`.primary` branch alongside it was collateral, and the two changes travelled in one
commit.

Nothing else moves: `rowSurface`, the capsules, the semibold weight,
`SmartModeFanLayout`, the mic pill badge, the toolbar centre slot and the discovery
hint are all untouched. `SmartModeFanView` has exactly one consumer
(`DictusKeyboard/KeyboardRootView.swift:242`) and the helper is file-private.

## Acceptance criteria

| Criterion | Status | Evidence |
| --- | --- | --- |
| Light keyboard, finger on Normal: Normal blue, Notes and → EN near-black | PASS | Simulator capture mid-drag (iPhone 17, iOS 26.5): Normal on a washed blue capsule in blue semibold, Notes and → EN black on pale glass |
| Same in a dark keyboard — `.primary` inverts | PASS | Same drag with `simctl ui … appearance dark`: Normal blue, Notes and → EN white |
| The blue follows the finger and does not accumulate | PASS | Burst of captures during one continuous drag: highlight on Normal, then on Notes with Normal back to black — one blue row at a time |
| Disabled rows unchanged (`.secondary` at 0.4) | Code only | The branch is byte-for-byte the previous behaviour; not reproducible in the simulator, which reports Apple Intelligence available (no reason strip drew in any capture). On the manual list. |
| `cd DictusCore && swift test` green | PASS | `Executed 1193 tests, with 1 test skipped and 0 failures` |
| `swiftlint lint --strict` clean | PASS | `Done linting! Found 0 violations, 0 serious in 214 files.` |
| Build | PASS | `xcodebuild … -destination 'platform=iOS Simulator,id=231991C2…'` → `** BUILD SUCCEEDED **` |

refs #399 — `Closes` does not auto-close on a merge into `develop`, so the issue
needs closing by hand.
