### PR TITLE
Open the fan on Normal when a mode is armed with nothing pinned (refs #402)

### DIFF
--- a/DictusCore/Sources/DictusCore/Polish/SmartModeFanLayout.swift
+++ b/DictusCore/Sources/DictusCore/Polish/SmartModeFanLayout.swift
@@ -74,7 +74,8 @@ public enum SmartModeFanLayout {
     /// a target except Normal.
     public static let reasonHeight: CGFloat = 24
 
-    /// The rows, in order, for a pinned list.
+    /// The rows, in order, for a pinned list and the mode currently armed — or no
+    /// rows at all, which is this type's way of saying the fan should not open.
     ///
     /// Normal first because the fan deploys downward from the mic and the thumb
     /// travels away from the palm: the nearest row is the cheapest to reach, and
@@ -83,8 +84,32 @@ public enum SmartModeFanLayout {
     ///
     /// The pinned list is capped defensively as well as at the store, because this
     /// is the side that cannot draw more.
-    public static func entries(pinned: [SmartMode]) -> [SmartModeFanEntry] {
-        [.normal] + pinned.prefix(SmartModeCatalogue.maximumPinnedModes).map(SmartModeFanEntry.mode)
+    ///
+    /// ### Why the armed mode is an input to a list it never appears in
+    ///
+    /// It decides whether a Normal-only fan is worth opening, and #402 is what
+    /// happens when that question is answered somewhere else. With nothing pinned
+    /// and nothing armed, a one-row fan is a menu with one item, no way to learn
+    /// what the others are, and nothing to undo — the user is better served by
+    /// being told where the mode list lives. With nothing pinned but a mode
+    /// **armed**, that same one row is the only surface in the product that clears
+    /// it: releasing back on the mic aborts, so the mic is not the way out. A user
+    /// who unpins everything while "→ DE" is armed otherwise dictates German
+    /// forever, which is the bug as Pierre hit it on device.
+    ///
+    /// ### Why an empty array rather than a second return type
+    ///
+    /// A fan with no rows is not a state `SmartModeFanState` is allowed to hold —
+    /// its own doc comment says so — so "no rows" already means "do not open" for
+    /// everything downstream, and `rowHeight` and `entryIndex` already answer 0 and
+    /// nil for it. Wrapping that in an enum would name the same thing twice.
+    ///
+    /// `armed` is the resolved record, not the stored identifier: an identifier this
+    /// build cannot resolve reads as nil, and refusing on it is right — that user is
+    /// already getting Normal, so there is nothing to escape from.
+    public static func entries(pinned: [SmartMode], armed: SmartMode?) -> [SmartModeFanEntry] {
+        guard !pinned.isEmpty || armed != nil else { return [] }
+        return [.normal] + pinned.prefix(SmartModeCatalogue.maximumPinnedModes).map(SmartModeFanEntry.mode)
     }
 
     /// Height of one row, given the space below the toolbar.

--- a/DictusCore/Tests/DictusCoreTests/Polish/SmartModeFanLayoutTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/Polish/SmartModeFanLayoutTests.swift
@@ -79,7 +79,7 @@ final class SmartModeFanLayoutTests: XCTestCase {
     // MARK: - Entries
 
     func testNormalIsAlwaysTheFirstEntry() {
-        let entries = SmartModeFanLayout.entries(pinned: [SmartModeCatalogue.notes])
+        let entries = SmartModeFanLayout.entries(pinned: [SmartModeCatalogue.notes], armed: nil)
         XCTAssertEqual(entries.first, .normal)
         XCTAssertNil(entries.first?.smartMode)
     }
@@ -89,15 +89,60 @@ final class SmartModeFanLayoutTests: XCTestCase {
             SmartModeCatalogue.translate(to: .german),
             SmartModeCatalogue.notes
         ]
-        let entries = SmartModeFanLayout.entries(pinned: pinned)
+        let entries = SmartModeFanLayout.entries(pinned: pinned, armed: nil)
         XCTAssertEqual(entries.map(\.id), ["normal", "translate.de", "notes"])
     }
 
     /// The store caps the list too, but this side is the one that physically cannot
     /// draw more, so it refuses independently.
     func testMoreThanThreePinnedIsTruncated() {
-        let entries = SmartModeFanLayout.entries(pinned: SmartModeCatalogue.builtIns)
+        let entries = SmartModeFanLayout.entries(pinned: SmartModeCatalogue.builtIns, armed: nil)
         XCTAssertEqual(entries.count, SmartModeFanLayout.maximumEntries)
+    }
+
+    // MARK: - Opening on an empty pinned list (#402)
+
+    /// Row 1 of #402's table. Nothing pinned and nothing armed: no rows, so the
+    /// keyboard refuses and says where the mode list lives. A one-row fan here would
+    /// be a menu with one item and nothing to undo.
+    func testNothingPinnedAndNothingArmedGivesNoRows() {
+        XCTAssertTrue(SmartModeFanLayout.entries(pinned: [], armed: nil).isEmpty)
+    }
+
+    /// Row 2, and the bug. A user who unpins every mode while one is armed keeps
+    /// dictating in it forever unless the fan opens on Normal — releasing back on the
+    /// mic aborts the gesture, so the mic is not the way out.
+    func testNothingPinnedButAModeArmedGivesTheNormalRowAlone() {
+        let entries = SmartModeFanLayout.entries(
+            pinned: [], armed: SmartModeCatalogue.translate(to: .german)
+        )
+        XCTAssertEqual(entries, [.normal])
+        XCTAssertNil(entries.first?.smartMode, "the single row must be the one that disarms")
+    }
+
+    /// Row 3: with modes pinned, the armed mode changes nothing. It is not a row of
+    /// its own, and it does not reorder the ones the user arranged.
+    func testTheArmedModeDoesNotChangeAPopulatedFan() {
+        let pinned = [SmartModeCatalogue.notes, SmartModeCatalogue.translate(to: .english)]
+        let unarmed = SmartModeFanLayout.entries(pinned: pinned, armed: nil)
+        for armed in [SmartModeCatalogue.notes, SmartModeCatalogue.translate(to: .german)] {
+            XCTAssertEqual(SmartModeFanLayout.entries(pinned: pinned, armed: armed), unarmed)
+        }
+        XCTAssertEqual(unarmed.map(\.id), ["normal", "notes", "translate.en"])
+    }
+
+    /// The one-row fan gets the whole area, which is far above the touch-target
+    /// floor — so #402 raises no layout question, and this is the assertion that says
+    /// why nobody had to design a special case for it.
+    func testTheSingleNormalRowIsComfortablyTappable() {
+        for available in [standardHeight, compactHeight] {
+            XCTAssertGreaterThan(
+                SmartModeFanLayout.rowHeight(
+                    availableHeight: available, entryCount: 1, showsReason: true
+                ),
+                SmartModeFanLayout.minimumRowHeight
+            )
+        }
     }
 
     // MARK: - Hit testing

--- a/DictusKeyboard/KeyboardSmartModeFan.swift
+++ b/DictusKeyboard/KeyboardSmartModeFan.swift
@@ -144,10 +144,16 @@ final class KeyboardSmartModeState: ObservableObject {
     /// appears and then arming a mode on release would change a setting the user
     /// never saw a menu for.
     ///
-    /// **Nothing is pinned.** A fan holding only Normal is a menu with one item and
-    /// no way to learn what the others are. The user is told where the list lives
-    /// instead. Only reachable by unpinning everything in the app — a fresh install
-    /// seeds two (`SmartModeCatalogue.defaultPinnedIdentifiers`).
+    /// **Nothing is pinned, and nothing is armed.** A fan holding only Normal is a
+    /// menu with one item, no way to learn what the others are, and nothing to
+    /// undo. The user is told where the list lives instead. Only reachable by
+    /// unpinning everything in the app — a fresh install seeds two
+    /// (`SmartModeCatalogue.defaultPinnedIdentifiers`).
+    ///
+    /// Both halves of that condition matter, and #402 is the bill for checking only
+    /// the first: with a mode armed, the Normal row is the one surface that clears
+    /// it, so the fan opens on it alone. `SmartModeFanLayout.entries` owns the rule
+    /// and states it at length; an empty result is the refusal.
     @discardableResult
     func open() -> Bool {
         let keyboard = KeyboardState.shared
@@ -155,8 +161,14 @@ final class KeyboardSmartModeState: ObservableObject {
             keyboard.logProbe("smartModeFanRefused", details: "reason=dictation-in-flight")
             return false
         }
-        let pinned = SmartModeCatalogue.pinnedModes
-        guard !pinned.isEmpty else {
+        // The store rather than the published `armedMode` beside it: that copy is a
+        // cache for view bodies and can be one `refreshFromDefaults` behind the app,
+        // and the app unpinning everything is exactly the moment it would be. One
+        // read per long-press is not the cost that cache exists to avoid.
+        let entries = SmartModeFanLayout.entries(
+            pinned: SmartModeCatalogue.pinnedModes, armed: SmartModeStore.armedMode
+        )
+        guard !entries.isEmpty else {
             keyboard.logProbe("smartModeFanRefused", details: "reason=nothing-pinned")
             keyboard.presentStatusMessage(
                 String(
@@ -174,7 +186,7 @@ final class KeyboardSmartModeState: ObservableObject {
         // thread inside a gesture.
         let armability = SmartModeAvailability.current
         fan = SmartModeFanState(
-            entries: SmartModeFanLayout.entries(pinned: pinned),
+            entries: entries,
             highlightedIndex: nil,
             unavailableReason: armability.reason.map(Self.localizedReason)
         )


### PR DESCRIPTION
refs #402 — the issue does **not** auto-close on a merge into `develop`, so close it by hand.

## What this was for

Unpin every Smart Mode while one is armed and the keyboard strands you in it. Pierre hit
this on device on 2026-08-24: he armed → DE, unpinned everything from the new mode list,
and every dictation from then on came out in German with no way back. Roughly 180 refused
long-presses in twenty seconds, because the one surface that clears an armed mode — the
fan's **Normal** row — was behind a guard that only looked at the pinned list.

The fan now opens on that single Normal row whenever a mode is armed, however empty the
pinned list is. The message stays for the case it honestly describes: nothing pinned
**and** nothing armed.

## To test by hand

The three states below were all reached on the iPhone 17 simulator (evidence in the
acceptance table), so this list is what a **device** still has to settle — the haptics, the
thumb geometry and the dictation that follows the release, none of which a simulator shows.

1. In Dictus, pin at least one mode. On the keyboard, long-press the mic and drag onto a
   mode row. → The fan opens with Normal on top; the row highlights under your thumb with a
   selection haptic; releasing arms it and starts recording. Nothing here should feel
   different from before this PR.
2. Open Dictus → the Smart Modes list → unpin every mode. Go back to the keyboard.
   → The pill still carries the armed mode's badge (this is correct).
3. Long-press the mic. → The fan opens with **one** row, Normal, filling the whole keyboard
   area. Judge the look: a single ~268 pt capsule is a much taller pill than the three-row
   fan draws, and no one has seen it on a real screen yet. If it reads wrong, that is a
   design call to raise, not a bug in this change.
4. Slide down onto that row and release. → The badge disappears from the pill, a recording
   starts, and the dictation that follows is a plain one — not translated.
5. Long-press the mic again, still with nothing pinned. → No fan; the red line
   *"Choisis tes modes dans Dictus."* for three seconds; the keys stay usable.
6. Repeat step 4 with Apple Intelligence turned **off** on the device. → The one-row fan
   should still open with the unavailability sentence under it, and Normal should still be
   selectable. This is the path `SmartModeStore.resolveArmedMode` describes and it is the
   one I could not reach in a simulator at all.

## What changed

`SmartModeFanLayout.entries` now takes the armed mode as well as the pinned list, and
answers with **no rows** when there is nothing pinned and nothing armed. Everything
downstream already treats "no rows" as "no fan" — `SmartModeFanState` forbids the state,
`rowHeight` returns 0, `entryIndex` returns nil — so an empty result is the refusal and no
second return type was needed.

`KeyboardSmartModeFan.open()` calls it and guards on the result instead of on
`pinned.isEmpty`. It reads `SmartModeStore.armedMode` fresh rather than the published copy
beside it: that copy is a cache for view bodies and can be one `refreshFromDefaults` behind
the app, and the app unpinning everything is precisely when it would be.

**The decision moved into DictusCore** because the keyboard target has no test bundle, and
because `SmartModeFanLayout` already owned the rows *and* the doc comment explaining why
Normal is one of them. Splitting "which rows exist" from "is there a fan at all" across two
targets is what produced this bug; they are one decision now, in the target that can test
it. `SmartModeFanView.swift` is untouched — no conflict with #400.

## Acceptance criteria

| # | Criterion | Status | Evidence |
| --- | --- | --- | --- |
| 1 | Armed + nothing pinned → one-row fan; release disarms | ✅ | Simulator, `translate.de` armed and `dictus.smartModePinned = []`: `smartModeFanOpened entries=1 reason=-`, then `smartModeArmed mode=normal` on release. `dictus.smartModeArmed` gone from the App Group plist afterwards, and the DE badge gone from the pill in the next capture. |
| 2 | Nothing pinned + nothing armed → the message, unchanged | ✅ | Same device, both keys cleared: `smartModeFanRefused reason=nothing-pinned` + `dictationMessageSet reason=smartModeFan-empty` + `dictationMessageDisplayed`, and *"Choisis tes modes dans Dictus."* on screen. The keys stayed; no fan. |
| 3 | Modes pinned → unchanged | ✅ | Seeded pinned list: `smartModeFanOpened entries=3 reason=-`, fan drawn as Normal / Notes / → EN in that order, release armed `notes`. |
| 4 | A test in `DictusCoreTests` covering the three rows | ✅ | `testNothingPinnedAndNothingArmedGivesNoRows`, `testNothingPinnedButAModeArmedGivesTheNormalRowAlone`, `testTheArmedModeDoesNotChangeAPopulatedFan`, plus `testTheSingleNormalRowIsComfortablyTappable` for the geometry the issue says raises no question. |

Verification commands:

- `cd DictusCore && swift test` — **1197 tests, 0 failures**, 1 skipped.
- `swiftlint lint --strict` — **0 violations, 0 serious in 214 files**.
- `xcodebuild -project Dictus.xcodeproj -scheme DictusApp -destination 'id=231991C2-…' -derivedDataPath build/DerivedData build` — **BUILD SUCCEEDED**.

## Left undone, deliberately

**The refusal message is still red.** The issue asks to consider it and says to fix it here
only if it is free. It is not: `presentStatusMessage(_:reason:timeoutReason:)` carries no
severity and `ToolbarView` hard-codes `.foregroundColor(.red)`, so giving this one message a
quieter treatment means adding a severity to the message layer — which is exactly the
contract #313 exists to define, across `KeyboardState` and `ToolbarView`. Doing it here
would settle #313's central question in a bug fix.

One note for whoever picks that up: after this change the message only ever appears when
nothing is pinned and nothing is armed, so it is now purely informational — nothing has
failed and nothing is stuck. That strengthens the case for taking it out of the error
channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUUyDpuVjZnLoXMdB2Ynn4
