### PR TITLE
Keep the downloaded model when a prewarm times out (refs #405)

### DIFF
--- a/DictusApp/Models/ModelManager.swift
+++ b/DictusApp/Models/ModelManager.swift
@@ -212,9 +212,11 @@ class ModelManager: ObservableObject {
 
         // Tracks which phase a failure (if any) belongs to. Download-phase failures
         // keep files on disk (every file is complete thanks to atomic per-file
-        // moves) so a retry resumes where it left off; prewarm-phase failures still
-        // clean up, because ANE compilation failures (E5 bundle errors) can leave
+        // moves) so a retry resumes where it left off; a prewarm failure keeps them
+        // too when it is the deadline guard firing (issue #405) and only cleans up
+        // otherwise, because ANE compilation failures (E5 bundle errors) can leave
         // behind unusable cached files that prevent retry from working.
+        // `ModelCleanupPolicy` owns the rule; this flag is one of its two inputs.
         var downloadPhaseCompleted = false
 
         do {
@@ -328,18 +330,27 @@ class ModelManager: ObservableObject {
             downloadByteInfo.removeValue(forKey: identifier)
             lastLoggedDeciles.removeValue(forKey: identifier)
 
-            if downloadPhaseCompleted {
-                // Prewarm failure: clean up. ANE compilation failures (E5 bundle
-                // errors) leave behind unusable cached files that prevent
-                // re-download from working correctly.
+            // Three failure kinds, one of which deletes anything — see
+            // ModelCleanupPolicy for the rule and its reasons:
+            //   • download failure → keep (issue #210, same policy as the Parakeet
+            //     path): every file on disk is complete, a retry resumes;
+            //   • prewarm timeout → keep (issue #405): the payload is intact and only
+            //     the Core ML compile ran out of clock, so a retry must resume at the
+            //     compile step instead of repaying a 1 GB download;
+            //   • any other prewarm failure → clean up: an E5 bundle error (issue
+            //     #104) leaves a corrupt Core ML cache that fails identically forever.
+            // Since issue #235, tapping the card's "Retry" affordance retries in
+            // place; the full reset stays in the overflow menu's "Delete partial
+            // download" entry (cleanupFailedModel). When nothing is deleted here the
+            // debug log shows .modelPrewarmTimeout with no .modelCleanupPerformed
+            // line after it — that pair is what says the bytes were kept.
+            let isPrewarmTimeout = (error as? ModelManagerError)?.isPrewarmTimeout ?? false
+            if ModelCleanupPolicy.shouldCleanUpFiles(
+                downloadPhaseCompleted: downloadPhaseCompleted,
+                isPrewarmTimeout: isPrewarmTimeout
+            ) {
                 cleanupModelFiles(identifier)
             }
-            // Download failure: deliberately NO cleanup (issue #210, same policy as
-            // the Parakeet path) — the downloader moves each file into place
-            // atomically, so anything on disk is a complete file and a retry skips
-            // it and resumes where it left off. Since issue #235, tapping the card's
-            // "Retry" affordance retries in place; the full reset lives in the
-            // overflow menu's "Delete partial download" entry (cleanupFailedModel).
 
             PersistentLog.log(.modelDownloadFailed(name: identifier, error: error.localizedDescription))
             throw error
@@ -630,6 +641,14 @@ enum ModelManagerError: Error, LocalizedError {
         case .prewarmTimeout(let seconds):
             return "Model optimization did not complete within \(seconds)s"
         }
+    }
+
+    /// Whether this is the prewarm deadline guard firing rather than a real
+    /// failure of the model files (issue #405). The one prewarm failure whose
+    /// downloaded payload is still worth keeping — see `ModelCleanupPolicy`.
+    var isPrewarmTimeout: Bool {
+        if case .prewarmTimeout = self { return true }
+        return false
     }
 }
 

--- a/DictusCore/Sources/DictusCore/ModelCleanupPolicy.swift
+++ b/DictusCore/Sources/DictusCore/ModelCleanupPolicy.swift
@@ -1,0 +1,51 @@
+// DictusCore/Sources/DictusCore/ModelCleanupPolicy.swift
+// Extracted decision rule for whether a failed model preparation may delete the
+// files it downloaded. Testable in isolation -- no file system, no engine.
+
+import Foundation
+
+/// Decides whether a failed download/prewarm is allowed to wipe the model files
+/// already on disk.
+///
+/// WHY extracted from `ModelManager` (issue #405):
+/// `ModelManager` is `@MainActor`, owns live WhisperKit/FluidAudio pipelines and
+/// lives in the DictusApp target, so none of it can be exercised from a unit
+/// test. The rule itself is pure -- it reads two facts and returns a Bool -- and
+/// it is exactly where #405's defect lived: the prewarm branch cleaned up
+/// unconditionally, so a Turbo compile that merely ran out of clock cost the user
+/// a 1.05 GB re-download. Same pattern as `IdleReleasePolicy`.
+///
+/// WHY an enum with statics (not a struct): there is no state to carry. The
+/// caller owns the facts; this type only combines them.
+public enum ModelCleanupPolicy {
+
+    /// Whether the files a failed preparation left behind must be removed.
+    ///
+    /// Three cases, and only one of them deletes anything:
+    ///
+    /// - **Download-phase failure** (`downloadPhaseCompleted == false`): keep.
+    ///   The downloader moves each file into place atomically, so everything on
+    ///   disk is a complete file and a retry skips it and resumes where it left
+    ///   off (issue #210, the policy the Parakeet path has always had).
+    /// - **Prewarm timeout** (issue #405): keep. The payload downloaded fine and
+    ///   only the Core ML compilation ran out of clock -- on a slow device, on a
+    ///   thermally throttled one, or because the budget itself is too tight
+    ///   (issue #406). The bytes are still good, so a retry must be able to
+    ///   resume at the compile step instead of repaying the download.
+    /// - **Any other prewarm failure**: delete. ANE compilation failures ("Must
+    ///   re-compile the E5 bundle", issue #104) leave behind an unusable Core ML
+    ///   cache that makes every retry fail identically until it is cleared.
+    ///
+    /// - Parameters:
+    ///   - downloadPhaseCompleted: the payload finished downloading, so the
+    ///     failure belongs to the prewarm phase.
+    ///   - isPrewarmTimeout: the failure is the deadline guard firing, not the
+    ///     compilation itself reporting an error.
+    /// - Returns: true when the caller should remove the model's files.
+    public static func shouldCleanUpFiles(
+        downloadPhaseCompleted: Bool,
+        isPrewarmTimeout: Bool
+    ) -> Bool {
+        downloadPhaseCompleted && !isPrewarmTimeout
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/ModelCleanupPolicyTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/ModelCleanupPolicyTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import DictusCore
+
+/// Coverage for the "may a failed preparation delete the downloaded files?" rule
+/// (issue #405).
+///
+/// These tests exist because `ModelManager` itself cannot be unit-tested: it is
+/// `@MainActor`, drives WhisperKit/FluidAudio and lives in the DictusApp target.
+/// The predicate below is the part of #405 that was actually wrong, so it is the
+/// part worth pinning down.
+final class ModelCleanupPolicyTests: XCTestCase {
+
+    func testDownloadFailureKeepsTheFiles() {
+        // Issue #210 resume policy: every file on disk is complete, a retry skips it.
+        XCTAssertFalse(ModelCleanupPolicy.shouldCleanUpFiles(
+            downloadPhaseCompleted: false,
+            isPrewarmTimeout: false
+        ))
+    }
+
+    func testPrewarmTimeoutKeepsTheFiles() {
+        // The #405 regression: a Turbo compile that ran out of clock used to cost
+        // the user a 1.05 GB re-download.
+        XCTAssertFalse(ModelCleanupPolicy.shouldCleanUpFiles(
+            downloadPhaseCompleted: true,
+            isPrewarmTimeout: true
+        ))
+    }
+
+    func testOtherPrewarmFailureStillCleansUp() {
+        // Issue #104: an E5 bundle failure leaves an unusable Core ML cache that
+        // makes every retry fail identically until it is cleared.
+        XCTAssertTrue(ModelCleanupPolicy.shouldCleanUpFiles(
+            downloadPhaseCompleted: true,
+            isPrewarmTimeout: false
+        ))
+    }
+
+    func testATimeoutBeforeTheDownloadCompletedIsStillAKeep() {
+        // Not reachable today (the deadline guard only wraps the prewarm), but the
+        // rule must not become "clean up" if a future timeout ever fires earlier.
+        XCTAssertFalse(ModelCleanupPolicy.shouldCleanUpFiles(
+            downloadPhaseCompleted: false,
+            isPrewarmTimeout: true
+        ))
+    }
+
+    func testCleanupIsTheSingleExceptionInTheTruthTable() {
+        // One deleting case out of four -- stated as a whole so a future edit that
+        // widens the deletion has to change this assertion on purpose.
+        let deleting = [(true, false), (true, true), (false, true), (false, false)]
+            .filter { ModelCleanupPolicy.shouldCleanUpFiles(
+                downloadPhaseCompleted: $0.0,
+                isPrewarmTimeout: $0.1
+            ) }
+        XCTAssertEqual(deleting.count, 1)
+        XCTAssertTrue(deleting[0] == (true, false))
+    }
+}


### PR DESCRIPTION
refs #405

## What this was for

A TestFlight tester downloaded Turbo over 5G, the download finished, and the Core ML
optimization stopped after 120 s with `Model optimization did not complete within 120s`.
The damage was not the timeout itself: it was that the timeout **deleted the 1.05 GB he
had just downloaded**, so every Retry made him pay the whole download again over cellular.

The prewarm branch of `downloadWhisperKitModel` cleaned up unconditionally. That is right
for an ANE compilation failure (#104: an E5 bundle error leaves a corrupt Core ML cache
that fails identically forever) and wrong for the deadline guard firing, where the bytes
on disk are perfectly good and only the compile ran out of clock. The code already told
the two apart — but only to write a log line.

This PR makes the timeout keep its files. #406 is the companion that fixes the 120 s
number itself; this half matters even with a longer budget, because a slow device must be
able to retry without repaying the download.

## To test by hand

A real prewarm timeout cannot be produced on a simulator (Core ML ANE compilation timing
there says nothing about device timing), so the core criterion needs the phone. The only
way to make a timeout happen on demand is to shorten the budget for one run.

1. On the phone, delete Turbo if it is installed (Settings → Models → Turbo → Delete).
2. In `DictusApp/Models/ModelManager.swift`, temporarily change `let prewarmTimeoutSeconds = 120`
   to `= 5`, and build to the device. **This edit is not in the PR — revert it before merging.**
3. Settings → Models → tap Turbo. Let the ~1 GB download finish on Wi-Fi.
   → Expected: the card moves to `OPTIMIZING`, then to `Error — Model optimization did not
   complete within 5s`.
4. Tap the card's Retry arrow and watch the card closely.
   → Expected: the progress bar appears and jumps straight to 100 % in about a second (this
   is the tree listing, a few KB — see the note below), then the card goes to `OPTIMIZING`.
   → **Fail** if a percentage climbs slowly for minutes: that would be the 1 GB coming down again.
5. Let step 4's Retry run with the budget still at 5 s so it times out again, then use the
   card's overflow menu → `Delete partial download`.
   → Expected: the card returns to `Available`, and the next tap does download the full
   payload again. The manual reset must still work.
6. Settings → Export logs, and read the tail.
   → Expected around each timeout: `modelPrewarmTimeout` then `modelDownloadFailed`, with
   **no** `modelCleanupPerformed` line between them. That pair is what says the bytes were kept.
   → After step 5 you should see `modelCleanupPerformed` — that path is unchanged.
7. Revert step 2, rebuild, and re-run steps 1-3 once with the real 120 s budget on the
   15 Pro Max to confirm Turbo still reaches `ready` normally.

Everything else was covered headlessly: `swift test` (1209 tests, incl. 5 new ones on the
extracted rule), `swiftlint lint --strict` (0 violations), and a Debug simulator build of
the `DictusApp` scheme.

## What changed

- **`DictusCore/Sources/DictusCore/ModelCleanupPolicy.swift`** (new) — the pure predicate
  `shouldCleanUpFiles(downloadPhaseCompleted:isPrewarmTimeout:)`. `ModelManager` is
  `@MainActor`, drives WhisperKit/FluidAudio and lives in DictusApp, so the rule could not
  be asserted anywhere; extracting it follows the same pattern as `IdleReleasePolicy`.
  The doc comment carries the three-way rule and its issue numbers.
- **`ModelManagerError.isPrewarmTimeout`** — the discrimination the `catch` needed.
- **`downloadWhisperKitModel`'s catch** — routes through the policy instead of
  `if downloadPhaseCompleted`.
- **`ModelCleanupPolicyTests.swift`** (new) — the 4-case truth table, plus an assertion that
  exactly one of the four cases deletes anything, so a future edit that widens deletion has
  to change a test on purpose.

**The Parakeet path needs nothing.** `downloadParakeetModel`'s catch performs no cleanup on
any failure (it has had #210's keep-the-files policy since it was written), and its prewarm
is not wrapped by `withPrewarmTimeout` at all, so `.prewarmTimeout` cannot arise there. This
PR aligns WhisperKit onto Parakeet's policy, not the reverse.

## Acceptance criteria

| Criterion | Status | Evidence |
|---|---|---|
| A prewarm timeout leaves the model files on disk | code + unit test; **device step 4/6 confirms** | `ModelCleanupPolicyTests.testPrewarmTimeoutKeepsTheFiles` passes; the only `cleanupModelFiles` call on a failure path is now behind the policy |
| Retry goes straight to `.prewarming`, no download bar, no network traffic | **partially met — see below** | the 1 GB re-download is gone; a few-KB tree listing and a bar that flashes to 100 % remain |
| A non-timeout prewarm failure still cleans up | met, unchanged | `testOtherPrewarmFailureStillCleansUp`; that branch's behaviour is byte-identical |
| `modelStates[identifier]` still lands on `.error` in both cases | met, unchanged | the assignment precedes the branch and was not touched; a standalone harness reproducing `withPrewarmTimeout` confirms the error arriving at the catch is an unwrapped `ModelManagerError.prewarmTimeout` whose `localizedDescription` is `Model optimization did not complete within Ns` |

## One divergence from the issue, deliberate

The second criterion asks for **no network traffic** on Retry. That is not reachable from the
fix the issue prescribes, and I did not force it: a retry re-enters `downloadWhisperKitModel`,
so it sets `.downloading` and `ModelRepoDownloader` lists the repo tree over the network (a
few KB) before skipping every file already on disk. The bar therefore appears and jumps to
100 % almost at once.

Short-circuiting the download phase entirely would mean treating
`Configuration.requiredPaths` — a tripwire, not a manifest — as proof the variant is complete,
which would silently skip re-fetching a missing non-required file. Not worth it for a metadata
round trip. What the issue is actually about, the 1 GB, is gone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model download failure handling to preserve downloaded files after prewarm timeouts and incomplete downloads.
  * Continued removing files for completed downloads that fail during preparation for reasons other than a timeout.

* **Tests**
  * Added coverage for all model cleanup scenarios to ensure files are removed only when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->