### PR TITLE
Seed the Pro feature toggles into the App Group so the keyboard agrees with the app (refs #401)

### DIFF
--- a/DictusCore/Sources/DictusCore/SharedKeys.swift
+++ b/DictusCore/Sources/DictusCore/SharedKeys.swift
@@ -229,11 +229,14 @@ public enum SharedKeys {
     /// Bool: true when the user has an active Pro subscription.
     /// Written by SubscriptionManager (DictusApp), read by the keyboard extension.
     public static let proActive = "dictus.proActive"
-    /// Bool: per-feature toggle for Smart Mode, default true (registered by ProStatusManager)
+    /// Bool: per-feature toggle for Smart Mode. Seeded to true, once, by
+    /// `ProStatusManager.seedFeatureTogglesIfNeeded()`; written afterwards only by the
+    /// Settings toggle. Stored, never merely registered -- the keyboard extension reads
+    /// these and a registered default would not reach it (#401).
     public static let smartModeEnabled = "dictus.smartModeEnabled"
-    /// Bool: per-feature toggle for History, default true (registered by ProStatusManager)
+    /// Bool: per-feature toggle for History. Seeded like `smartModeEnabled` above.
     public static let historyEnabled = "dictus.historyEnabled"
-    /// Bool: per-feature toggle for Vocabulary, default true (registered by ProStatusManager)
+    /// Bool: per-feature toggle for Vocabulary. Seeded like `smartModeEnabled` above.
     public static let vocabularyEnabled = "dictus.vocabularyEnabled"
 
     // MARK: - Retired keys

--- a/DictusCore/Sources/DictusCore/Subscription/ProStatusManager.swift
+++ b/DictusCore/Sources/DictusCore/Subscription/ProStatusManager.swift
@@ -24,22 +24,48 @@ public final class ProStatusManager: ObservableObject {
     @Published public private(set) var isProActive: Bool
 
     public init() {
-        // Register defaults so per-feature toggles are ON by default
-        // WHY registerDefaults: UserDefaults.bool(forKey:) returns false for unset keys.
-        // Pro features should be enabled by default when user subscribes -- they can
-        // then toggle individual features off in Settings if desired.
-        // CAVEAT: registerDefaults is per-process and never persisted, so the
-        // keyboard extension (which never runs this init) reads false for
-        // un-toggled features. Irrelevant while keyboard gating is unused;
-        // revisit when wiring FeatureGate.isKeyboardFeatureAvailable (issue #79).
-        let defaults = AppGroup.defaults
-        defaults.register(defaults: [
-            SharedKeys.smartModeEnabled: true,
-            SharedKeys.historyEnabled: true,
-            SharedKeys.vocabularyEnabled: true
-        ])
+        // Runs at every app launch (DictusApp.init), which is what makes the
+        // seeding idempotent and always ahead of the first read.
+        ProStatusManager.seedFeatureTogglesIfNeeded()
 
-        self.isProActive = defaults.bool(forKey: SharedKeys.proActive)
+        self.isProActive = AppGroup.defaults.bool(forKey: SharedKeys.proActive)
+    }
+
+    /// Writes the per-feature Pro toggles into the App Group the first time, so that
+    /// the keyboard extension and the app read the same answer (issue #401).
+    ///
+    /// WHY a write and not `register(defaults:)`, which is what this replaced:
+    /// registration is per-process and never hits disk. DictusApp runs this init and
+    /// read `true` for an un-toggled feature; the keyboard extension never runs it and
+    /// read `false`. Same key, two processes, two answers -- a subscriber who never
+    /// opened the Settings toggle got a locked Smart Mode fan while Settings showed it
+    /// on. The App Group is the source of truth both sides already assume it is, so
+    /// the value has to actually be in it.
+    ///
+    /// WHY `object(forKey:) == nil` and not an unconditional write: seed, never
+    /// assign. `SubscriptionManager.updateProStatus()` runs on every launch, so an
+    /// unconditional write would silently switch a feature back on for a user who
+    /// deliberately turned it off. `bool(forKey:)` cannot tell "never set" from "set
+    /// to false"; `object(forKey:)` can.
+    ///
+    /// WHY no `register(defaults:)` survives alongside it: a registered value makes
+    /// `object(forKey:)` return non-nil, which would disarm the guard above and leave
+    /// the keys unpersisted all over again.
+    ///
+    /// Seeding is deliberately not conditioned on Pro being active: `FeatureGate`
+    /// checks `isProActive` first, so a stored `true` grants a free user nothing --
+    /// it is only the on-by-default state waiting for the day they subscribe, which
+    /// is exactly what the registration used to express.
+    nonisolated public static func seedFeatureTogglesIfNeeded() {
+        let defaults = AppGroup.defaults
+        let unseeded = ProFeature.allCases.filter {
+            defaults.object(forKey: $0.settingsKey) == nil
+        }
+        guard !unseeded.isEmpty else { return }
+
+        unseeded.forEach { defaults.set(true, forKey: $0.settingsKey) }
+        // Same reason as setProActive below: the reader is another process.
+        defaults.synchronize()
     }
 
     /// Called by SubscriptionManager after transaction updates (DictusApp only).

--- a/DictusCore/Tests/DictusCoreTests/ProGatingTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/ProGatingTests.swift
@@ -16,6 +16,18 @@ final class ProGatingTests: XCTestCase {
         AppGroup.defaults
     }
 
+    /// What `key` looks like to a process that never called `register(defaults:)` --
+    /// which is to say, to DictusKeyboard (#401).
+    ///
+    /// `persistentDomain(forName:)` returns only values that were actually stored, so a
+    /// registered-but-unpersisted default is invisible to it, exactly as it is invisible
+    /// to the extension. Reading through `AppGroup.defaults` cannot make that
+    /// distinction: registration is process-wide, so once anything in this process has
+    /// registered a key, every `UserDefaults` instance on the suite reports it.
+    private func valueVisibleToAnotherProcess(forKey key: String) -> Bool? {
+        UserDefaults.standard.persistentDomain(forName: AppGroup.identifier)?[key] as? Bool
+    }
+
     private let proKeys = [
         SharedKeys.proActive,
         SharedKeys.smartModeEnabled,
@@ -116,12 +128,84 @@ final class ProGatingTests: XCTestCase {
     }
 
     @MainActor
-    func testInitRegistersFeatureToggleDefaults() {
+    func testInitSeedsFeatureTogglesIntoAppGroupStorage() {
         _ = ProStatusManager()
         for feature in ProFeature.allCases {
             XCTAssertTrue(defaults.bool(forKey: feature.settingsKey),
                           "\(feature) toggle should default to true after init")
+            XCTAssertEqual(valueVisibleToAnotherProcess(forKey: feature.settingsKey), true,
+                           "\(feature) toggle must be stored, not merely registered: the "
+                           + "keyboard extension never runs this init (#401)")
         }
+    }
+
+    // MARK: - Feature toggle seeding (#401)
+
+    /// The regression test for #401, and the case the rest of this file does not cover:
+    /// every other test writes the feature keys explicitly, which is precisely the state
+    /// the bug does not occur in.
+    ///
+    /// A subscriber who never opens the Settings toggle. The app launches, the keyboard
+    /// reads the key with no registration of its own, and must get the same `true`.
+    @MainActor
+    func testUnToggledFeatureReachesTheKeyboardAfterAppLaunch() {
+        defaults.set(true, forKey: SharedKeys.proActive)
+
+        // The app launching. Nothing touches the Smart Mode toggle.
+        _ = ProStatusManager()
+
+        XCTAssertEqual(valueVisibleToAnotherProcess(forKey: SharedKeys.smartModeEnabled), true,
+                       "the keyboard reads storage, not this process's registration domain")
+        XCTAssertTrue(FeatureGate.isKeyboardFeatureAvailable(.smartMode),
+                      "a subscriber who never opened the toggle must get an unlocked fan")
+    }
+
+    /// Criterion: the keyboard and DictusApp return the same answer for the same key,
+    /// with no registration in the keyboard process.
+    @MainActor
+    func testAppAndKeyboardAgreeOnUnToggledFeatures() {
+        defaults.set(true, forKey: SharedKeys.proActive)
+        _ = ProStatusManager()
+
+        for feature in ProFeature.allCases {
+            XCTAssertEqual(valueVisibleToAnotherProcess(forKey: feature.settingsKey) ?? false,
+                           FeatureGate.isAvailable(feature),
+                           "\(feature) reads differently in the two processes")
+        }
+    }
+
+    /// Seed, never assign. `SubscriptionManager.updateProStatus()` runs on every launch,
+    /// so this is the launch-after-launch case: a feature the user deliberately turned
+    /// off must stay off.
+    @MainActor
+    func testSeedingNeverRevivesADeliberatelyDisabledFeature() {
+        defaults.set(true, forKey: SharedKeys.proActive)
+        _ = ProStatusManager()
+
+        // The user turns Smart Mode off in Settings.
+        defaults.set(false, forKey: ProFeature.smartMode.settingsKey)
+
+        // Two more launches, each with its entitlement refresh.
+        _ = ProStatusManager()
+        _ = ProStatusManager()
+
+        XCTAssertEqual(valueVisibleToAnotherProcess(forKey: SharedKeys.smartModeEnabled), false)
+        XCTAssertFalse(FeatureGate.isAvailable(.smartMode))
+        XCTAssertFalse(FeatureGate.isKeyboardFeatureAvailable(.smartMode))
+        // The features they left alone are untouched.
+        XCTAssertTrue(FeatureGate.isAvailable(.history))
+        XCTAssertTrue(FeatureGate.isAvailable(.vocabulary))
+    }
+
+    /// The seeding is callable on its own -- the keyboard never constructs the manager,
+    /// so the migration must not be welded to the initialiser's other work.
+    func testSeedingIsIdempotent() {
+        ProStatusManager.seedFeatureTogglesIfNeeded()
+        defaults.set(false, forKey: ProFeature.vocabulary.settingsKey)
+        ProStatusManager.seedFeatureTogglesIfNeeded()
+
+        XCTAssertEqual(valueVisibleToAnotherProcess(forKey: SharedKeys.vocabularyEnabled), false)
+        XCTAssertEqual(valueVisibleToAnotherProcess(forKey: SharedKeys.smartModeEnabled), true)
     }
 
     @MainActor


### PR DESCRIPTION
## What this was for

A paying subscriber who never touches the Smart Mode toggle sees Settings say "on" while the keyboard says locked, and only toggling off and back on fixes it — with nothing in the product telling them so.

`ProStatusManager.init()` *registered* the three per-feature toggles instead of storing them. `register(defaults:)` is per-process and never hits disk: DictusApp reads `true` for an un-toggled key, DictusKeyboard reads `false`. Same key, two processes, two answers. The state the user can see contradicts the state that decides.

Nobody can hit this yet (`PremiumFlags.paywallVisible` is `false`, no ASC product — #215), which is why this is a #215 blocker rather than a hotfix.

refs #401

## To test by hand

Everything below needs entitlement, which today means the throwaway `test/79-block-c-unlocked` build. **Start by rebasing that branch onto this one** (`git rebase fix/401-seed-pro-feature-keys test/79-block-c-unlocked`), then edit its `DictusApp.init` block to write **only** `proActive` — delete the three `smartModeEnabled` / `historyEnabled` / `vocabularyEnabled` writes. That is the whole point of the test: the fixed build must unlock the fan with `proActive` alone.

1. On the iPhone, delete Dictus entirely (Settings → General → iPhone Storage → Dictus → Delete App). This is the "never touched the toggle" state; a leftover App Group would hide the bug. → the app is gone.
2. Install and launch the modified `test/79-block-c-unlocked` build. → the app opens normally.
3. Settings → Pro Features. → the three rows show as toggles (not lock + PRO pills), all **on**. Do **not** touch them.
4. Open any app with a text field, switch to the Dictus keyboard (long-press the globe, pick Dictus — a simple tap skips third-party keyboards).
5. Long-press the mic to open the Smart Mode fan. → **the mode rows are enabled**. Before this PR they were all disabled under "Smart Modes are part of Dictus Pro." *This is the acceptance criterion.*
6. Pick a mode, dictate something. → the mode applies.
7. Back in the app: Settings → Pro Features → turn **Smart Modes off**.
8. Force-quit the app and relaunch it (this runs an entitlement refresh, which is where a naive fix would re-enable the feature). → the Smart Modes toggle is still **off**.
9. Reopen the keyboard and long-press the mic. → the fan is locked again, as it should be: the user said no.
10. Turn Smart Modes back **on** in Settings, force-quit, relaunch. → still **on**, and the fan is unlocked again.
11. Only if you want the "before" for comparison: reinstall the same test build from `develop` with only `proActive` written, and step 5 shows every row disabled.

Step 5 and step 9 are the pair that matters. Steps 1 and 8 are the ones that are easy to skip and that invalidate the run if skipped.

## What changed

**`DictusCore/Sources/DictusCore/Subscription/ProStatusManager.swift`**
`register(defaults:)` is replaced by `nonisolated public static func seedFeatureTogglesIfNeeded()`, called from `init()` — which runs at every app launch, from `DictusApp.init`, ahead of any read.

The write is guarded on `object(forKey:) == nil`, not on `bool(forKey:)`. `SubscriptionManager.updateProStatus()` runs on every launch, so an unconditional write would silently revive a feature the user deliberately turned off, every launch. `bool(forKey:)` cannot tell "never set" from "set to false"; `object(forKey:)` can. Seed, never assign.

**The registration had to be removed, not just re-commented.** Measured: `object(forKey:)` returns the *registered* value, so a surviving `register(defaults:)` running first makes the seeding guard always false and the keys never get stored — the naive "add seeding, keep registration" version of this fix is silently a no-op. That is now written down next to the guard.

Placement is `init()` rather than the transition into `setProActive(true)`, which the issue comment offered as the alternative: the throwaway entitlement build writes `proActive` directly and guards `setProActive` against `false`, so seeding hung off `setProActive` would never run there — and the acceptance requires `proActive` alone to unlock. `init()` covers every launch and every entitlement path.

Seeding is deliberately not conditioned on Pro being active: `FeatureGate` checks `isProActive` first, so a stored `true` grants a free user nothing. It is the on-by-default state waiting for the day they subscribe — exactly what the registration used to express.

**`DictusCore/Sources/DictusCore/SharedKeys.swift`** — the three key comments said "registered by ProStatusManager". They now say seeded and stored, and why.

**`DictusCore/Tests/DictusCoreTests/ProGatingTests.swift`** — four tests, three of which fail on `develop` (evidence below).

The caveat comment in `ProStatusManager.init` — which predicted this bug and deferred it "while keyboard gating is unused" — is gone with the registration it described.

## Acceptance criteria

| Criterion | Status | Evidence |
|---|---|---|
| A subscriber who has never opened the Smart Modes toggle gets an unlocked fan in the keyboard | **Verified mechanically, not visually** | Unit: `testUnToggledFeatureReachesTheKeyboardAfterAppLaunch` passes. Runtime: clean install + `dictus.proActive=true` alone, one launch of the built app on the booted simulator → the App Group plist gains all three keys as `true`. (`proActive` then flips back to `false` in that run: the entitlement refresh finds no product, which is exactly what the throwaway build's `guard active else { return }` exists to prevent. It does not affect the seeding, which is unconditional on Pro.) The fan itself is a manual step (5 above). |
| A user who turned a feature off stays off across launches and entitlement refreshes | **Verified** | Unit: `testSeedingNeverRevivesADeliberatelyDisabledFeature` — toggle off, then two more `ProStatusManager()` launches; stays `false`. Also `testSeedingIsIdempotent`. Runtime: set `dictus.smartModeEnabled=false` in the App Group plist, relaunch the built app → still `false`, while the two untouched keys stay `true`. |
| The keyboard and DictusApp return the same answer for the same key, with no registration in the keyboard process | **Verified** | `testAppAndKeyboardAgreeOnUnToggledFeatures` — compares `FeatureGate.isAvailable` against `persistentDomain(forName:)`, which is registration-blind. Fails on `develop` for all three features. |
| `ProStatusManager.init`'s caveat comment is gone or corrected | **Verified** | Deleted in `e4264eb` along with the `register(defaults:)` it described. |
| Regression test covers the un-toggled path, not just the explicitly-set one | **Verified** | The new tests never write the feature keys before reading them; the pre-existing ones all did. |

## Verification run

- `cd DictusCore && swift test` → **1208 tests, 1 skipped, 0 failures**
- `swiftlint lint --strict` → **0 violations, 0 serious in 215 files**
- `xcodebuild build -scheme DictusApp -destination 'platform=iOS Simulator,id=…'` (after `-resolvePackageDependencies` and `./scripts/patch-fluidaudio-swift5.sh build/DerivedData`) → **BUILD SUCCEEDED**, producing `DictusApp.app`, `DictusKeyboard.appex`, `DictusWidgets.appex`

### Fails on `develop`, passes here

Confirmed by restoring `develop`'s `ProStatusManager.swift` under the new tests and re-running:

```
testAppAndKeyboardAgreeOnUnToggledFeatures : XCTAssertEqual failed: ("false") is not equal to ("true") - smartMode reads differently in the two processes
  (and the same for history and vocabulary)
testInitSeedsFeatureTogglesIntoAppGroupStorage : XCTAssertEqual failed: ("nil") is not equal to ("Optional(true)") - smartMode toggle must be stored, not merely registered
testUnToggledFeatureReachesTheKeyboardAfterAppLaunch : XCTAssertEqual failed: ("nil") is not equal to ("Optional(true)") - the keyboard reads storage, not this process's registration domain
```

On this branch all 17 tests in `ProGatingTests` pass.

`testSeedingNeverRevivesADeliberatelyDisabledFeature` passes on `develop` too, by design: it does not guard against today's bug but against the naive fix for it (an unconditional write in `setProActive`).

## Not verified here

- **The fan itself.** No agent can put a subscriber's keyboard on screen: it needs entitlement, and entitlement needs the throwaway build. The manual list above is the whole of it.
- The device-level cross-process read. The simulator check confirms the key reaches the shared plist; that the keyboard extension then reads it is the same `AppGroup.defaults` path every other shared key uses, but it has not been observed end to end.
