### PR TITLE
Rebuild the audio engine when the input node latches a dead format (refs #123)

### DIFF
--- a/DictusApp/Audio/UnifiedAudioEngine.swift
+++ b/DictusApp/Audio/UnifiedAudioEngine.swift
@@ -423,22 +423,60 @@ class UnifiedAudioEngine: ObservableObject {
     /// tear down the engine here; that path is reserved for explicit interruptions.
     /// If the input route disappears entirely, the next recording attempt fails
     /// gracefully via the hwFormat guards in `startEngine()`.
+    /// - Note on what this line carries (issue #123): this handler describes the
+    ///   moment the dead-input-node fault is *created*, so it is the one line in the
+    ///   file a reader reaches for first, and it used to say almost nothing.
+    ///   `reason` printed raw (`AVAudioSessionRouteChangeReason(rawValue: 0)`), which
+    ///   sends the reader to a lookup table for the only genuinely diagnostic part of
+    ///   the field. `inputs=none` said what the route had become and never what it had
+    ///   been, which is exactly the question — what disappeared? And without
+    ///   `availableInputs`, "no input, nothing connected" and "no input while the
+    ///   built-in mic sits right there" read identically, though they are two
+    ///   different faults.
     private func handleRouteChange(_ note: Notification) {
         guard let userInfo = note.userInfo,
-              let raw = userInfo[AVAudioSessionRouteChangeReasonKey] as? UInt,
-              let reason = AVAudioSession.RouteChangeReason(rawValue: raw) else {
+              let raw = userInfo[AVAudioSessionRouteChangeReasonKey] as? UInt else {
             return
         }
 
-        let inputs = AVAudioSession.sharedInstance()
-            .currentRoute.inputs
-            .map { $0.portType.rawValue }
-            .joined(separator: ",")
+        // WHY the previous route comes from `userInfo` and not from a field we kept:
+        // AVAudioSession hands it to us in the notification and it is the only place
+        // it exists. Tracking it ourselves would mean holding a copy that is wrong for
+        // every route change that happens while the app is suspended.
+        let previous = (userInfo[AVAudioSessionRouteChangePreviousRouteKey] as? AVAudioSessionRouteDescription)
+            .map { portList($0.inputs) } ?? "unknown"
 
         PersistentLog.log(.audioRouteChanged(
-            reason: "\(reason)",
-            details: "inputs=\(inputs.isEmpty ? "none" : inputs)"
+            reason: Self.routeChangeReasonName(raw),
+            details: "previous=\(previous) \(routeStateDescription())"
         ))
+    }
+
+    /// The name of a route-change reason, with its raw value kept alongside.
+    ///
+    /// WHY both (issue #123): the eight case names are the whole diagnostic value of
+    /// the field, and the raw value is what survives a reason iOS adds after this
+    /// build shipped — an unmapped one now logs `unmapped(9)` instead of what the old
+    /// `guard let` did, which was to drop the line entirely and leave a route change
+    /// with no trace at all.
+    private static func routeChangeReasonName(_ raw: UInt) -> String {
+        guard let reason = AVAudioSession.RouteChangeReason(rawValue: raw) else {
+            return "unmapped(\(raw))"
+        }
+
+        let name: String
+        switch reason {
+        case .unknown: name = "unknown"
+        case .newDeviceAvailable: name = "newDeviceAvailable"
+        case .oldDeviceUnavailable: name = "oldDeviceUnavailable"
+        case .categoryChange: name = "categoryChange"
+        case .override: name = "override"
+        case .wakeFromSleep: name = "wakeFromSleep"
+        case .noSuitableRouteForCategory: name = "noSuitableRouteForCategory"
+        case .routeConfigurationChange: name = "routeConfigurationChange"
+        @unknown default: name = "unmapped"
+        }
+        return "\(name)(\(raw))"
     }
 
     /// AVAudioSession.mediaServicesWereReset handler. This is rare but brutal:
@@ -1074,17 +1112,18 @@ class UnifiedAudioEngine: ObservableObject {
     /// asked for a device that is gone".
     private func routeStateDescription() -> String {
         let session = AVAudioSession.sharedInstance()
-        let route = session.currentRoute.inputs
-            .map { $0.portType.rawValue }
-            .joined(separator: ",")
-        let available = (session.availableInputs ?? [])
-            .map { $0.portType.rawValue }
-            .joined(separator: ",")
-        let preferred = session.preferredInput?.portType.rawValue
+        return "route=\(portList(session.currentRoute.inputs))"
+            + " available=\(portList(session.availableInputs ?? []))"
+            + " preferred=\(session.preferredInput.map { $0.portType.rawValue } ?? "none")"
+    }
 
-        return "route=\(route.isEmpty ? "none" : route)"
-            + " available=\(available.isEmpty ? "none" : available)"
-            + " preferred=\(preferred ?? "none")"
+    /// Port types as one comma-separated token, or `none` for an empty list.
+    ///
+    /// Shared by `routeStateDescription()` and the route-change handler so the same
+    /// fact never gets two spellings in the log an agent has to scan (#255).
+    private func portList(_ ports: [AVAudioSessionPortDescription]) -> String {
+        let names = ports.map { $0.portType.rawValue }.joined(separator: ",")
+        return names.isEmpty ? "none" : names
     }
 
     /// Reset recording state without stopping the engine.

--- a/DictusApp/Audio/UnifiedAudioEngine.swift
+++ b/DictusApp/Audio/UnifiedAudioEngine.swift
@@ -29,7 +29,13 @@ enum AudioEngineError: Error, DiagnosableError {
     /// wrong one is worse than one that asserts nothing (#313 review).
     case phoneCallActive(evidence: String)
 
-    case audioHardwareUnavailable
+    /// The input node reported a format nothing can be recorded from, and it reported
+    /// it again from a node that had just been built (#123). The payload names which
+    /// half of the format was missing — `AudioInputFormatFailure.rawValue` — and is
+    /// diagnostic only, for the same reason `phoneCallActive` carries evidence: the
+    /// two ways to reach this are indistinguishable in a log that only says "the
+    /// hardware is unavailable".
+    case audioHardwareUnavailable(reason: String)
 
     /// `installTap` or `engine.start` raised an Objective-C exception. The payload is the
     /// exception's own text and is diagnostic only — it is an AVFoundation sentence that
@@ -67,8 +73,8 @@ enum AudioEngineError: Error, DiagnosableError {
             return "microphone permission not yet requested"
         case .phoneCallActive(let evidence):
             return "a call holds the microphone — \(evidence)"
-        case .audioHardwareUnavailable:
-            return "input node reports an unusable format after the retry"
+        case .audioHardwareUnavailable(let reason):
+            return "input node reports an unusable format after the engine rebuild — \(reason)"
         case .installTapFailed(let reason):
             return "installTap/engine.start raised: \(reason)"
         }
@@ -870,45 +876,35 @@ class UnifiedAudioEngine: ObservableObject {
         lastWaveformWrite = 0
         lastWaveformDiagnosticsWrite = 0
 
-        let inputNode = engine.inputNode
-        var hwFormat = inputNode.outputFormat(forBus: 0)
-
-        // Guard: zero-channel format means hardware is unavailable (phone call active)
-        guard hwFormat.channelCount > 0 else {
-            throw AudioEngineError.phoneCallActive(evidence: "input node reports zero channels")
-        }
-
-        // B.2 — One-shot retry when hardware reports a valid channel count but
-        // sampleRate == 0. Seen on wake-from-URL-scheme: setActive(true) returns
-        // success but the input node hasn't finished negotiating the format.
-        // installTap throws `IsFormatSampleRateAndChannelCountValid` NSException
-        // in that window, causing SIGABRT (#102).
-        if hwFormat.sampleRate == 0 {
-            usleep(50_000)
-            hwFormat = inputNode.outputFormat(forBus: 0)
-        }
-
-        guard hwFormat.sampleRate > 0, hwFormat.channelCount > 0 else {
-            PersistentLog.log(.dictationFailed(
-                error: "invalid hwFormat: sr=\(hwFormat.sampleRate) ch=\(hwFormat.channelCount)"
-            ))
-            throw AudioEngineError.audioHardwareUnavailable
-        }
+        let (inputNode, hwFormat) = try resolveUsableInputFormat(context: context)
 
         // Guard: detect telephony audio route (phone call in progress)
         // WHY only check inputs for "telephony" (not builtInReceiver on outputs):
         // Without .defaultToSpeaker, iOS routes output to builtInReceiver by default.
         // That's normal operation, not a phone call indicator.
+        //
+        // Since #123 this is the ONLY site that produces the phone-call message. The
+        // zero-channel guard above used to throw it too, on the strength of a format
+        // that says nothing about telephony — see `resolveUsableInputFormat`.
         let currentRoute = AVAudioSession.sharedInstance().currentRoute
         let hasTelephony = currentRoute.inputs.contains {
             $0.portType.rawValue.lowercased().contains("telephony")
         }
         if hasTelephony {
+            PersistentLog.log(.dictationFailed(
+                error: "telephony input route active — \(routeStateDescription())"
+            ))
             throw AudioEngineError.phoneCallActive(evidence: "a telephony input route is active")
         }
 
         // Create converter from hardware format to 16kHz mono
         guard let conv = AVAudioConverter(from: hwFormat, to: targetFormat) else {
+            // Logged for the same reason as the guards above (#123): a start that
+            // fails here leaves no trace at all, and the format that could not be
+            // converted is the only thing that would explain it.
+            PersistentLog.log(.dictationFailed(
+                error: "no converter from sr=\(hwFormat.sampleRate) ch=\(hwFormat.channelCount) to 16kHz mono"
+            ))
             throw NSError(domain: "UnifiedAudioEngine", code: 1,
                           userInfo: [NSLocalizedDescriptionKey: "Cannot create audio converter from \(hwFormat) to 16kHz mono"])
         }
@@ -964,6 +960,11 @@ class UnifiedAudioEngine: ObservableObject {
         }
         if let swiftStartError {
             inputNode.removeTap(onBus: 0)
+            // The last silent throw in this function before #123. AUIOClient_StartIO
+            // failures land here and left nothing in the log to date them by.
+            PersistentLog.log(.dictationFailed(
+                error: "engine.start failed: \((swiftStartError as NSError).localizedDescription)"
+            ))
             throw swiftStartError
         }
 
@@ -985,6 +986,105 @@ class UnifiedAudioEngine: ObservableObject {
         if #available(iOS 14.0, *) {
             DictusLogger.app.info("UnifiedAudioEngine started (hw: \(hwFormat.sampleRate, privacy: .public)Hz -> 16kHz)")
         }
+    }
+
+    /// Get an input node whose format can actually be recorded from, rebuilding the
+    /// engine once if the one we have reports a dead format.
+    ///
+    /// ### The bug (issue #123, three device captures)
+    ///
+    /// The audio session momentarily reports no input at all
+    /// (`audioRouteChanged details=inputs=none`). The input node, read in that window,
+    /// latches `sr=0.0 ch=2` — what `outputFormat(forBus:)` returns with no input
+    /// present. The route comes back a second later; the node keeps the dead format
+    /// for the life of the process. Every dictation after that failed, and the only
+    /// thing that ever cleared it was the user force-quitting the app.
+    ///
+    /// The old code answered `sr == 0` with a 50 ms sleep and a re-read of **the same
+    /// node**, which cannot work: the node is what is latched. `engine` was created
+    /// once and replaced in exactly one place — `handleMediaServicesReset()`, which
+    /// never fired in any of the three captures (`audioMediaServicesReset` count 0).
+    ///
+    /// So a dead format means "this engine is unusable", and the answer is a new one.
+    /// `replaceEngine()` is the media-services-reset rebuild, extracted; the 50 ms
+    /// settle stays because it is the separate #102 fix, for a node that has not
+    /// finished negotiating its format after a wake-from-URL-scheme `setActive(true)`.
+    /// A fresh node deserves that window just as much as the old one did.
+    ///
+    /// ### Why the loop terminates
+    ///
+    /// `AudioInputFormatPolicy.decide` returns `.rebuildEngine` only while
+    /// `hasRebuiltEngine` is false, and the only branch that does not return or throw
+    /// sets it to true. Pinned by `testAtMostOneRebuildIsEverAsked` in DictusCore.
+    ///
+    /// - Returns: the node the tap must be installed on — which is NOT necessarily
+    ///   `engine.inputNode` as read by the caller before this ran — and its format.
+    private func resolveUsableInputFormat(context: String) throws -> (AVAudioInputNode, AVAudioFormat) {
+        var node = engine.inputNode
+        var format = node.outputFormat(forBus: 0)
+        var hasRebuiltEngine = false
+
+        while true {
+            let decision = AudioInputFormatPolicy.decide(
+                channelCount: format.channelCount,
+                sampleRate: format.sampleRate,
+                hasRebuiltEngine: hasRebuiltEngine
+            )
+
+            switch decision {
+            case .proceed:
+                return (node, format)
+
+            case .rebuildEngine:
+                let before = "sr=\(format.sampleRate) ch=\(format.channelCount)"
+                replaceEngine()
+                hasRebuiltEngine = true
+                usleep(50_000)
+                node = engine.inputNode
+                format = node.outputFormat(forBus: 0)
+
+                // The trigger is sporadic and has no identified cause, so the next
+                // field occurrence has to be able to tell its own story: this line is
+                // what will say whether the rebuild is what unblocked the user.
+                PersistentLog.log(.diagnosticProbe(
+                    component: "UnifiedAudioEngine",
+                    instanceID: context,
+                    action: "engineRebuiltOnDeadFormat",
+                    details: "before=\(before) after=sr=\(format.sampleRate) ch=\(format.channelCount) \(routeStateDescription())"
+                ))
+
+            case .fail(let reason):
+                // A fresh node reporting a dead format is not a latch, it is an
+                // absence — the hardware is not there. `reason` names which half was
+                // missing; the user-facing sentence is the same either way (#313).
+                PersistentLog.log(.dictationFailed(
+                    error: "invalid hwFormat after engine rebuild: sr=\(format.sampleRate) ch=\(format.channelCount) reason=\(reason.rawValue) \(routeStateDescription())"
+                ))
+                throw AudioEngineError.audioHardwareUnavailable(reason: reason.rawValue)
+            }
+        }
+    }
+
+    /// What the audio session says about its inputs right now, for a log line.
+    ///
+    /// WHY all three fields (issue #123): the failure this file spent months not
+    /// explaining was a route that went empty and came back. `route` alone would have
+    /// shown the built-in mic by the time the guard ran and told the reader nothing;
+    /// `available` and `preferred` are what separate "nothing is connected" from "we
+    /// asked for a device that is gone".
+    private func routeStateDescription() -> String {
+        let session = AVAudioSession.sharedInstance()
+        let route = session.currentRoute.inputs
+            .map { $0.portType.rawValue }
+            .joined(separator: ",")
+        let available = (session.availableInputs ?? [])
+            .map { $0.portType.rawValue }
+            .joined(separator: ",")
+        let preferred = session.preferredInput?.portType.rawValue
+
+        return "route=\(route.isEmpty ? "none" : route)"
+            + " available=\(available.isEmpty ? "none" : available)"
+            + " preferred=\(preferred ?? "none")"
     }
 
     /// Reset recording state without stopping the engine.

--- a/DictusApp/Audio/UnifiedAudioEngine.swift
+++ b/DictusApp/Audio/UnifiedAudioEngine.swift
@@ -444,14 +444,7 @@ class UnifiedAudioEngine: ObservableObject {
         logHapticsAllowance(context: "mediaServicesReset")
 
         cancelIdleRelease()
-        engine.inputNode.removeTap(onBus: 0)
-        engine.stop()
-        // Bump generation BEFORE replacing the engine so any in-flight tap callbacks
-        // from the old engine see a stale generation and bail out instead of writing
-        // into shared audio-thread state and racing with the new engine's tap.
-        engineGeneration &+= 1
-        engine = AVAudioEngine()
-        converter = nil
+        replaceEngine()
         sessionConfigured = false
         isInterrupted = true
         isRecording = false
@@ -459,6 +452,32 @@ class UnifiedAudioEngine: ObservableObject {
 
         NotificationCenter.default.post(name: .dictusAudioSessionInterrupted, object: nil)
         DarwinNotificationCenter.post(DarwinNotificationName.audioSessionInterrupted)
+    }
+
+    /// Throw the current `AVAudioEngine` away and put a fresh one in its place.
+    ///
+    /// This is the only operation in the class that discards the input node, and
+    /// therefore the only one that can clear a format the node has latched. Extracted
+    /// from `handleMediaServicesReset()` for #123, where a dead input format needs
+    /// exactly this and nothing else.
+    ///
+    /// WHY the two callers are not the same call: the reset handler additionally tears
+    /// down `sessionConfigured`, raises `isInterrupted`, clears the recording flags and
+    /// posts both interruption notifications. None of that may happen inside
+    /// `startEngine()` — the flags in particular, because `forceRestart()` reaches
+    /// `startEngine()` in the middle of a live recording and clearing them there would
+    /// silently stop accumulating samples.
+    ///
+    /// The generation bump stays welded to the replacement: it must happen BEFORE the
+    /// new engine exists so any in-flight tap callback from the old one sees a stale
+    /// generation and bails out, instead of writing into shared audio-thread state and
+    /// racing the new engine's tap.
+    private func replaceEngine() {
+        engine.inputNode.removeTap(onBus: 0)
+        engine.stop()
+        engineGeneration &+= 1
+        engine = AVAudioEngine()
+        converter = nil
     }
 
     // MARK: - Session & Permissions (ported from AudioRecorder)

--- a/DictusCore/Sources/DictusCore/AudioInputFormatPolicy.swift
+++ b/DictusCore/Sources/DictusCore/AudioInputFormatPolicy.swift
@@ -1,0 +1,87 @@
+// DictusCore/Sources/DictusCore/AudioInputFormatPolicy.swift
+// What to do with the format an audio input node reports, before anything is built on it.
+import Foundation
+
+/// Why a dictation was refused after the input node reported an unusable format.
+///
+/// The two cases exist to be told apart in a log, not to be shown to anyone. They
+/// carry no user-facing text — #313 owns that layer, and both of these end up
+/// behind the same sentence there, because from the user's side they are the same
+/// event: the microphone is not available.
+public enum AudioInputFormatFailure: String, Equatable, Sendable {
+    /// The node reported no channels at all. Until #123 this threw the phone-call
+    /// error, which told the user a call held the microphone when nothing said so —
+    /// a zero-channel format means the hardware is unavailable for any reason.
+    case zeroChannelCount
+    /// The node reported channels but no sample rate. This is the signature #123 was
+    /// filed on, `sr=0.0 ch=2`: the format the node latches when it is read while the
+    /// session momentarily has no input at all.
+    case zeroSampleRate
+}
+
+/// What a caller should do with the format its audio input node just reported.
+public enum AudioInputFormatDecision: Equatable, Sendable {
+    /// The format is usable. Build the converter and install the tap on it.
+    case proceed
+    /// The format is dead. Throw the whole engine away, build a new one, and read the
+    /// format again from the new node. Returned at most once per start attempt — see
+    /// `AudioInputFormatPolicy.decide`.
+    case rebuildEngine
+    /// The format is dead and a fresh node reported it too. The hardware genuinely is
+    /// not there; give up and say which half of the format was missing.
+    case fail(AudioInputFormatFailure)
+}
+
+/// Decides whether an audio input format can be recorded from (issue #123).
+///
+/// ### Why this is in DictusCore and not next to the engine
+///
+/// Same reason as `IdleReleasePolicy`: `UnifiedAudioEngine` is `@MainActor` and owns a
+/// live `AVAudioEngine`, so nothing about its start path can be exercised from a test.
+/// This decision is pure — it reads two numbers and one bool — and it is the entire
+/// substance of the fix, so it is the part that has to be assertable.
+///
+/// ### The bug this encodes
+///
+/// Measured on device three times (2026-08-24, 2026-08-29, 2026-08-30): the audio
+/// session momentarily reports no input, the input node latches `sr=0.0 ch=2`, the
+/// route comes back a second later and the node keeps the dead format forever. Every
+/// dictation after that fails, and only force-quitting the app clears it — because the
+/// engine was created once and the only code that replaced it was the
+/// media-services-reset handler, which never fired in any of the three captures.
+///
+/// The old code re-read **the same node** after a 50 ms sleep, which cannot help: the
+/// node is what is latched. So a dead format means "this engine is unusable", not "the
+/// hardware is unavailable" — and the answer is a new engine.
+///
+/// ### Why exactly one rebuild
+///
+/// A second dead format from a node that has never been read before is not a latch, it
+/// is an absence. Retrying past that would spin against hardware that is not there
+/// while the user waits on a microphone tap.
+public enum AudioInputFormatPolicy {
+
+    /// - Parameters:
+    ///   - channelCount: `AVAudioFormat.channelCount` from the input node.
+    ///   - sampleRate: `AVAudioFormat.sampleRate` from the same format. A NaN — which
+    ///     no observed capture has produced, but which is representable — fails the
+    ///     `> 0` test and is treated as dead, which is the safe direction.
+    ///   - hasRebuiltEngine: whether this start attempt has already replaced the
+    ///     engine once. The caller owns that fact; this type only combines it.
+    public static func decide(
+        channelCount: UInt32,
+        sampleRate: Double,
+        hasRebuiltEngine: Bool
+    ) -> AudioInputFormatDecision {
+        if channelCount > 0 && sampleRate > 0 {
+            return .proceed
+        }
+        if !hasRebuiltEngine {
+            return .rebuildEngine
+        }
+        // Channels first when both are missing: a node with no channels has told us
+        // less than one with a channel count and no rate, and the reader of the log
+        // should see the more fundamental absence named.
+        return .fail(channelCount == 0 ? .zeroChannelCount : .zeroSampleRate)
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/AudioInputFormatPolicyTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/AudioInputFormatPolicyTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+@testable import DictusCore
+
+/// Coverage for the input-format decision behind the dead-input-node fix (issue #123).
+///
+/// These tests exist because `UnifiedAudioEngine.startEngine` cannot be unit-tested:
+/// it is `@MainActor`, owns a live `AVAudioEngine` and lives in the DictusApp target.
+/// The three-way decision below is the whole substance of the fix, so it is the part
+/// worth pinning down — especially since the failure it addresses cannot be reproduced
+/// on demand on a device.
+final class AudioInputFormatPolicyTests: XCTestCase {
+
+    // MARK: - proceed
+
+    func testHealthyFormatProceeds() {
+        // 48 kHz mono is what the built-in mic reports on every device Dictus runs on.
+        XCTAssertEqual(
+            AudioInputFormatPolicy.decide(channelCount: 1, sampleRate: 48000, hasRebuiltEngine: false),
+            .proceed
+        )
+    }
+
+    func testHealthyFormatProceedsAfterARebuild() {
+        // The point of the rebuild: the new node reports a usable format and recording
+        // goes ahead. Before #123 there was no path from a dead format to this outcome
+        // short of the user force-quitting the app.
+        XCTAssertEqual(
+            AudioInputFormatPolicy.decide(channelCount: 1, sampleRate: 48000, hasRebuiltEngine: true),
+            .proceed
+        )
+    }
+
+    // MARK: - rebuild
+
+    func testMeasuredDeadFormatAsksForARebuild() {
+        // The exact signature captured on device: `invalid hwFormat: sr=0.0 ch=2`.
+        XCTAssertEqual(
+            AudioInputFormatPolicy.decide(channelCount: 2, sampleRate: 0, hasRebuiltEngine: false),
+            .rebuildEngine
+        )
+    }
+
+    func testZeroChannelsAsksForARebuild() {
+        XCTAssertEqual(
+            AudioInputFormatPolicy.decide(channelCount: 0, sampleRate: 48000, hasRebuiltEngine: false),
+            .rebuildEngine
+        )
+    }
+
+    func testFullyEmptyFormatAsksForARebuild() {
+        XCTAssertEqual(
+            AudioInputFormatPolicy.decide(channelCount: 0, sampleRate: 0, hasRebuiltEngine: false),
+            .rebuildEngine
+        )
+    }
+
+    func testNaNSampleRateIsTreatedAsDead() {
+        // No capture has produced one, but it is representable and it must not slip
+        // through `> 0` into an AVAudioConverter.
+        XCTAssertEqual(
+            AudioInputFormatPolicy.decide(channelCount: 1, sampleRate: .nan, hasRebuiltEngine: false),
+            .rebuildEngine
+        )
+    }
+
+    // MARK: - fail
+
+    func testDeadSampleRateAfterTheRebuildFails() {
+        XCTAssertEqual(
+            AudioInputFormatPolicy.decide(channelCount: 2, sampleRate: 0, hasRebuiltEngine: true),
+            .fail(.zeroSampleRate)
+        )
+    }
+
+    func testZeroChannelsAfterTheRebuildFails() {
+        XCTAssertEqual(
+            AudioInputFormatPolicy.decide(channelCount: 0, sampleRate: 48000, hasRebuiltEngine: true),
+            .fail(.zeroChannelCount)
+        )
+    }
+
+    func testFullyEmptyFormatAfterTheRebuildNamesTheChannels() {
+        // Both halves are missing; the channel count is the one reported, because it is
+        // the more fundamental absence.
+        XCTAssertEqual(
+            AudioInputFormatPolicy.decide(channelCount: 0, sampleRate: 0, hasRebuiltEngine: true),
+            .fail(.zeroChannelCount)
+        )
+    }
+
+    func testNaNSampleRateAfterTheRebuildFails() {
+        XCTAssertEqual(
+            AudioInputFormatPolicy.decide(channelCount: 1, sampleRate: .nan, hasRebuiltEngine: true),
+            .fail(.zeroSampleRate)
+        )
+    }
+
+    // MARK: - the loop terminates
+
+    func testAtMostOneRebuildIsEverAsked() {
+        // The guarantee the call site depends on: feed the decision back to itself with
+        // `hasRebuiltEngine` set from the previous answer and it must reach a terminal
+        // outcome, never a second `.rebuildEngine`.
+        var hasRebuilt = false
+        var decisions: [AudioInputFormatDecision] = []
+        for _ in 0..<5 {
+            let decision = AudioInputFormatPolicy.decide(
+                channelCount: 2, sampleRate: 0, hasRebuiltEngine: hasRebuilt
+            )
+            decisions.append(decision)
+            if decision == .rebuildEngine { hasRebuilt = true }
+        }
+        XCTAssertEqual(decisions.filter { $0 == .rebuildEngine }.count, 1)
+        XCTAssertEqual(decisions.last, .fail(.zeroSampleRate))
+    }
+}


### PR DESCRIPTION
Implements the brief on #123 (comment of 2026-08-30). Part (A) of the issue body — "the AirPods microphone is not used" — stays closed by design (#85); nothing here touches the audio session category or its options, and no user-facing copy is added or changed (#313 owns that layer).

## What this was for

Three times now — 2026-08-24, 2026-08-29, 2026-08-30 — Dictus has stopped being able to record until the app was force-quit, and each time that cost a dictation in progress. Retapping the mic did not help. Closing and reopening the keyboard did not help. The app's own warm-up did not help. Only killing the process did.

The reason: the audio session momentarily reports that it has no input at all. The input node, read in that instant, latches `sr=0.0 ch=2` — the format `outputFormat(forBus:)` returns when there is no input present — and it keeps that dead format for the rest of the process, even after the route comes back to the built-in mic a second later. Every dictation after that fails on the same guard.

Nothing in-process could recover, because the code's answer to `sr == 0` was to sleep 50 ms and re-read **the same node**. The node is what is latched. The `AVAudioEngine` was created once at launch and replaced in exactly one place — the media-services-reset handler, which never fired in any of the three captures. So the only thing that discarded the poisoned node was the thing Pierre was doing by hand: killing the app.

This makes the app do it for him: a dead format now means "this engine is unusable" and gets one fresh engine.

## À tester à la main

**Ce que cette liste peut et ne peut pas être.** La panne n'est pas reproductible à la demande — `inputs=none` est sporadique et son déclencheur n'est pas identifié. Ce qui suit est donc un test de non-régression, plus la sonde qui prouvera le correctif la prochaine fois que la signature apparaîtra sur le terrain. **Le correctif n'est pas vérifié en conditions réelles et ne le sera pas avant cette prochaine occurrence.**

1. Installer la branche sur l'iPhone, lancer l'app, attendre que le modèle soit chargé. Attendu : aucun changement visible.
2. Dicter 3 fois de suite depuis l'app (bouton micro), phrases courtes. Attendu : les 3 transcriptions arrivent normalement.
3. Ouvrir le clavier Dictus dans Messages, dicter 3 fois de suite. Attendu : les 3 textes s'insèrent normalement.
4. Mettre l'app en arrière-plan, attendre 30 s, revenir, dicter. Attendu : la dictée démarre (moteur réchauffé au `didBecomeActive`).
5. Brancher des AirPods, écouter de la musique, dicter depuis le clavier. Attendu : **le micro de l'iPhone est utilisé, pas celui des AirPods** — c'est le comportement voulu (#85), pas un bug. La musique baisse de volume et reprend. Rien dans cette PR ne change ça.
6. Lancer un appel, le raccrocher, dicter tout de suite après. Attendu : la dictée démarre, ou échoue avec un message et repart au tap suivant.
7. Récupérer le log de debug et vérifier qu'il est **silencieux** : aucune ligne `engineRebuiltOnDeadFormat`, aucune ligne `invalid hwFormat`. Sur un appareil sain, le correctif ne doit rien faire du tout.
8. **La vraie preuve, plus tard.** Si la panne revient un jour, chercher dans le log :
   - `diagnosticProbe ... action=engineRebuiltOnDeadFormat` avec `before=sr=0.0 ch=2` et un `after=` valide → le correctif a fonctionné, la dictée est repartie toute seule.
   - `dictationFailed error=invalid hwFormat after engine rebuild:` → le nouveau nœud était mort aussi, le matériel n'était vraiment pas là. La ligne porte maintenant `route=`, `available=` et `preferred=`, ce qui manquait pour comprendre.

## What changed

**`DictusCore/AudioInputFormatPolicy.swift` (new)** — the decision as a pure function: given a channel count, a sample rate and whether a rebuild has already been tried, the outcome is `.proceed`, `.rebuildEngine` or `.fail(reason)`. In DictusCore for the reason `IdleReleasePolicy` is: `UnifiedAudioEngine` is `@MainActor` and holds a live `AVAudioEngine`, so its start path cannot be exercised from a test. That matters more than usual here, because the failure cannot be reproduced on a device — the unit test is the only place the rule can be shown to hold.

**`UnifiedAudioEngine.replaceEngine()` (extracted)** — the rebuild, lifted out of `handleMediaServicesReset()` unchanged: same five statements, same order, generation bump still before the replacement so in-flight tap callbacks from the old engine bail out instead of racing the new one. What stays behind in the handler is what must not run inside `startEngine()`: the session teardown, `isInterrupted`, the recording flags and the two notifications. The flags in particular — `forceRestart()` reaches `startEngine()` in the middle of a live recording, and clearing them there would silently stop accumulating samples.

**`UnifiedAudioEngine.resolveUsableInputFormat(context:)` (new)** — replaces the two format guards. One rebuild at most, then the format is read from the *new* node. The 50 ms settle stays, after the rebuild: it is the separate #102 fix for a node that has not finished negotiating after a wake-from-URL-scheme `setActive(true)`, and a fresh node deserves that window as much as the old one did.

**Logging.** Every throw site in `startEngine` now writes a `PersistentLog` line. Four wrote nothing at all before, which is why this bug spent months in the log as nothing but its symptom. The format and telephony sites carry the route state — `route=` / `available=` / `preferred=`.

**The mislabel is gone.** A zero-channel format used to throw `phoneCallActive`, telling the user a call held their microphone on the strength of a format that says nothing about telephony. It now routes to `audioHardwareUnavailable`; the genuine telephony test thirty lines below is the only producer of the phone-call message. Both formats already share #313's existing sentence, so no string was written.

## Acceptance

| Criterion | Status | Evidence |
|---|---|---|
| `sr == 0` causes exactly one rebuild, a valid format then proceeds | ✅ | `testMeasuredDeadFormatAsksForARebuild`, `testHealthyFormatProceedsAfterARebuild`, `testAtMostOneRebuildIsEverAsked` |
| A second dead format fails with a logged, correctly named reason | ✅ | `testDeadSampleRateAfterTheRebuildFails`, `testZeroChannelsAfterTheRebuildFails`; `dictationFailed error=invalid hwFormat after engine rebuild: … reason=…` |
| All throw sites in `startEngine` log, carrying the route state | ✅ | `routeStateDescription()` at the format and telephony sites; the converter and `engine.start` sites gained lines too |
| A zero-channel format no longer mentions a phone call | ✅ | `grep phoneCallActive` → one throw site left, the telephony one |
| The decision is a pure function in DictusCore with tests | ✅ | `swift test` → 1431 tests, 1 skipped, 0 failures (11 new) |
| A rebuild is visible in the log with the format before and after | ✅ | `diagnosticProbe component=UnifiedAudioEngine action=engineRebuiltOnDeadFormat details=before=… after=… route=…` |
| Recording still works on device, repeatedly, in-app and from the keyboard | ⏳ | Manual — steps above. Not run by an agent. |

## Verification run

```
xcodebuild -resolvePackageDependencies …            OK
./scripts/patch-fluidaudio-swift5.sh build/DerivedData   OK
xcodebuild build -scheme DictusApp …                ** BUILD SUCCEEDED **  (0 errors, 0 warnings; DictusApp + DictusKeyboard + DictusWidgets)
cd DictusCore && swift test                         1431 tests, 1 skipped, 0 failures
swiftlint lint --strict                             0 violations in 233 files
```

## One judgment call worth a reviewer's eye

The brief says "rebuild the engine in the `sr == 0` branch". I made the rebuild symmetric: `ch == 0` gets the same one rebuild before it fails. Reasons: the brief's own fail condition is "a fresh node still reports `sr == 0` **or `ch == 0`**"; both branches fail 100% today so neither can regress; and a single "dead format" predicate is what lets the decision function be one honest rule instead of two. The consequence the brief already accepted holds either way — a zero-channel format during a real call now reaches the "microphone not available" sentence instead of the phone-call one, because the telephony test is the only thing allowed to claim a call.

refs #123


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio startup recovery when the input format is invalid.
  * Added a single engine rebuild and retry before reporting a failure.
  * Audio hardware errors now include diagnostic details.
  * Phone-call errors are reported only when a telephony input route is detected.
  * Improved handling of media-services resets, route changes, and engine-start failures.

* **Tests**
  * Added coverage for valid, invalid, and unrecoverable audio input formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->