### PR TITLE
docs: split the bug backlog out of 1.8.1 into a 1.8.2

### DIFF
--- a/docs/RELEASE-PLAN.md
+++ b/docs/RELEASE-PLAN.md
@@ -11,8 +11,9 @@ Last reviewed: 2026-09-01.
 | | |
 | --- | --- |
 | App Store | **1.8.0 (build 27)**, live since 2026-08-28 |
-| Next App Store release | **1.8.1**, a PATCH: the Turbo model-preparation campaign |
-| Cycle after that | **2.0.0**, the Dictus Pro launch |
+| Next App Store release | **1.8.1**, a PATCH: the Turbo model-preparation fix, and nothing else |
+| Cycle after that | **1.8.2**, a PATCH: the bug backlog |
+| Then | **2.0.0**, the Dictus Pro launch |
 | `PremiumFlags.paywallVisible` | `false` |
 
 Build 28 was cut and archived, then abandoned: it still advertised Dictus Pro in the keyboard (#460). 1.8.1 ships as build 29 or later. Build numbers never repeat, so 28 is simply spent.
@@ -33,17 +34,31 @@ Reason to ship at all: 1.8.0 carries a model-preparation bug that a TestFlight t
 
 Fixed in the cycle: #405, #406, #408 (Turbo swapped to the 632 MB variant), #422, #426, #427, #428 (a stuck compile can no longer lock the user out of the app), #432, #433. Plus error copy (#313) and backspace cadence (#390, #419).
 
-Blocking: **#460**. Nothing else.
+Blocking: **#460**. Nothing else, and this is now an execution rule rather than a preference.
+
+1.8.0 ships a Turbo preparation bug that a tester hit and that every App Store user has. Every day 1.8.1 waits is a day that bug is live, so the cycle is closed the moment #460 is validated: **cut build 29 first, merge everything else after.** A fix that is ready but unreviewed does not join the cycle — it waits for the cut and ships in 1.8.2. This is what keeps 1.8.1 a one-fix release instead of a second campaign.
+
+In flight at the time of writing and therefore *not* in 1.8.1: #456 (PR #463, open), #449, #438.
 
 Not in it: **#417**, the `Failed to create tap due to format mismatch` failure, which is the second thing that tester reported. Still open, unfixed on every branch.
 
 It stays a PATCH because everything user-visible in it is a fix. Smart Modes and transcription history are merged but sit behind the flag, so no returning user sees anything new.
 
+## 1.8.2 — the bug backlog
+
+The release 1.8.1 deliberately does not carry. It exists because the open-bug count is high enough that holding those fixes until 2.0.0 would mean shipping the Pro launch on top of a year of unfixed reports.
+
+Fixes in flight when 1.8.1 was cut, in the order they are expected to land: **#456** (a French dictation polished into English), **#449** (the onboarding download restarts 445 MB after a backgrounding), **#438** (the download tripwire accepts an empty `.mlmodelc`). Then the triaged prod bugs: **#459**, **#458**, **#349** with **#455**, **#431**.
+
+Still a PATCH: every line of it is a fix, and `paywallVisible` stays `false` throughout.
+
+**#417** is not committed to this cycle either. It has no identified cause, only a rejected format the pre-flight guards accept. It joins 1.8.2 if a repro lands in time, and slips if it does not.
+
 ## 2.0.0 — the Pro launch
 
 MAJOR, per VERSIONING.md's own table: *premium launch, breaking UX shift*. Not 1.9.0. The version is chosen once, when 1.8.1 reaches the App Store, and then stays frozen across every TestFlight build of the campaign — 2.0.0 (30), 2.0.0 (31), and so on.
 
-**No App Store release between 1.8.1 and 2.0.0** unless a production bug forces one. 1.8.1 exists to fix Turbo; the next thing users see should be the finished product, not the build-out.
+**No App Store release between 1.8.2 and 2.0.0** unless a production bug forces one. The build-out should not be visible to users; the next thing they see after 1.8.2 should be the finished product.
 
 How the campaign runs:
 


### PR DESCRIPTION
## Why

1.8.0 carries a Turbo model-preparation bug that a TestFlight tester reported and that every App Store user has. The cost of holding 1.8.1 is measured in days that bug stays live, so the cycle closes on #460 and nothing else.

The plan already named #460 as the only blocker. What it did not say is what happens to a fix that becomes *ready* before the cut — and #456 (PR #463) is already open, with #449 and #438 behind it. Without a rule, they drift into 1.8.1 one merge at a time and turn a one-fix release into a second campaign.

## What changes

- **Execution rule in the 1.8.1 section**: cut build 29 the moment #460 is validated, merge everything else after. A fix that is ready but unreviewed waits for the cut.
- **New 1.8.2 section**: the bug backlog. #456, #449, #438 first, then the prod bugs today's triage routed — #459, #458, #349 with #455, #431. Still a PATCH, `paywallVisible` stays `false`.
- **#417** is not committed to 1.8.2 either: no identified cause, joins if a repro lands in time.
- The *no release between X and 2.0.0* rule moves from 1.8.1 to 1.8.2. The reason behind it was never the number — users should not watch the Pro build-out — and they now get their bug fixes first.

Documentation only. No code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155NfNULhoE24Yz5dGPjFTo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the release plan to add the 1.8.2 bug-fix cycle between versions 1.8.1 and 2.0.0.
  * Clarified the scope and release sequencing for version 1.8.1.
  * Documented fixes and triaged production issues planned for version 1.8.2.
  * Clarified that no App Store release is planned between versions 1.8.2 and 2.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->