### PR TITLE
Keep the load-state write synchronous while satisfying Swift 6 (refs #470)

### DIFF
--- a/DictusApp/LiveActivityManager.swift
+++ b/DictusApp/LiveActivityManager.swift
@@ -143,12 +143,20 @@ class LiveActivityManager {
         // End all Live Activities when the app is terminated (force-quit from app switcher).
         // WHY: Without this, the DI stays visible for up to 8 hours after a force-quit.
         // willTerminate fires reliably when the user swipes up in the app switcher.
+        //
+        // WHY `MainActor.assumeIsolated` and not `Task { @MainActor in }` (issue #470):
+        // this is the one observer here that cannot afford a hop at all. The process is
+        // being torn down, and `endAllActivitiesSync` drains its own `activity.end`
+        // calls with `RunLoop.current.run(until:)` precisely because there is no later
+        // turn to be had. Deferred work may simply never run, and the DI then survives
+        // the force-quit for hours — the exact failure this observer exists to prevent.
+        // `queue: .main` already confines the closure to the main thread.
         NotificationCenter.default.addObserver(
             forName: UIApplication.willTerminateNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.endAllActivitiesSync()
+            MainActor.assumeIsolated { self?.endAllActivitiesSync() }
         }
 
         // End the Live Activity when the audio session is interrupted (phone call,

--- a/DictusApp/Models/ModelManager.swift
+++ b/DictusApp/Models/ModelManager.swift
@@ -133,6 +133,17 @@ class ModelManager: ObservableObject {
            let state = ModelLoadState(rawValue: raw) {
             modelLoadState = state
         }
+        // WHY `MainActor.assumeIsolated` and not `Task { @MainActor in }`: the write
+        // has to land in the same run-loop turn as the post, because it is not the
+        // only consumer of that post. `ModelLoadingOverlay` observes the very same
+        // notification through a Combine publisher and its `checkForCompletion()`
+        // reads `modelManager.modelLoadState` back while the post is still being
+        // delivered. Deferring the write by a turn would hand that read the previous
+        // value, on the screen #428 is about escaping. `queue: .main` already makes
+        // this closure main-thread-only — measured for a post from either a main or a
+        // background thread — so there is no assumption here left to violate. The
+        // same reasoning, on the same API, is written out at
+        // `UnifiedAudioEngine.registerInterruptionObservers`.
         loadStateObserver = NotificationCenter.default.addObserver(
             forName: .dictusModelLoadStateChanged,
             object: nil,
@@ -140,7 +151,7 @@ class ModelManager: ObservableObject {
         ) { [weak self] note in
             guard let raw = note.userInfo?["state"] as? String,
                   let state = ModelLoadState(rawValue: raw) else { return }
-            self?.modelLoadState = state
+            MainActor.assumeIsolated { self?.modelLoadState = state }
         }
     }
 


### PR DESCRIPTION
refs #470

## What this was for

`ModelManager.swift:143` mutates `modelLoadState` from the `@Sendable` closure
`NotificationCenter` hands its observer. That is a warning today and a **compile error**
the day the targets move to Swift 6 language mode. The code is correct at runtime;
`queue: .main` guarantees what the compiler cannot read off an argument value.

The issue's real question was not how to silence it but **which of three fixes is safe on
this particular path**. `modelLoadState` is the property the model-loading UI renders from,
and it is the centre of #428 (a stuck load locked the user out of the whole app) and #144
(Turbo unreliability). Both are timing bugs on load-state transitions, so adding a
run-loop turn of latency there is a behaviour change, not a refactor — and one no unit
test would catch.

## The choice: `MainActor.assumeIsolated`, argued from evidence

**1. Can this observer ever be delivered off the main queue?** Measured, not assumed. I ran
the exact shape `addObserver(forName:object:queue: .main)` against a post from each side:

| post from | observer runs on | timing |
|---|---|---|
| main thread | `Thread.isMainThread == true` | **synchronously, inline, before `post` returns** |
| background thread | `Thread.isMainThread == true` | hopped to main |

The observer cannot be delivered off the main thread, so `assumeIsolated` has no assumption
left to violate. Corroborated by production: `UnifiedAudioEngine.registerInterruptionObservers`
(lines 306-327) already makes the identical call on the **harder** case — AVAudioSession
notifications, which AVFoundation posts off-main — and ships.

**2. Is the write synchronous today?** Yes. `.dictusModelLoadStateChanged` has exactly one
poster, `DictationCoordinator.setModelLoadState:1411`, on `@MainActor class
DictationCoordinator`. All 17 call sites are main-actor, so every post today is the inline
row of that table. The issue's premise was correct.

**3. Why `Task { @MainActor in }` is rejected — concretely, not by preference.**
`ModelLoadingOverlay.swift:133` observes the **same notification** through a Combine
publisher and calls `checkForCompletion()`, which reads the property straight back:

```swift
let preparationWasAlreadyReady = activeContext.isPrepareOnly
    && currentModelState == .ready
    && modelManager.modelLoadState == .ready   // ModelLoadingOverlay.swift:426
```

Two consumers, one post. Today `ModelManager` writes inline, so the overlay reads the new
value. A `Task` hop defers that write to a later turn and the overlay would read the
**previous** one — and `preparationWasAlreadyReady` decides whether the loading cover stays
up. That is the #428 lockout surface exactly.

**4. Why not `AsyncStream`/Combine.** It removes the `@Sendable` closure entirely but
rewrites the hand-off the #428 and #144 fixes sit on. The issue calls it "probably too much
for this issue alone"; agreed.

## Does this change *when* `modelLoadState` is observed to change?

**No — and this is the point of the choice.** `MainActor.assumeIsolated` executes its body
inline on the calling thread. The write happens at the same instruction, in the same
run-loop turn, in the same order relative to every other observer of that post as it did
before. The diff is a compile-time isolation annotation with no runtime scheduling effect.
Evidence: the measured delivery table above (nothing about delivery changes), the
single main-actor poster, and the semantics of `assumeIsolated` itself, which has no
enqueue path — contrast `Task`, which does.

## Second instance found in the sweep

`LiveActivityManager.swift:151` — `willTerminate` observer, `queue: .main`, calling
main-actor `endAllActivitiesSync()` directly. Different diagnostic text ("call to main
actor-isolated instance method in a synchronous nonisolated context"), identical shape.
Fixed the same way, and here a `Task` hop would not merely be slower but **wrong**:
`endAllActivitiesSync` drains its `activity.end` calls with `RunLoop.current.run(until:)`
precisely because the process is terminating and there is no later turn. Deferred work may
never run, and the Dynamic Island then outlives the force-quit by hours — the failure the
observer exists to prevent.

## Swept and deliberately left, with reasons

- `DictationCoordinator.swift:369, 398, 412` and `LiveActivityManager.swift:159, 173` —
  `queue: .main` + `Task { @MainActor in }`. No warning. Not on the load-state path;
  latency is irrelevant to a standby power-off, an interruption cleanup and a
  `didBecomeActive` log line. Changing them is scope creep.
- `UnifiedAudioEngine.swift:306/314/322` — already `assumeIsolated`. Correct.
- `GlobeKeyTutorialPage.swift:541` — selector-based `addObserver(_:selector:name:object:)`.
  No closure, so no `@Sendable` closure. Not this shape.
- **`DarwinNotificationCenter.addObserver`** (`DarwinNotifications.swift:89`) and its 8 call
  sites (`DictationCoordinator` 1042/1054/1066/1082/1090, `KeyboardState` 375/384/397).
  Its callback is `() -> Void`, **not** `@Sendable`, so it emits no warning and is not "a
  `@Sendable`-closure mutation of main-actor state". All 8 call sites already open with
  `DispatchQueue.main.async { }`, so all are correct at runtime. Marking the wrapper
  `@Sendable` would *add* a constraint and surface new diagnostics across 8 sites on the
  keyboard's critical path, unverifiable by the compiler until the targets actually move to
  Swift 6 mode. **Listed, not fixed** — it belongs to the Swift 6 migration, not to #470.

## Verification

**Warning count, clean build both sides** (fresh `-derivedDataPath`, FluidAudio patched per
#285), which is what the first acceptance criterion asks for:

```
grep -c "can not be mutated from a Sendable closure"
  before: 1     after: 0
grep -c "call to main actor-isolated instance method 'endAllActivitiesSync()'"
  before: 1     after: 0
```

Clean-vs-clean diff of every warning in `DictusApp`/`DictusKeyboard`/`DictusCore`/`DictusWidgets`
(26 -> 24): the only entries removed are those two. The only "new" line is
`LiveActivityManager.swift:716 switch must be exhaustive`, which is the pre-existing
warning from line 708 shifted by the 8 comment lines added above it.

- `xcodebuild build -scheme DictusApp` -> `** BUILD SUCCEEDED **` (builds the embedded
  keyboard, widgets and DictusCore)
- `cd DictusCore && swift test` -> **1485 tests, 0 failures**, 1 skipped
- `swiftlint lint --strict` -> **0 violations, 0 serious in 237 files**
- Installed and launched on a headless iPhone 17 Pro simulator, driven past onboarding:
  the app runs, no crash. This proves both observers **register** without trapping. It does
  **not** prove the load-state observer body ran — see below.

**What the simulator could not settle.** I could not force a real `modelLoadState`
transition from outside the process: `cfprefsd` hands the running app a cached snapshot of
the App Group defaults, so seeded values are not read (the app logged `modelReady=false`
while the plist on disk said `1`). So observer *delivery* is unproven at runtime here. What
stands in its place is the measured delivery table, the single main-actor poster, and the
identical `assumeIsolated` call shipping today in `UnifiedAudioEngine` against a harder case.

## To test by hand

1. **Launch the app normally on the iPhone.** *Expect:* it opens to the tab bar as usual, no
   crash. A wrong `assumeIsolated` would trap the instant the first load-state notification
   is delivered, so a normal launch that reaches the UI already exercises the fix.
2. **Trigger a real model load.** Settings -> Model -> select a model that is downloaded but
   not currently active. *Expect:* the preparation screen appears, shows progress, and
   dismisses by itself when the load finishes. No crash at any transition.
3. **Watch for added flicker or a stale frame** during that load — this is the #428 path and
   the one thing only your eyes can settle. *Expect:* identical to before this PR. The
   change is designed to be timing-neutral; anything that looks *different* is a finding and
   worth reporting.
4. **Export the debug log** (Settings -> hidden debug screen) and grep `modelLoadStateChanged`.
   *Expect:* the usual `loading` -> `ready` transitions, in the usual order, with no gaps.
   Check line 2 shows `rev` matching this branch.
5. **Force-quit from the app switcher while a Live Activity is showing** (start a dictation,
   swipe up to kill the app mid-flight). *Expect:* the Dynamic Island disappears immediately.
   This is the `LiveActivityManager` fix; a regression here would leave the pill on screen
   for hours. Not reproducible on a simulator — `simctl terminate` is a SIGKILL and does not
   fire `willTerminate`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when the app closes by ensuring active activities end synchronously.
  * Fixed model loading status updates so the loading overlay reflects changes immediately and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->