### PR TITLE
Tie the backspace auto-repeat to the view that scheduled it

### DIFF
--- a/DictusCore/Sources/DictusCore/LogEvent.swift
+++ b/DictusCore/Sources/DictusCore/LogEvent.swift
@@ -109,6 +109,20 @@ public enum LogEvent: Sendable {
     case keyboardMicTapped
     case keyboardTextInserted  // No content parameter -- privacy by design
 
+    // MARK: Key auto-repeat (#390)
+    // Neither case carries a key or a character. Only backspace auto-repeats, so
+    // naming the key would add nothing and would open the door `keyboardTextInserted`
+    // keeps shut.
+    /// The held-key auto-repeat engaged: the press outlasted the 0.5 s pause and the
+    /// first repeated deletion just fired. A plain tap schedules the same timer and
+    /// logs nothing, which is what keeps a 1 MB log readable while someone types.
+    case keyRepeatStarted
+    /// The auto-repeat ended. `ticks` is how many times it fired, `reason` names what
+    /// stopped it -- a finger lifting, the keyboard going off screen, the view being
+    /// torn down. A `keyRepeatStarted` with no matching stop is a repeat that outlived
+    /// its keyboard, which is the whole of #390 and was previously invisible.
+    case keyRepeatStopped(ticks: Int, reason: String)
+
     // MARK: Keyboard status message (#261)
     /// The toolbar message was assigned. `reason` names what asked for it.
     case dictationMessageSet(reason: String, owner: String, visible: Bool)
@@ -344,6 +358,7 @@ public enum LogEvent: Sendable {
              .modelDownloadProgress, .modelDownloadStalled, .modelDownloadSizeMismatch:
             return .model
         case .keyboardDidAppear, .keyboardDidDisappear, .keyboardMicTapped, .keyboardTextInserted,
+             .keyRepeatStarted, .keyRepeatStopped,
              .overlayShown, .overlayHidden, .rapidTapRejected,
              .dictationMessageSet, .dictationMessageDisplayed, .dictationMessageCleared,
              .waveformAppeared, .waveformDisappeared, .waveformHeartbeat, .waveformStall,
@@ -446,6 +461,7 @@ public enum LogEvent: Sendable {
              .onboardingKeyboardRetry,
              .audioEngineStopped,
              .keyboardDidDisappear, .keyboardTextInserted,
+             .keyRepeatStarted, .keyRepeatStopped,
              .appDidBecomeActive, .appWillResignActive, .appDidEnterBackground,
              .rapidTapRejected,
              .engineWarmUpAttempt, .engineWarmUpSuccess,
@@ -526,6 +542,8 @@ public enum LogEvent: Sendable {
         case .dictationMessageDisplayed: return "dictationMessageDisplayed"
         case .dictationMessageCleared: return "dictationMessageCleared"
         case .keyboardTextInserted: return "keyboardTextInserted"
+        case .keyRepeatStarted: return "keyRepeatStarted"
+        case .keyRepeatStopped: return "keyRepeatStopped"
         case .engineWarmUpAttempt: return "engineWarmUpAttempt"
         case .engineWarmUpSuccess: return "engineWarmUpSuccess"
         case .engineWarmUpFailed: return "engineWarmUpFailed"
@@ -684,6 +702,10 @@ public enum LogEvent: Sendable {
         case .keyboardDidAppear, .keyboardDidDisappear,
              .keyboardMicTapped, .keyboardTextInserted:
             return ""
+        case .keyRepeatStarted:
+            return ""
+        case .keyRepeatStopped(let ticks, let reason):
+            return "ticks=\(ticks) reason=\(reason)"
 
         // Engine Diagnostics
         case .engineWarmUpAttempt(let context):

--- a/DictusCore/Tests/DictusCoreTests/KeyRepeatLogEventTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/KeyRepeatLogEventTests.swift
@@ -1,0 +1,62 @@
+// DictusCore/Tests/DictusCoreTests/KeyRepeatLogEventTests.swift
+// Tests for the held-key auto-repeat log events (#390).
+//
+// The repeat timer itself lives in the vendored keyboard view and is not reachable
+// from this package. What IS reachable, and what the issue actually asks for, is the
+// pair of lines a reader greps for: a start, and a stop carrying the tick count and
+// what stopped it.
+import XCTest
+@testable import DictusCore
+
+final class KeyRepeatLogEventTests: XCTestCase {
+
+    func testKeyRepeatStartedIsDebugKeyboard() {
+        let event = LogEvent.keyRepeatStarted
+        XCTAssertEqual(event.level, .debug)
+        XCTAssertEqual(event.subsystem, .keyboard)
+        XCTAssertEqual(event.name, "keyRepeatStarted")
+    }
+
+    func testKeyRepeatStoppedIsDebugKeyboard() {
+        let event = LogEvent.keyRepeatStopped(ticks: 12, reason: "touch")
+        XCTAssertEqual(event.level, .debug)
+        XCTAssertEqual(event.subsystem, .keyboard)
+        XCTAssertEqual(event.name, "keyRepeatStopped")
+    }
+
+    func testKeyRepeatStoppedCarriesTickCountAndReason() {
+        let event = LogEvent.keyRepeatStopped(ticks: 12, reason: "windowDetached")
+        XCTAssertEqual(event.message, "ticks=12 reason=windowDetached")
+    }
+
+    /// The two lines have to be findable by name in an exported log, because that is
+    /// how they are read: `grep keyRepeat`.
+    func testFormattedOutputIsGreppableAndCarriesTheTickCount() {
+        let started = LogEvent.keyRepeatStarted.formatted()
+        XCTAssertTrue(started.contains("keyRepeatStarted"))
+        XCTAssertTrue(started.contains("[keyboard]"))
+
+        let stopped = LogEvent.keyRepeatStopped(ticks: 347, reason: "viewDeallocated").formatted()
+        XCTAssertTrue(stopped.contains("keyRepeatStopped"))
+        XCTAssertTrue(stopped.contains("[keyboard]"))
+        XCTAssertTrue(stopped.contains("ticks=347"))
+        XCTAssertTrue(stopped.contains("reason=viewDeallocated"))
+    }
+
+    /// A runaway is only diagnosable if the stop line can say the timer was still
+    /// firing after the view was gone, so the unknown tick count has to survive
+    /// formatting rather than being clamped away.
+    func testKeyRepeatStoppedAcceptsAnUnknownTickCount() {
+        let event = LogEvent.keyRepeatStopped(ticks: -1, reason: "viewDeallocated")
+        XCTAssertEqual(event.message, "ticks=-1 reason=viewDeallocated")
+    }
+
+    /// Neither case can name a key or a character -- the same rule
+    /// `keyboardTextInserted` follows.
+    func testKeyRepeatEventsCarryNoKeyOrCharacter() {
+        XCTAssertEqual(LogEvent.keyRepeatStarted.message, "")
+        let stopped = LogEvent.keyRepeatStopped(ticks: 3, reason: "touch").message
+        XCTAssertFalse(stopped.contains("key="))
+        XCTAssertFalse(stopped.contains("character="))
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/LogPrivacyTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/LogPrivacyTests.swift
@@ -29,6 +29,8 @@ final class LogPrivacyTests: XCTestCase {
             .keyboardDidDisappear,
             .keyboardMicTapped,
             .keyboardTextInserted,
+            .keyRepeatStarted,
+            .keyRepeatStopped(ticks: 12, reason: "touch"),
             .appLaunched(version: "1.2"),
             .appDidBecomeActive,
             .appWillResignActive,

--- a/DictusKeyboard/DictusKeyboardBridge.swift
+++ b/DictusKeyboard/DictusKeyboardBridge.swift
@@ -196,6 +196,32 @@ final class DictusKeyboardBridge: NSObject,
         }
     }
 
+    /// Perform `key`'s auto-repeat action and report whether a deletion was actually
+    /// issued.
+    ///
+    /// WHY the keyboard view asks rather than just calling and assuming (#390): the
+    /// repeat tick used to fire its haptic and its click unconditionally, so a repeat
+    /// that had outlived its controller kept tapping the user's wrist while every
+    /// deletion went nowhere. `controller` is weak and dies with the keyboard, which
+    /// makes "is there still a document to delete into" a question this class can
+    /// answer and the view cannot.
+    ///
+    /// WHY the answer is proxy availability and not "did the document change": a host
+    /// may withhold `documentContextBeforeInput` -- a secure field reports none -- while
+    /// still accepting the deletion, so gating the feedback on the context would silence
+    /// a backspace that works, and #286 must not regress. A deletion issued into a live
+    /// proxy is a deletion issued.
+    func didTriggerRepeat(_ key: KeyDefinition, wordMode: Bool) -> Bool {
+        guard controller?.textDocumentProxy != nil else { return false }
+
+        if wordMode {
+            didTriggerHoldKey(key)
+        } else {
+            didTriggerKey(key)
+        }
+        return true
+    }
+
     func didMoveCursor(_ movement: Int) {
         // Moving the caret is what the undo check tests for, so drop the offer
         // here rather than wait for the host to report the selection change (#266).

--- a/DictusKeyboard/KeyboardViewController.swift
+++ b/DictusKeyboard/KeyboardViewController.swift
@@ -679,6 +679,10 @@ class KeyboardViewController: UIInputViewController {
         // (#260): a detached controller must not adopt an ownerless dictation.
         isAttached = false
 
+        // A finger held on backspace when iOS takes the keyboard away never produces a
+        // touchesEnded, and the repeat timer was cleared by nothing else (#390).
+        giellaKeyboard?.cancelKeyRepeat(reason: "viewDidDisappear")
+
         // Restore system gesture recognizer delay (be a good citizen)
         restoreWindowGestureDelay()
 
@@ -852,6 +856,7 @@ class KeyboardViewController: UIInputViewController {
         hostingController?.removeFromParent()
         hostingController = nil
 
+        giellaKeyboard?.cancelKeyRepeat(reason: "controllerDeinit")
         giellaKeyboard?.removeFromSuperview()
         giellaKeyboard = nil
 
@@ -1275,7 +1280,10 @@ class KeyboardViewController: UIInputViewController {
             details: "status=\(KeyboardState.shared.dictationStatus.rawValue) oldHosting=\(hostingHeightConstraint?.constant ?? -1) oldHeight=\(heightConstraint?.constant ?? -1) inputBounds=\(Int(kbInputView.bounds.width))x\(Int(kbInputView.bounds.height))"
         ))
 
-        // Remove old keyboard
+        // Remove old keyboard. Stop its auto-repeat first: this controller and its
+        // bridge outlive the rebuild, so an outgoing view still holding a repeat would
+        // keep deleting into the live document from outside the hierarchy (#390).
+        giellaKeyboard?.cancelKeyRepeat(reason: "reloadLayout")
         giellaKeyboard?.removeFromSuperview()
 
         // Create new keyboard with updated definition

--- a/DictusKeyboard/Vendored/Views/KeyboardView.swift
+++ b/DictusKeyboard/Vendored/Views/KeyboardView.swift
@@ -11,6 +11,9 @@ protocol GiellaKeyboardViewDelegate: AnyObject {
     func didTriggerKey(_ key: KeyDefinition)
     func didTriggerDoubleTap(forKey key: KeyDefinition)
     func didTriggerHoldKey(_ key: KeyDefinition)
+    /// Perform `key`'s auto-repeat action and report whether a deletion was actually
+    /// issued. The repeat tick fires its haptic and its click on that answer (#390).
+    func didTriggerRepeat(_ key: KeyDefinition, wordMode: Bool) -> Bool
     func didMoveCursor(_ movement: Int)
 }
 
@@ -560,9 +563,7 @@ final internal class GiellaKeyboardView: UIView,
                 dismissOverlayTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: false, block: { [weak self] _ in
                     self?.removeOverlay(forKey: activeKey.key)
                 })
-                keyRepeatTimer?.invalidate()
-                keyRepeatTimer = nil
-                deleteRepeatCount = 0
+                stopKeyRepeat(reason: "touch")
             }
 
             if let key = newValue, key.key.type.supportsRepeatTrigger, keyRepeatTimer == nil {
@@ -581,13 +582,65 @@ final internal class GiellaKeyboardView: UIView,
         }
     }
 
+    /// Schedule the auto-repeat tick.
+    ///
+    /// WHY the block form rather than `target:selector:` (#390): a scheduled `Timer` is
+    /// retained by its run loop AND retains its target, so the selector form kept this
+    /// whole view alive after the controller had dropped it. A hold interrupted by a
+    /// layout rebuild or by the keyboard being dismissed left a detached view ticking
+    /// haptics forever. The sibling `dismissOverlayTimer` above already takes
+    /// `[weak self]`; this now matches it.
     private func makeKeyRepeatTimer(timeInterval: TimeInterval) -> Timer {
-        return Timer.scheduledTimer(
-            timeInterval: timeInterval,
-            target: self,
-            selector: #selector(GiellaKeyboardView.keyRepeatTimerDidTrigger),
-            userInfo: nil,
-            repeats: true)
+        return Timer.scheduledTimer(withTimeInterval: timeInterval, repeats: true) { [weak self] timer in
+            guard let self = self else {
+                // Nothing left to stop this from the inside. The tick count went with
+                // the view, so the line reports it as unknown rather than as zero.
+                timer.invalidate()
+                PersistentLog.log(.keyRepeatStopped(ticks: -1, reason: "viewDeallocated"))
+                return
+            }
+            self.keyRepeatTimerDidTrigger()
+        }
+    }
+
+    /// Invalidate the auto-repeat timer and close its log entry.
+    ///
+    /// Logs only a repeat that had actually engaged: every backspace *tap* schedules the
+    /// same timer for its 0.5 s pause, and a line per keystroke would bury the signal in
+    /// a 1 MB log whose reader is an agent (#255).
+    private func stopKeyRepeat(reason: String) {
+        keyRepeatTimer?.invalidate()
+        keyRepeatTimer = nil
+        if deleteRepeatCount > 0 {
+            PersistentLog.log(.keyRepeatStopped(ticks: deleteRepeatCount, reason: reason))
+        }
+        deleteRepeatCount = 0
+    }
+
+    /// Stop any auto-repeat in flight, from outside the touch sequence.
+    ///
+    /// WHY this exists (#390): `activeKey` is cleared by `touchesEnded` and
+    /// `touchesCancelled` and by nothing else, so a view torn down mid-hold kept a
+    /// populated `activeKey` and a live timer. The controller calls this when it goes
+    /// off screen and before it drops this view, and `willMove(toWindow:)` below calls
+    /// it for every other path that detaches us.
+    func cancelKeyRepeat(reason: String) {
+        stopKeyRepeat(reason: reason)
+        // Clearing the active key is what `touchesCancelled` does, and it is what stops
+        // the tick's own `activeKey != nil` guard from letting a stale hold resume if
+        // anything reschedules. `stopKeyRepeat` already ran, so the `willSet` below
+        // finds no timer and logs nothing a second time.
+        activeKey = nil
+    }
+
+    /// Leaving the window is the one teardown signal this view gets on every path that
+    /// drops it: a layout rebuild, the controller deallocating, the keyboard being
+    /// dismissed mid-hold. None of them delivers a touch event (#390).
+    override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
+        if newWindow == nil {
+            cancelKeyRepeat(reason: "windowDetached")
+        }
     }
 
     override func touchesBegan(_ touches: Set<UITouch>, with _: UIEvent?) {
@@ -836,27 +889,32 @@ final internal class GiellaKeyboardView: UIView,
         }
     }
 
-    @objc func keyRepeatTimerDidTrigger() {
-        if let activeKey = activeKey, activeKey.key.type.supportsRepeatTrigger {
-            deleteRepeatCount += 1
+    func keyRepeatTimerDidTrigger() {
+        guard let activeKey = activeKey, activeKey.key.type.supportsRepeatTrigger else { return }
 
-            if deleteRepeatCount > Self.wordModeThreshold {
-                // Word-level deletion after threshold
-                delegate?.didTriggerHoldKey(activeKey.key)
-            } else {
-                // Character-level deletion
-                delegate?.didTriggerKey(activeKey.key)
-            }
-
-            // Haptic feedback on each deletion
-            HapticFeedback.keyTapped()
-            // ...and its click. Each repeat tick used to click from inside the bridge's
-            // delete handlers; emitting it here keeps a held backspace at exactly one
-            // click per deletion now that those handlers are silent (#286).
-            playSound(for: activeKey.key)
-
-            increaseKeyRepeatRateIfNeeded()
+        deleteRepeatCount += 1
+        if deleteRepeatCount == 1 {
+            // The hold outlasted the 0.5 s pause, so this is where the repeat begins.
+            PersistentLog.log(.keyRepeatStarted)
         }
+
+        // Word-level deletion after threshold, character-level before it.
+        let wordMode = deleteRepeatCount > Self.wordModeThreshold
+        let deleted = delegate?.didTriggerRepeat(activeKey.key, wordMode: wordMode) ?? false
+
+        // The feedback follows the deletion, not the tick (#390). Both used to fire
+        // unconditionally, which is what produced "haptics in a chain while nothing is
+        // deleted": with no delegate left there is nothing to delete into and the repeat
+        // has to be silent. Still exactly one haptic and one click per deletion, as #286
+        // left it -- each repeat tick used to click from inside the bridge's delete
+        // handlers, and emitting it here is what keeps that count right now they are
+        // silent.
+        if deleted {
+            HapticFeedback.keyTapped()
+            playSound(for: activeKey.key)
+        }
+
+        increaseKeyRepeatRateIfNeeded()
     }
 
     private func increaseKeyRepeatRateIfNeeded() {


### PR DESCRIPTION
refs #390

## What this was for

You felt continuous haptic feedback — "as if I were holding the delete key down while
nothing is being deleted" — that survived dismissing the keyboard and came back on
every recording. Reinstalling the build stopped it, which put the runaway inside one
extension process.

## To test by hand

A green build says nothing about whether the extension launches, and nothing at all
about haptics — no simulator and no test can feel a tap. Everything below needs the
phone.

1. Install this branch on the iPhone and open any app with a text field (Notes, a
   Safari address bar). Bring up the Dictus keyboard.
   → It draws normally. If it does not appear at all, stop here and tell me.
2. Type a couple of sentences. Hold backspace for about three seconds and let go.
   → Characters delete one by one, then whole words after ten characters, and you feel
   exactly one tap and hear exactly one click per deletion. This is #286's behaviour and
   it must be unchanged.
3. Same hold, but this time **release your finger outside the keyboard** — slide up onto
   the text before lifting.
   → Deletion stops when you slide off. No haptic continues.
4. Hold backspace and, without releasing, press the Home bar / swipe up to leave the app.
   Wait ten seconds, come back, and put the cursor in the field again.
   → No further deletion, and no haptics. This is the case the simulator reproduced; on
   device it is the one that matters.
5. Hold backspace in an **empty** field for three seconds.
   → Nothing to delete. You should still feel a tap on each repeat tick here, because the
   deletion is issued into a live field — see "Not comfortable with" below, this is the
   one point I would like your judgement on.
6. Start a dictation, let it insert text, then hold backspace on the result.
   → Deletion behaves as in step 2. No stuck haptics afterwards, during the ten minutes
   the engine stays warm.
7. Do a dictation, then leave the phone alone for a few minutes with the keyboard
   dismissed.
   → No haptics at any point. #293 is what makes them come and go, and it is not fixed
   here; if you feel a burst returning on a recording, export the log and grep
   `keyRepeat` — a `keyRepeatStarted` with no matching `keyRepeatStopped` is the
   runaway, and its absence means the burst is something else.

## What changed and why

`GiellaKeyboardView` scheduled its backspace auto-repeat with
`Timer.scheduledTimer(timeInterval:target:selector:…)`. A scheduled `Timer` is retained
by its run loop *and* retains its target, so the run loop kept the whole view alive. The
timer's only guard is `activeKey != nil`, and `activeKey` was cleared by `touchesEnded`
and `touchesCancelled` and by nothing else — so a view torn down mid-hold kept a
populated `activeKey` and a live timer, with no touch left that could ever stop it.

Two shapes fall out of that, and only the first was reported:

- **Controller gone.** The bridge dies with it, the view's `delegate` is nil, so nothing
  is deleted — and the tick fired its haptic anyway, unconditionally. That is the
  reported symptom, verbatim.
- **Controller alive.** `reloadKeyboardLayout()` replaces the view but keeps the same
  controller and the same bridge. The dropped view's weak `delegate` still points at that
  live bridge with a live proxy, and past ten ticks it calls `didTriggerHoldKey` →
  word-level deletion into the user's document, forever. That is open question 2,
  answered from the code.

Four changes:

1. `makeKeyRepeatTimer` uses the block form with `[weak self]`, matching the sibling
   `dismissOverlayTimer` two lines above. When the view is gone the block invalidates the
   timer and logs `keyRepeatStopped reason=viewDeallocated`.
2. `cancelKeyRepeat(reason:)` gives the repeat an owner that dies with the controller. It
   is called from `viewDidDisappear`, from `reloadKeyboardLayout` before the old view is
   dropped, from `deinit`, and by the view itself from `willMove(toWindow:)` whenever it
   leaves its window — which covers every teardown path, including ones nobody has
   enumerated.
3. The tick's haptic and click now follow the deletion instead of the tick. A new
   delegate requirement, `didTriggerRepeat(_:wordMode:) -> Bool`, performs the deletion
   and reports whether one was issued; the bridge returns false when there is no proxy
   left to delete into.
4. Two log events, `keyRepeatStarted` and `keyRepeatStopped(ticks:reason:)`. Neither
   carries a key or a character — only backspace auto-repeats, so naming the key would
   add nothing and would open the door `keyboardTextInserted` keeps shut.

`keyRepeatStarted` is logged on the first tick, after the 0.5 s pause, not when the timer
is scheduled: every backspace *tap* schedules the same timer, and two lines per keystroke
would bury the signal in a 1 MB log whose reader is an agent (#255).

`KeyboardView.swift` is vendored; the diff stays inside the four points above. The
declared height constraint is untouched.

## Acceptance criteria

**1. The repeat timer cannot outlive the view that scheduled it — no strong `target: self`.**
✅ `grep -n "target: self" DictusKeyboard/Vendored/Views/KeyboardView.swift` returns one
line, `170`, the pre-existing `UILongPressGestureRecognizer` — owned by the view, not by a
run loop. The timer is now `Timer.scheduledTimer(withTimeInterval:repeats:) { [weak self] … }`.

**2. The timer is invalidated on the controller's disappearance, not only on a touch ending.**
✅ Measured on an iOS 26.5 simulator, Dictus keyboard live in Safari with Full Access.
Holding backspace and pressing Home **without releasing** — so no `touchesEnded` ever
arrives — produced, three runs out of three:

```
[2026-08-25T12:31:21Z] DEBUG [keyboard] <KBD> keyRepeatStarted
[2026-08-25T12:31:22Z] DEBUG [keyboard] <KBD> keyRepeatStopped ticks=11 reason=windowDetached
```

Same scenario on `develop` (90c889a), three runs of each, identical text and identical
timings: **pre-fix deletes 15 characters every time, this branch deletes 11 every time**,
and this branch says in the log why it stopped. See "What stays unknown" for what this
does *not* show.

**3. The haptic and the click fire only when a deletion was actually issued.**
⚠️ Code path only. `keyRepeatTimerDidTrigger` now fires both inside
`if deleted { … }`, and the bridge returns `false` when `controller?.textDocumentProxy`
is nil. **Nothing in a build, a test or a simulator can observe a haptic** — this needs
step 5 of the manual list.

**4. A log event records the repeat timer starting and stopping, with its tick count.**
✅ Unit-tested in `DictusCore` (`KeyRepeatLogEventTests`, 6 tests: level, subsystem, name,
`ticks=` / `reason=` in the message, greppable formatted output, no key or character in
either case) and observed on device-shaped runs, above and here:

```
[2026-08-25T12:16:50Z] DEBUG [keyboard] <KBD> keyRepeatStarted
[2026-08-25T12:16:53Z] DEBUG [keyboard] <KBD> keyRepeatStopped ticks=30 reason=touch
```

**5. A held backspace still deletes at the same rate and still escalates to word deletion,
with one haptic and one click per deletion (#286 must not regress).**
⚠️ Half measured. A 3 s hold in a 27-character field logged `ticks=30` and emptied the
field, so the rate and the escalation past the ten-tick threshold both still work. **The
haptic and click counts cannot be observed anywhere but on a device** — step 2 of the
manual list.

## The three open questions

**1. Does it need a held backspace at all?** Yes, as your own comment concluded. Nothing
else in the file sets `activeKey`: it is written in `handleTouches` (from `touchesBegan`)
and in `touchesMoved`, and nowhere else. There is no second path.

**2. Can it delete for real?** **Yes, and this is the part worth knowing.** The `develop`
run above deleted 15 characters after the finger stopped mattering, four more than this
branch, repeatably. And in the code, `reloadKeyboardLayout()` keeps the controller and the
bridge while replacing the view: the dropped view's weak `delegate` still points at a live
bridge with a live proxy, and past ten ticks it is calling word-level deletion. The
reported episode had a dead proxy and destroyed nothing; that was luck, not design.

**3. Does it survive the extension process?** Already answered no, by you. Consistent with
everything here — the fix needs no cross-process or persisted state.

## What stays unknown

- **The simulator did not reproduce the unbounded runaway.** In both builds, deletion
  stopped once iOS suspended the extension, and nothing resumed when Safari came back.
  What is measured is the mechanism — ticks continuing after the view has left the window,
  with no touch able to stop them — and that this branch removes them. The unbounded
  version you felt needs a process that keeps living, which is the device.
- **Haptics are unobservable here.** Every haptic claim in this PR is a code-path claim.
- **#293 is untouched**, so the bursts stay. As #390 says, fixing this without #293 leaves
  the intermittency; the two are independent.

## Not comfortable with

**Empty field, live proxy.** Criterion 3 says the haptic fires only when "a deletion was
actually issued". I read that as *issued*, and gated on the proxy being reachable — the
measured failure mode. I deliberately did **not** also gate on the document being
non-empty. Gating on `documentContextBeforeInput` would silence a working backspace in
every host that withholds context (secure fields report none), and gating on `hasText`
trusts a host-implemented flag with a working backspace as the stake — both risk
regressing #286 to buy a case nobody reported. The consequence is step 5 of the manual
list: hold backspace in an empty field and you still feel taps. If you want that silent
too, say so and I will add the `hasText` gate; it is three lines.

**No heartbeat on a long repeat.** A runaway is diagnosed here by a `keyRepeatStarted`
with no matching stop — diagnosis by absence, which is the shape of evidence that made
#390 unfalsifiable in the first place. A periodic line carrying the running tick count
would make it positive instead. I left it out because criterion 4 asks for a start and a
stop and nothing more, and scope is yours to widen.

## Testing

- `cd DictusCore && swift test` — 1210 tests, 1 skipped, 0 failures.
- `swiftlint lint --strict` — 0 violations in 215 files. `DictusKeyboard/Vendored` is
  excluded from lint; the two linted files were clean before and after.
- `xcodebuild build -scheme DictusApp -destination 'platform=iOS Simulator,id=…'` after
  `patch-fluidaudio-swift5.sh build/DerivedData` — **BUILD SUCCEEDED**, which builds the
  embedded keyboard extension.
- Simulator run: iPhone 17 / iOS 26.5, Dictus keyboard enabled and granted Full Access,
  driven with `axe`, headless throughout. The device created for it has been deleted.

The vendored keyboard view is not reachable from `DictusCore`, so criteria 2, 3 and 5 have
no unit test and I have not invented one. What is testable there — the new log events — is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155NfNULhoE24Yz5dGPjFTo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic backspace repeat behavior, including character and word deletion modes.
  - Added feedback and diagnostic events for repeat start and stop activity.

- **Bug Fixes**
  - Prevented held backspace from continuing to delete after the keyboard closes, reloads, or is removed.
  - Improved cleanup of repeat timers and stale key states.
  - Ensured feedback is provided only when deletion succeeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->