### PR TITLE
Detect a call carried on a bluetooth headset, and ask before resolving the format

### DIFF
--- a/DictusApp/Audio/UnifiedAudioEngine.swift
+++ b/DictusApp/Audio/UnifiedAudioEngine.swift
@@ -411,6 +411,26 @@ class UnifiedAudioEngine: ObservableObject {
             //    observer calls warmUp.
             //  - if user taps the keyboard mic, the cold-start dictation path
             //    starts the engine fresh.
+            // The interruption is over, so the flag that says one is in flight must say
+            // so — that is its documented meaning, and until #459 nothing here cleared
+            // it. The only clear was at the end of a successful `startEngine`, which was
+            // harmless while nothing read the flag before a start could finish.
+            //
+            // WHY it stopped being harmless (#459 review): the call guard now reads this
+            // flag *before* the engine starts, and refuses the start when it is raised.
+            // A flag that only a successful start can clear, gating a start, is a latch:
+            // guard refuses → the start never reaches the clear → the next tap refuses
+            // again, with nothing the user can do about it. Today iOS drops the HFP route
+            // when the call ends, so the other half of the guard's conjunction falls and
+            // the latch never closes — but that is iOS saving us, not us being correct.
+            //
+            // Clearing here does NOT resume anything: the engine stays cold on purpose,
+            // for the reason above. It says the audio layer is no longer degraded, which
+            // is true, and lets the next mic tap try. The clear in `startEngine` stays —
+            // it answers a different question (this start succeeded, so we are healthy)
+            // and covers the interruptions that never deliver an `.ended` at all.
+            isInterrupted = false
+
             // Either way, the warm-state contract matches reality and the orange
             // mic only appears when the user actually wants to record (issue #106).
             PersistentLog.log(.audioInterruptionEnded(shouldResume: shouldResume, restored: false))

--- a/DictusApp/Audio/UnifiedAudioEngine.swift
+++ b/DictusApp/Audio/UnifiedAudioEngine.swift
@@ -25,8 +25,10 @@ enum AudioEngineError: Error, DiagnosableError {
     case permissionUndetermined
 
     /// A call holds the microphone. The payload names which of the two signals said so —
-    /// the two sites disagree about the channel count, and a diagnostic that asserts the
-    /// wrong one is worse than one that asserts nothing (#313 review).
+    /// a telephony input route, or a bluetooth headset route during an interruption
+    /// (#459). Diagnostic only: a log that says nothing but "a call" cannot tell a
+    /// handset call from an AirPods one, and those are two different fixes if this
+    /// detection is ever wrong again.
     case phoneCallActive(evidence: String)
 
     /// The input node reported a format nothing can be recorded from, and it reported
@@ -914,26 +916,20 @@ class UnifiedAudioEngine: ObservableObject {
         lastWaveformWrite = 0
         lastWaveformDiagnosticsWrite = 0
 
-        let (inputNode, hwFormat) = try resolveUsableInputFormat(context: context)
-
-        // Guard: detect telephony audio route (phone call in progress)
-        // WHY only check inputs for "telephony" (not builtInReceiver on outputs):
-        // Without .defaultToSpeaker, iOS routes output to builtInReceiver by default.
-        // That's normal operation, not a phone call indicator.
+        // WHY this runs BEFORE the format is resolved (issue #459):
+        // it used to run thirty lines below, and that is why the AirPods case never
+        // reached it. A call takes the input hardware away, so the input node reports a
+        // dead format, so `resolveUsableInputFormat` threw `audioHardwareUnavailable`
+        // and returned — the call guard was never evaluated at all. Measured on device
+        // 2026-08-31: `engineRebuiltOnDeadFormat … route=BluetoothHFP` then
+        // `invalid hwFormat after engine rebuild`, and no phone-call line anywhere.
         //
-        // Since #123 this is the ONLY site that produces the phone-call message. The
-        // zero-channel guard above used to throw it too, on the strength of a format
-        // that says nothing about telephony — see `resolveUsableInputFormat`.
-        let currentRoute = AVAudioSession.sharedInstance().currentRoute
-        let hasTelephony = currentRoute.inputs.contains {
-            $0.portType.rawValue.lowercased().contains("telephony")
-        }
-        if hasTelephony {
-            PersistentLog.log(.dictationFailed(
-                error: "telephony input route active — \(routeStateDescription())"
-            ))
-            throw AudioEngineError.phoneCallActive(evidence: "a telephony input route is active")
-        }
+        // Asking "is a call holding this?" first is also the cheaper order: rebuilding
+        // a whole AVAudioEngine to chase a format a call is holding cannot succeed.
+        // Nothing about the #457 rebuild itself changes — only when it is reached.
+        try refuseIfACallHoldsTheMicrophone()
+
+        let (inputNode, hwFormat) = try resolveUsableInputFormat(context: context)
 
         // Create converter from hardware format to 16kHz mono
         guard let conv = AVAudioConverter(from: hwFormat, to: targetFormat) else {
@@ -1100,6 +1096,59 @@ class UnifiedAudioEngine: ObservableObject {
                 ))
                 throw AudioEngineError.audioHardwareUnavailable(reason: reason.rawValue)
             }
+        }
+    }
+
+    /// Refuse the start when a call holds the microphone, and say that it is a call.
+    ///
+    /// ### What was wrong (issue #459)
+    ///
+    /// The guard used to be one `contains("telephony")` on the input ports. **A call
+    /// carried over AirPods or any bluetooth headset does not present as `telephony`.
+    /// It presents as `BluetoothHFP`** — so for most people, on the majority of their
+    /// calls, the guard never fired. Until #457 that miss was hidden: a zero-channel
+    /// format threw `phoneCallActive` too, so the AirPods case reached the user with
+    /// the right message for the wrong reason. #457 corrected the mislabel, which left
+    /// this case telling the user the microphone is unavailable without saying that a
+    /// call is holding it — the one situation the user can actually act on.
+    ///
+    /// ### WHY only the inputs, and not `builtInReceiver` on the outputs
+    ///
+    /// Unchanged from the original guard: without `.defaultToSpeaker`, iOS routes
+    /// output to `builtInReceiver` by default. That is normal operation, not a call.
+    ///
+    /// The rule itself is `CallRoutePolicy` in DictusCore, because this method cannot
+    /// be tested — `@MainActor`, a live `AVAudioEngine`, and a simulator that has
+    /// neither a telephony route nor bluetooth audio. Since #123 this is the only site
+    /// in the file that produces the phone-call message.
+    private func refuseIfACallHoldsTheMicrophone() throws {
+        let session = AVAudioSession.sharedInstance()
+        let decision = CallRoutePolicy.decide(
+            inputPortTypes: session.currentRoute.inputs.map { $0.portType.rawValue },
+            isInterrupted: isInterrupted,
+            builtInMicrophoneIsAvailable: (session.availableInputs ?? [])
+                .contains { $0.portType == .builtInMic }
+        )
+
+        guard case .callHoldsMicrophone(let evidence) = decision else { return }
+
+        PersistentLog.log(.dictationFailed(
+            error: "a call holds the microphone: \(evidence.rawValue) — \(routeStateDescription())"
+        ))
+        throw AudioEngineError.phoneCallActive(evidence: Self.evidenceSentence(for: evidence))
+    }
+
+    /// The English fragment `AudioEngineError.phoneCallActive` carries into the log.
+    ///
+    /// Diagnostic only — never shown to anyone. It exists because the two signals are
+    /// indistinguishable in a log that only says "a call", and the reader of that log
+    /// is an agent (#255).
+    private static func evidenceSentence(for evidence: CallRouteEvidence) -> String {
+        switch evidence {
+        case .telephonyInputRoute:
+            return "a telephony input route is active"
+        case .headsetRouteDuringInterruption:
+            return "a bluetooth headset is the input route while the session is interrupted"
         }
     }
 

--- a/DictusCore/Sources/DictusCore/CallRoutePolicy.swift
+++ b/DictusCore/Sources/DictusCore/CallRoutePolicy.swift
@@ -1,0 +1,116 @@
+// DictusCore/Sources/DictusCore/CallRoutePolicy.swift
+// Whether a call is holding the microphone, read from the audio route rather than the port type alone.
+import Foundation
+
+/// What said a call holds the microphone.
+///
+/// The two cases exist to be told apart in a log, not to be shown to anyone. They carry
+/// no user-facing text — #313 owns that layer, and both end up behind the same sentence
+/// there, because from the user's side they are the same event: a call has the mic, and
+/// the remedy is to hang up or wait.
+public enum CallRouteEvidence: String, Equatable, Sendable {
+    /// A telephony port is the input route. This is the signal the guard has always
+    /// used, and it is a call on its own: nothing but a call routes input through
+    /// telephony. It matches a call carried on the handset or on a wired headset.
+    case telephonyInputRoute
+
+    /// A bluetooth hands-free port is the input route while an interruption is in
+    /// flight. This is the case #459 was filed on: a call carried over AirPods never
+    /// presents as `telephony`, it presents as `BluetoothHFP`, so the port type alone
+    /// missed what is, for most people, the majority of their calls.
+    case headsetRouteDuringInterruption
+}
+
+/// Whether the microphone is currently held by a call.
+public enum CallRouteDecision: Equatable, Sendable {
+    /// Nothing about the route says a call is in progress. Carry on starting the engine.
+    case noCall
+    /// A call holds the microphone. Refuse the dictation and say so, naming which signal
+    /// said it — the two are indistinguishable in a log that only says "a call".
+    case callHoldsMicrophone(CallRouteEvidence)
+}
+
+/// Decides whether a call holds the microphone, from the audio session state (issue #459).
+///
+/// ### Why the port type alone was not enough
+///
+/// `UnifiedAudioEngine.startEngine` used to decide this by looking for an input port
+/// whose type contains `telephony`. **A call carried over AirPods or any bluetooth
+/// headset does not present as `telephony`. It presents as `BluetoothHFP`.** So the
+/// guard never fired for it. Measured on device 2026-08-31, `rev 2af4d9a`, iPhone16,2,
+/// iOS 26.6.1, the maintainer on a call through AirPods:
+///
+/// ```
+/// 09:22:00  audioInterruptionBegan reason=…(0)
+/// 09:22:08  audioRouteChanged reason=…(8) details=inputs=BluetoothHFP
+/// 09:25:12  … route=BluetoothHFP available=MicrophoneBuiltIn preferred=none
+/// ```
+///
+/// ### Why an HFP route is not a call on its own
+///
+/// A headset can be the input route with no call in progress, so `BluetoothHFP` alone
+/// would misreport an ordinary headset as a call. The discriminator is the
+/// **interruption**: iOS interrupts our session when a call takes the audio hardware,
+/// and `isInterrupted` stays raised until a start succeeds, so it is still true minutes
+/// later when the user taps the mic — three minutes later, in the capture above.
+///
+/// ### Why the built-in microphone has to still be available
+///
+/// It is what separates the two messages. "A call holds your microphone, hang up or
+/// wait" is only true if there is a microphone to get back; if the mic we would fall
+/// back to is not even listed as available, the honest message is the hardware one.
+/// The other half of the fact the capture records — that the built-in mic is *not
+/// selected* — is already implied by the input route being the headset, so it is not
+/// asserted twice here.
+///
+/// ### Why this is in DictusCore and not next to the engine
+///
+/// Same reason as `AudioInputFormatPolicy` and `IdleReleasePolicy`: `UnifiedAudioEngine`
+/// is `@MainActor` and owns a live `AVAudioEngine`, so nothing about its start path can
+/// be exercised from a test. And this one can never be exercised on a simulator either —
+/// a simulator has neither a telephony route nor bluetooth audio — so a unit test is the
+/// only place the rule can be shown to hold at all.
+public enum CallRoutePolicy {
+
+    /// The port type a call over a bluetooth headset presents as.
+    ///
+    /// `AVAudioSession.Port.bluetoothHFP.rawValue`, spelled out rather than imported:
+    /// this type takes plain values so it stays testable without AVFoundation, and the
+    /// caller passes `portType.rawValue` straight through.
+    private static let bluetoothHandsFreePortType = "bluetoothhfp"
+
+    /// The substring that identifies a telephony input port.
+    ///
+    /// A substring rather than an equality test, kept exactly as the guard has always
+    /// spelled it: the telephony input port has no public `AVAudioSession.Port` constant
+    /// to compare against, so the original code matched on the word and this must not
+    /// narrow what it already caught.
+    private static let telephonyPortTypeFragment = "telephony"
+
+    /// - Parameters:
+    ///   - inputPortTypes: `portType.rawValue` for every port in
+    ///     `AVAudioSession.sharedInstance().currentRoute.inputs`.
+    ///   - isInterrupted: whether an AVAudioSession interruption is currently in flight,
+    ///     as the engine tracks it. The caller owns that fact; this type only combines it.
+    ///   - builtInMicrophoneIsAvailable: whether the built-in microphone is listed in
+    ///     `availableInputs`. Only consulted for the headset case — a telephony route is
+    ///     a call whether or not anything else is reachable.
+    public static func decide(
+        inputPortTypes: [String],
+        isInterrupted: Bool,
+        builtInMicrophoneIsAvailable: Bool
+    ) -> CallRouteDecision {
+        let types = inputPortTypes.map { $0.lowercased() }
+
+        if types.contains(where: { $0.contains(telephonyPortTypeFragment) }) {
+            return .callHoldsMicrophone(.telephonyInputRoute)
+        }
+
+        let hasHandsFreeRoute = types.contains(bluetoothHandsFreePortType)
+        if hasHandsFreeRoute && isInterrupted && builtInMicrophoneIsAvailable {
+            return .callHoldsMicrophone(.headsetRouteDuringInterruption)
+        }
+
+        return .noCall
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/CallRoutePolicyTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/CallRoutePolicyTests.swift
@@ -1,0 +1,185 @@
+import XCTest
+@testable import DictusCore
+
+/// Coverage for the call detection behind the AirPods-call fix (issue #459).
+///
+/// These tests carry more than usual, because this rule cannot be checked anywhere else:
+/// `UnifiedAudioEngine.startEngine` is `@MainActor`, owns a live `AVAudioEngine` and
+/// lives in the DictusApp target, and a simulator has neither a telephony route nor
+/// bluetooth audio. On device, reproducing it costs a real phone call. So this suite is
+/// the only place the two halves of the rule — a headset call is a call, a headset alone
+/// is not — are asserted at all.
+final class CallRoutePolicyTests: XCTestCase {
+
+    /// The raw values `AVAudioSession` reports, as they appear in the device log lines
+    /// this fix was written from (`route=BluetoothHFP available=MicrophoneBuiltIn`).
+    private enum Port {
+        static let bluetoothHandsFree = "BluetoothHFP"
+        static let builtInMic = "MicrophoneBuiltIn"
+        static let bluetoothA2DP = "BluetoothA2DPOutput"
+        static let wiredHeadset = "HeadsetMicrophone"
+    }
+
+    // MARK: - The case the issue was filed on
+
+    func testTheMeasuredAirPodsCallIsDetectedAsACall() {
+        // Device session 2026-08-31, rev 2af4d9a, iPhone16,2, iOS 26.6.1: the maintainer
+        // was on a call through AirPods and tapped the mic. Before this fix the guard saw
+        // no `telephony` port and let the start proceed into a hardware-unavailable error.
+        XCTAssertEqual(
+            CallRoutePolicy.decide(
+                inputPortTypes: [Port.bluetoothHandsFree],
+                isInterrupted: true,
+                builtInMicrophoneIsAvailable: true
+            ),
+            .callHoldsMicrophone(.headsetRouteDuringInterruption)
+        )
+    }
+
+    // MARK: - A headset that is merely the route is not a call
+
+    func testAHandsFreeRouteWithNoInterruptionIsNotACall() {
+        // The criterion that stops this fix being a false-positive machine: a headset can
+        // be the input route with nothing holding it. Only the interruption says a call.
+        XCTAssertEqual(
+            CallRoutePolicy.decide(
+                inputPortTypes: [Port.bluetoothHandsFree],
+                isInterrupted: false,
+                builtInMicrophoneIsAvailable: true
+            ),
+            .noCall
+        )
+    }
+
+    func testAnInterruptionWithNoHandsFreeRouteIsNotACall() {
+        // Siri, an alarm, another app taking the session: the engine is interrupted with
+        // the built-in mic still the route. Nothing here says a call, so nothing claims one.
+        XCTAssertEqual(
+            CallRoutePolicy.decide(
+                inputPortTypes: [Port.builtInMic],
+                isInterrupted: true,
+                builtInMicrophoneIsAvailable: true
+            ),
+            .noCall
+        )
+    }
+
+    func testAHandsFreeRouteWithNoBuiltInMicrophoneToFallBackOnIsNotReportedAsACall() {
+        // "A call holds your microphone, hang up or wait" promises a microphone to get
+        // back. With none listed as available, the hardware message is the truer one.
+        XCTAssertEqual(
+            CallRoutePolicy.decide(
+                inputPortTypes: [Port.bluetoothHandsFree],
+                isInterrupted: true,
+                builtInMicrophoneIsAvailable: false
+            ),
+            .noCall
+        )
+    }
+
+    func testAnA2DPHeadsetIsNotAHandsFreeRoute() {
+        // What #85 leaves us in normally: AirPods as an A2DP output, capture on the
+        // iPhone's own mic. `contains` on the port list must not match this on the
+        // shared "Bluetooth" prefix.
+        XCTAssertEqual(
+            CallRoutePolicy.decide(
+                inputPortTypes: [Port.bluetoothA2DP, Port.builtInMic],
+                isInterrupted: true,
+                builtInMicrophoneIsAvailable: true
+            ),
+            .noCall
+        )
+    }
+
+    // MARK: - The telephony route, unchanged
+
+    func testATelephonyRouteIsACallOnItsOwn() {
+        // What the guard has always caught: a call on the handset or a wired headset.
+        // No interruption term — nothing but a call routes input through telephony.
+        XCTAssertEqual(
+            CallRoutePolicy.decide(
+                inputPortTypes: ["Telephony"],
+                isInterrupted: false,
+                builtInMicrophoneIsAvailable: true
+            ),
+            .callHoldsMicrophone(.telephonyInputRoute)
+        )
+    }
+
+    func testATelephonyRouteIsACallEvenWithNoBuiltInMicrophoneAvailable() {
+        XCTAssertEqual(
+            CallRoutePolicy.decide(
+                inputPortTypes: ["Telephony"],
+                isInterrupted: false,
+                builtInMicrophoneIsAvailable: false
+            ),
+            .callHoldsMicrophone(.telephonyInputRoute)
+        )
+    }
+
+    func testTelephonyMatchingIsCaseInsensitiveAndPartial() {
+        // The original guard was `portType.rawValue.lowercased().contains("telephony")`.
+        // This fix widens the detection; it must not narrow what was already caught, and
+        // the telephony input port has no public constant to compare against.
+        XCTAssertEqual(
+            CallRoutePolicy.decide(
+                inputPortTypes: ["AVAudioSessionPortTelephonyReceiver"],
+                isInterrupted: false,
+                builtInMicrophoneIsAvailable: true
+            ),
+            .callHoldsMicrophone(.telephonyInputRoute)
+        )
+    }
+
+    func testTelephonyWinsOverAHandsFreeRoute() {
+        // Both present: the stronger signal names the evidence, so a log reader is not
+        // told a headset explained something telephony already explained.
+        XCTAssertEqual(
+            CallRoutePolicy.decide(
+                inputPortTypes: [Port.bluetoothHandsFree, "Telephony"],
+                isInterrupted: true,
+                builtInMicrophoneIsAvailable: true
+            ),
+            .callHoldsMicrophone(.telephonyInputRoute)
+        )
+    }
+
+    // MARK: - Ordinary states
+
+    func testTheBuiltInMicrophoneAloneIsNotACall() {
+        XCTAssertEqual(
+            CallRoutePolicy.decide(
+                inputPortTypes: [Port.builtInMic],
+                isInterrupted: false,
+                builtInMicrophoneIsAvailable: true
+            ),
+            .noCall
+        )
+    }
+
+    func testAWiredHeadsetMicrophoneIsNotACall() {
+        // A wired headset is an ordinary input route. A call on one presents as telephony,
+        // which the first rule catches; the headset port itself claims nothing.
+        XCTAssertEqual(
+            CallRoutePolicy.decide(
+                inputPortTypes: [Port.wiredHeadset],
+                isInterrupted: true,
+                builtInMicrophoneIsAvailable: true
+            ),
+            .noCall
+        )
+    }
+
+    func testAnEmptyRouteIsNotACall() {
+        // `inputs=none` is the #123 signature, and it is a hardware absence, not a call.
+        // The guard must leave it to `AudioInputFormatPolicy` to explain.
+        XCTAssertEqual(
+            CallRoutePolicy.decide(
+                inputPortTypes: [],
+                isInterrupted: true,
+                builtInMicrophoneIsAvailable: false
+            ),
+            .noCall
+        )
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/CallRoutePolicyTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/CallRoutePolicyTests.swift
@@ -182,4 +182,110 @@ final class CallRoutePolicyTests: XCTestCase {
             .noCall
         )
     }
+
+    // MARK: - The flag this policy reads must not be able to latch
+
+    /// The defect the #459 review caught, as a tripwire.
+    ///
+    /// This policy is pure and cannot latch: feed it `isInterrupted: false` and it
+    /// answers `.noCall`, as the tests above show. The latch was in the *caller*. The
+    /// engine's `isInterrupted` is documented as "an interruption is currently in
+    /// flight", but the interruption-ended handler never cleared it — the only clear was
+    /// at the end of a **successful** `startEngine`. Since #459 the guard reads that flag
+    /// before the start, so a raised flag refuses the start, and a refused start never
+    /// reaches the clear. The user cannot get out of it by tapping again.
+    ///
+    /// Nothing saves that but iOS dropping the HFP route when the call ends, which is
+    /// luck rather than design — so the clear that does not depend on a successful start
+    /// is checked here, at source level, because there is nowhere else it can be checked:
+    /// `UnifiedAudioEngine` is `@MainActor`, owns a live `AVAudioEngine`, and lives in a
+    /// target with no test bundle. Extracting the flag's four writes into a pure
+    /// event-to-Bool mapping would move a `switch` into this package and let a test
+    /// restate it, which would assert nothing this does not.
+    ///
+    /// The pattern — resolving a repo path from `#filePath` rather than copying source
+    /// into test resources — is `DictationErrorCopyTests`', for the reason it gives: a
+    /// copy would drift, and drift is the failure being checked for. Brittle by nature;
+    /// if a refactor moves this clear, read the message and decide deliberately.
+    func testTheInterruptionEndedHandlerClearsTheFlagThisPolicyIsGivenAsLive() throws {
+        let source = try engineSource()
+        let handler = try XCTUnwrap(
+            Self.body(ofFunction: "handleInterruption", in: source),
+            "handleInterruption not found in \(Self.enginePath) — this tripwire has gone blind"
+        )
+        let ended = try XCTUnwrap(
+            handler.range(of: "case .ended:").map { String(handler[$0.upperBound...]) },
+            "handleInterruption has no `case .ended:` branch any more"
+        )
+        let endedBranch = ended.components(separatedBy: "@unknown default:").first ?? ended
+
+        XCTAssertTrue(
+            endedBranch.contains("isInterrupted = false"),
+            """
+            The interruption-ended branch does not clear `isInterrupted`.
+            Since #459 the call guard refuses a start while that flag is raised, and a
+            refused start never reaches the clear at the end of `startEngine` — so the
+            flag latches and the user cannot recover by tapping again.
+            """
+        )
+    }
+
+    /// The other clear, which the #459 review asked to keep. It answers a different
+    /// question — this start succeeded, so the audio layer is healthy — and it is what
+    /// covers an interruption iOS never delivers an `.ended` for.
+    func testASuccessfulStartStillClearsTheFlagToo() throws {
+        let source = try engineSource()
+        let start = try XCTUnwrap(
+            Self.body(ofFunction: "startEngine", in: source),
+            "startEngine not found in \(Self.enginePath) — this tripwire has gone blind"
+        )
+        XCTAssertTrue(
+            start.contains("isInterrupted = false"),
+            "startEngine no longer clears `isInterrupted` on a successful start"
+        )
+    }
+
+    // MARK: - Source-level helpers
+
+    private static let enginePath = "DictusApp/Audio/UnifiedAudioEngine.swift"
+
+    private func engineSource(file: StaticString = #filePath, line: UInt = #line) throws -> String {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // DictusCoreTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // DictusCore
+            .deletingLastPathComponent()  // repo root
+        let url = root.appendingPathComponent(Self.enginePath)
+        guard let text = try? String(contentsOf: url, encoding: .utf8) else {
+            XCTFail("Source not found at \(url.path)", file: file, line: line)
+            throw CocoaError(.fileNoSuchFile)
+        }
+        return text
+    }
+
+    /// The text of one function, read by matching braces from its `{`.
+    ///
+    /// Brace counting rather than a line range: both functions below contain nested
+    /// closures and `switch` blocks, and a line-based read would stop at the first `}`.
+    /// String literals are tracked so a brace inside one cannot unbalance the count.
+    private static func body(ofFunction name: String, in source: String) -> String? {
+        guard let declaration = source.range(of: "func \(name)(") else { return nil }
+        guard let open = source.range(of: "{", range: declaration.upperBound..<source.endIndex) else { return nil }
+
+        var depth = 1
+        var index = open.upperBound
+        var inString = false
+
+        while index < source.endIndex, depth > 0 {
+            let character = source[index]
+            if character == "\"" { inString.toggle() }
+            if !inString {
+                if character == "{" { depth += 1 }
+                if character == "}" { depth -= 1 }
+            }
+            index = source.index(after: index)
+        }
+
+        return depth == 0 ? String(source[open.upperBound..<index]) : nil
+    }
 }


### PR DESCRIPTION
Implements #459. Nothing here touches the audio session category or its options (#85 stays), the #457 recovery path, or `preferredInput` (the issue's recorded open question).

## What this was for

When Pierre is on a call through AirPods and taps the Dictus mic, the app tells him the microphone is not available. It does not tell him a call is holding it — which is the one thing he can act on, by hanging up or waiting.

The reason is that the guard deciding "a call is in progress" looked for an input port type containing `telephony`. **A call carried over AirPods, or any bluetooth headset, never presents as `telephony`. It presents as `BluetoothHFP`.** So for most people, on the majority of their calls, the guard never fired.

Until #457 the miss was hidden by accident: a zero-channel format also threw `phoneCallActive`, so this case reached the user with the phone-call message — the label was wrong about its reason and right about the situation. #457 corrected the mislabel, which is right in general, and left this case with the worse message.

## À tester à la main

Le cœur du test n'a aucune forme headless : un simulateur n'a ni route téléphonie ni audio bluetooth. Rien de ce qui suit n'a été exécuté par un agent.

**A. Le cas de l'issue — un appel sur AirPods (le test principal)**

1. Installer cette branche sur l'iPhone, lancer l'app, attendre que le modèle soit chargé.
2. Mettre les AirPods, lancer un appel téléphonique (ou en recevoir un) et le prendre **sur les AirPods**.
3. Pendant l'appel, revenir sur Dictus (ou ouvrir le clavier Dictus dans Messages) et **taper le micro**.
4. Attendu : le message **« Le micro est occupé par un appel. Réessayez une fois l'appel terminé. »** (et non « Le micro n'est pas disponible pour le moment »). C'est le seul changement visible de toute la PR.
5. Raccrocher, puis taper le micro à nouveau. Attendu : la dictée démarre normalement (c'est la reprise de #457, inchangée ici).
6. Récupérer le log de debug et chercher :
   `dictationFailed error=a call holds the microphone: headsetRouteDuringInterruption — route=BluetoothHFP available=MicrophoneBuiltIn preferred=none`
   Attendu : cette ligne est présente, et il n'y a **plus** de `engineRebuiltOnDeadFormat` ni de `invalid hwFormat after engine rebuild` pour ce tap — le moteur n'est plus reconstruit inutilement pendant un appel.

**B. Le faux positif à écarter — des AirPods sans appel**

7. Sans aucun appel : mettre les AirPods, écouter de la musique, ouvrir le clavier Dictus et dicter une phrase courte.
8. Attendu : la dictée démarre et le texte s'insère **normalement**. Aucun message d'appel. (Le micro utilisé reste celui de l'iPhone — c'est #85, voulu, rien ici ne le change.)
9. Répéter 2 ou 3 fois, y compris juste après avoir mis en pause puis relancé la musique.

**C. Non-régression du cas déjà couvert — un appel sans AirPods**

10. Lancer un appel **sur le haut-parleur / l'écouteur de l'iPhone** (sans AirPods), taper le micro Dictus.
11. Attendu : même message d'appel qu'en A. Dans le log, la ligne porte `telephonyInputRoute` au lieu de `headsetRouteDuringInterruption`.

**D. Non-régression générale (le chemin normal ne doit rien voir)**

12. Sans AirPods et sans appel : dicter 3 fois depuis l'app, puis 3 fois depuis le clavier dans Messages.
13. Mettre l'app en arrière-plan 30 s, revenir, dicter.
14. Attendu : tout fonctionne comme avant, et le log ne contient **aucune** ligne `a call holds the microphone`.

**E. Le cas limite que je n'ai pas pu écarter, à regarder si l'occasion se présente**

15. Déclencher Siri avec les AirPods aux oreilles, puis taper le micro Dictus pendant que Siri écoute.
16. Si le message d'appel apparaît, c'est le faux positif décrit plus bas ("Une imprécision assumée"). Ce n'est pas bloquant — la dictée échouait déjà dans cet état — mais ça mérite une ligne dans l'issue.

## What changed

**`DictusCore/Sources/DictusCore/CallRoutePolicy.swift` (new)** — the classification as a pure function, modelled on `AudioInputFormatPolicy` from #457. Given the input port types, whether an interruption is in flight, and whether the built-in mic is still listed as available, the outcome is `.noCall` or `.callHoldsMicrophone(evidence)`.

Two rules:
- a port type containing `telephony` is a call **on its own, unconditionally** — exactly today's predicate, kept as a substring match because the telephony input port has no public `AVAudioSession.Port` constant to compare against. This widens the detection; it removes nothing.
- otherwise a `BluetoothHFP` input port **and** an interruption in flight **and** the built-in mic available is a call.

On the three signals the issue names: the interruption is the discriminator that stops an ordinary headset being read as a call. The built-in mic being *available* is kept because it is what separates the two messages — "a call holds your microphone, hang up or wait" promises a microphone to get back, and if none is listed the hardware message is the truer one. The other half of that fact, that the built-in mic is *not selected*, is already implied by the input route being the headset, so it is not asserted twice.

**`UnifiedAudioEngine.startEngine` — the guard moved, not just widened.** This is the part of the fix the issue does not name, and without it a widened predicate would have changed nothing.

The guard ran *after* `resolveUsableInputFormat`. A call takes the input hardware away, so the node latches `sr=0.0 ch=2`, so #457's format guard threw `audioHardwareUnavailable` and returned — and the call test thirty lines below was never evaluated. The issue's own capture shows exactly that: `engineRebuiltOnDeadFormat … route=BluetoothHFP` then `invalid hwFormat after engine rebuild`, and no phone-call line anywhere.

So the guard now runs first. Nothing inside `resolveUsableInputFormat` or `replaceEngine()` changes — only when they are reached, and not reaching them during a call is the better order anyway: rebuilding a whole `AVAudioEngine` to chase a format a call is holding cannot succeed.

**No user-facing string was written.** `AudioEngineError.phoneCallActive` already carries #313's sentence ("The microphone is busy on a call. Try again once the call ends.", translated in `Localizable.xcstrings`). Reusing the case is precisely what puts the AirPods call behind it. The `evidence:` payload and the log line now name *which* signal fired, because a log that says only "a call" cannot tell a handset call from an AirPods one — and the reader of that log is an agent (#255).

## Acceptance

| Criterion | Status | Evidence |
|---|---|---|
| A call over a bluetooth headset is detected as a call, not as generic hardware unavailability | ✅ code / ⏳ device | `testTheMeasuredAirPodsCallIsDetectedAsACall` reproduces the captured signals exactly; the guard moved above the format resolution so it is now reached. Only step A above proves it end to end. |
| A headset that is merely the input route, with no call, is not misdetected as a call | ✅ code / ⏳ device | `testAHandsFreeRouteWithNoInterruptionIsNotACall`, `testAnA2DPHeadsetIsNotAHandsFreeRoute`, `testAWiredHeadsetMicrophoneIsNotACall`. Step B by hand. |
| The user is told a call is holding the microphone, using #313's message layer | ✅ | No new string: the existing `phoneCallActive` case is reused, `git diff origin/develop \| grep '^+.*String(localized'` → nothing. `DictationErrorCopyTests` still passes. |
| The audio session category and options are unchanged | ✅ | `git diff origin/develop -- DictusApp/Audio/UnifiedAudioEngine.swift \| grep -E '^[+-].*(setCategory\|allowBluetooth\|preferredInput)'` → no output. `setCategory` is still line 554, `.allowBluetoothA2DP, .defaultToSpeaker, .duckOthers`. |
| The detection is a pure function with tests, in DictusCore, following `AudioInputFormatPolicy` | ✅ | `DictusCore/Sources/DictusCore/CallRoutePolicy.swift`, 12 tests in `CallRoutePolicyTests`. |

## Verification run

```
cd DictusCore && swift test          1557 tests, 1 skipped, 0 failures (12 new)
swiftlint lint --strict              0 violations, 0 serious in 242 files
./scripts/patch-fluidaudio-swift5.sh build/DerivedData    OK
xcodebuild build -scheme DictusApp -destination 'platform=iOS Simulator,id=…'
                                     ** BUILD SUCCEEDED **  0 errors, no new warnings
                                     (DictusApp + DictusKeyboard + DictusWidgets + DictusCore)
```

`git status` after the build is clean — no `Localizable.xcstrings` churn, because no string was added.

## Une imprécision assumée

`isInterrupted` says "something took the audio session", not "a call took it". Combined with an HFP input route it is a very good proxy, but it is a proxy: if Siri is listening through the AirPods when the mic is tapped, this will say a call holds the microphone. The dictation failed in that state before this change too, so nothing new breaks — only the sentence is slightly wrong, and it still tells the user the true actionable thing (something else has the mic, wait).

CallKit's `CXCallObserver` would answer the question outright, for telephony **and** VoIP calls, with no proxy. I did not reach for it: it adds a framework to the app target for one boolean, it is well outside what the issue asks for, and the issue is explicit that the classification should be a pure tested function over the signals we already log. Worth an issue if the proxy is ever seen misfiring.

refs #459


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved phone-call detection while recording.
  - Calls routed through Bluetooth hands-free headsets are now detected more reliably.
  - Reduced the risk of recording microphone audio while a phone call is using the microphone.
  - Improved handling of interruptions and available microphone routes when determining call status.

- **Tests**
  - Added coverage for telephony, Bluetooth headset, wired headset, and interruption scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->