### PR TITLE
Never raise a model preparation screen over a live dictation (refs #458)

### DIFF
--- a/DictusApp/Onboarding/ModelDownloadPage.swift
+++ b/DictusApp/Onboarding/ModelDownloadPage.swift
@@ -37,6 +37,15 @@ struct ModelDownloadPage: View {
     /// model manager.
     @State private var preparingModelID: String?
 
+    /// The same #458 gate `ModelManagerView` uses, for the same reactive pair below.
+    ///
+    /// Onboarding cannot overlap a dictation today — `OnboardingView` is a `switch` on
+    /// one page at a time and none of the pages before this one records. It is gated
+    /// anyway because the rule belongs to the screen, not to the flow that happens to
+    /// reach it, and because the comment on `liveActivePrepModel` promises this page
+    /// behaves identically to the model manager.
+    @State private var preparationGate = ModelPreparationGate()
+
     var body: some View {
         VStack(spacing: 0) {
             Spacer()
@@ -152,14 +161,10 @@ struct ModelDownloadPage: View {
             // Whether the model is already downloaded, and whether one is in flight.
             syncWithPreparationState()
             // If the user backgrounded the app mid-prep, surface the overlay again.
-            if preparingModelID == nil, let id = liveActivePrepModel {
-                preparingModelID = id
-            }
+            raisePreparationIfAllowed(liveActivePrepModel)
         }
         .onChange(of: liveActivePrepModel) { _, newValue in
-            if let id = newValue, preparingModelID == nil {
-                preparingModelID = id
-            }
+            raisePreparationIfAllowed(newValue)
         }
         // A download this page did not start can be in flight: a force quit during
         // onboarding leaves a transfer that `ModelManager` picks up on the next launch
@@ -187,6 +192,19 @@ struct ModelDownloadPage: View {
     /// Wrapper so `.fullScreenCover(item:)` works with a plain String identifier.
     private struct PreparingItem: Identifiable {
         let id: String
+    }
+
+    /// Raise the preparation screen for `liveModel`, unless #458's rule refuses it.
+    /// Mirrors `ModelManagerView.raisePreparationIfAllowed`, including reading the
+    /// status at the instant of the decision rather than observing it.
+    private func raisePreparationIfAllowed(_ liveModel: String?) {
+        if let id = preparationGate.modelToPresent(
+            liveModel: liveModel,
+            dictationStatus: DictationCoordinator.shared.status,
+            isPresenting: preparingModelID != nil
+        ) {
+            preparingModelID = id
+        }
     }
 
     /// First identifier currently in a user-facing prep phase. Mirrors the same

--- a/DictusApp/Views/MainTabView.swift
+++ b/DictusApp/Views/MainTabView.swift
@@ -32,6 +32,10 @@ struct MainTabView: View {
 
     /// Active model preparation requested by the keyboard without starting a
     /// recording. The overlay dismisses itself after its contextual ready state.
+    ///
+    /// Its three writers are all URL-driven, and the two that can fire while the process
+    /// is already alive are gated on #458's rule below. `init`'s launch-intent seed is
+    /// not: a process being launched has no dictation to interrupt.
     @State private var preparingModelID: String?
 
     /// The paywall, opened from the keyboard (#404).
@@ -167,6 +171,17 @@ struct MainTabView: View {
             guard let intent = KeyboardDictationURL.intent(from: url) else { return }
 
             if intent == .prepare {
+                // #458's rule applies here too. This overlay sits BELOW `RecordingView`
+                // in the ZStack above, so it could never be what replaced the recording
+                // screen — but raising it during a dictation would still leave the app
+                // showing a preparation screen the moment the dictation ended.
+                //
+                // A prepare URL arrives because the keyboard refused a mic tap while a
+                // load was in flight, so the app's own status is normally `.idle` here;
+                // this guard is about the case where it is not.
+                guard !ModelPreparationGate.dictationOwnsTheDisplay(coordinator.status) else {
+                    return
+                }
                 preparingModelID = activeModelIdentifier
                 return
             }
@@ -183,6 +198,13 @@ struct MainTabView: View {
             Self.hasHandledURL = true
         }
         .onReceive(NotificationCenter.default.publisher(for: .dictusKeyboardPreparationRequested)) { _ in
+            // Gated for the same reason as the `.prepare` branch above, and gated with
+            // it rather than instead of it: `DictusApp.handleIncomingURL` posts this
+            // notification for the very same `dictate?…prepare` URL that handler sees,
+            // so the two are one event and must not disagree about whether to answer it.
+            guard !ModelPreparationGate.dictationOwnsTheDisplay(coordinator.status) else {
+                return
+            }
             preparingModelID = activeModelIdentifier
         }
         .onChange(of: scenePhase) { _, newPhase in

--- a/DictusApp/Views/ModelManagerView.swift
+++ b/DictusApp/Views/ModelManagerView.swift
@@ -50,6 +50,16 @@ struct ModelManagerView: View {
     /// "ready" celebration moment after the model state flips back to .ready.
     @State private var preparingModelID: String?
 
+    /// Decides whether the overlay above may be raised at all (#458).
+    ///
+    /// This view's cover is a `.fullScreenCover`, which iOS presents at window level —
+    /// above the `RecordingView` that `MainTabView` puts in its `ZStack`. Once the user
+    /// has visited the Models tab, this body stays alive for the life of the process and
+    /// its `.onChange` keeps firing from whichever tab is frontmost, so a load starting
+    /// during a dictation covered the recording screen mid-sentence. The gate carries the
+    /// rule and the memory of a preparation it refused; see `ModelPreparationGate`.
+    @State private var preparationGate = ModelPreparationGate()
+
     // MARK: - Device snapshot
 
     /// Read once and reused by the Available section (issue #369).
@@ -296,15 +306,15 @@ struct ModelManagerView: View {
         // Issue #144: full-screen overlay during model download / compile / RAM-load.
         // We watch the live computed property and lift it into a @State binding the
         // overlay can flip back to nil when it's ready to dismiss.
+        //
+        // Issue #458 put a gate in front of both entry points: a preparation that starts
+        // while a dictation is on screen is not allowed to take the display, and is not
+        // replayed afterwards either.
         .onChange(of: liveActivePrepModel) { _, newValue in
-            if let id = newValue, preparingModelID == nil {
-                preparingModelID = id
-            }
+            raisePreparationIfAllowed(newValue)
         }
         .onAppear {
-            if preparingModelID == nil, let id = liveActivePrepModel {
-                preparingModelID = id
-            }
+            raisePreparationIfAllowed(liveActivePrepModel)
         }
         .fullScreenCover(item: Binding<PreparingModelItem?>(
             get: { preparingModelID.map(PreparingModelItem.init) },
@@ -325,6 +335,22 @@ struct ModelManagerView: View {
     /// Wrapper so we can use `.fullScreenCover(item:)` with a plain String.
     private struct PreparingModelItem: Identifiable {
         let id: String
+    }
+
+    /// Raise the preparation screen for `liveModel`, unless #458's rule refuses it.
+    ///
+    /// WHY the status is read here rather than observed through an `@EnvironmentObject`:
+    /// the gate answers a question about *this instant*, and the two callers are already
+    /// events. Observing the coordinator would re-evaluate this decision when the
+    /// dictation ends, which is precisely the delayed pop the rule forbids.
+    private func raisePreparationIfAllowed(_ liveModel: String?) {
+        if let id = preparationGate.modelToPresent(
+            liveModel: liveModel,
+            dictationStatus: DictationCoordinator.shared.status,
+            isPresenting: preparingModelID != nil
+        ) {
+            preparingModelID = id
+        }
     }
 
     // MARK: - Engine descriptions

--- a/DictusCore/Sources/DictusCore/ModelPreparationGate.swift
+++ b/DictusCore/Sources/DictusCore/ModelPreparationGate.swift
@@ -28,9 +28,18 @@ import Foundation
 /// string — so it lives where `swift test` can reach it.
 public struct ModelPreparationGate: Equatable, Sendable {
 
-    /// The preparation that was refused because a dictation held the display.
-    /// Cleared when that preparation ends, so the *next* one is judged on its own.
-    private var withheldModel: String?
+    /// Every preparation refused because a dictation held the display.
+    /// Emptied when preparation activity stops altogether, so the *next* one is judged
+    /// on its own.
+    ///
+    /// WHY A SET AND NOT ONE SLOT: `liveActivePrepModel` names a single model, but it can
+    /// name a different one from one moment to the next — a download of B while A is
+    /// prewarming makes it alternate. A single slot only remembered the last refusal, so
+    /// refusing A and then B left A unremembered, and A becoming the live preparation
+    /// again after the dictation ended would have been presented: the delayed pop this
+    /// type exists to prevent. Nothing distinguishes the two refusals, so nothing should
+    /// have to choose between them.
+    private var withheldModels: Set<String> = []
 
     public init() {}
 
@@ -61,18 +70,23 @@ public struct ModelPreparationGate: Equatable, Sendable {
         isPresenting: Bool
     ) -> String? {
         guard let liveModel else {
-            // No preparation in flight. Whatever was withheld is over, and a later
-            // preparation is a new event that gets judged on its own merits.
-            withheldModel = nil
+            // Nothing is preparing at all. Every refusal is over, and a later preparation
+            // is a new event that gets judged on its own merits.
+            //
+            // WHY this and not "forget a model once it stops being the live one": with
+            // two preparations in flight the live one alternates, so forgetting per model
+            // would clear a refusal while its load is still running. An empty
+            // `liveModel` is the one moment that says all of them are done.
+            withheldModels.removeAll()
             return nil
         }
         guard !Self.dictationOwnsTheDisplay(dictationStatus) else {
             // The load runs on regardless — it is only the screen that is refused.
-            withheldModel = liveModel
+            withheldModels.insert(liveModel)
             return nil
         }
-        // The dictation is over and this is still the load it started under.
-        guard withheldModel != liveModel else { return nil }
+        // The dictation is over and this is still a load it started under.
+        guard !withheldModels.contains(liveModel) else { return nil }
         guard !isPresenting else { return nil }
         return liveModel
     }

--- a/DictusCore/Sources/DictusCore/ModelPreparationGate.swift
+++ b/DictusCore/Sources/DictusCore/ModelPreparationGate.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// When a model preparation screen may take the display, and when it may not (#458).
+///
+/// WHY THIS EXISTS: the preparation screen is raised reactively by three views that all
+/// watch the same global `modelLoadState` flag, and none of them asked whether anything
+/// else was on screen. A dictation started inside DictusApp on a cold Core ML cache runs
+/// `startDictation`'s cold-start branch, which begins recording and *then* writes
+/// `modelLoadState = .loading` — so the load flips the flag while the microphone is live.
+/// `ModelManagerView`'s `.fullScreenCover` presents at window level, above the
+/// `RecordingView` that `MainTabView` puts in its `ZStack`, and the recording screen was
+/// replaced mid-sentence for the eleven seconds the load took. Measured on device
+/// 2026-08-30 and reproduced in the simulator; see the issue for both logs.
+///
+/// THE RULE: a preparation screen is never raised while a dictation is not idle, and a
+/// preparation withheld that way is never replayed once the dictation ends. Popping the
+/// screen when the user has just stopped talking and is watching their transcription
+/// arrive is the same lie one beat later.
+///
+/// WHY THE STATE, when the gate could have been a single `if`: the views raise the screen
+/// from `.onChange` *and* from `.onAppear`. `.onChange` alone would need no memory — a
+/// load withheld during a dictation does not change again when the dictation ends, so
+/// nothing re-fires. `.onAppear` does: switching to the Models tab re-asks the question,
+/// and by then the dictation is over and the load is still running. The latch is what
+/// makes the two entry points give the same answer.
+///
+/// Nothing here belongs to the app target — it is a decision about two booleans and a
+/// string — so it lives where `swift test` can reach it.
+public struct ModelPreparationGate: Equatable, Sendable {
+
+    /// The preparation that was refused because a dictation held the display.
+    /// Cleared when that preparation ends, so the *next* one is judged on its own.
+    private var withheldModel: String?
+
+    public init() {}
+
+    /// Whether a dictation currently owns what the user is looking at.
+    ///
+    /// WHY `!= .idle` and not `DictationSessionLivenessPolicy.isActive`: that policy
+    /// answers "is some process still driving this dictation", which is false for
+    /// `.ready` and `.failed`, and it is what the watchdogs judge staleness with. The
+    /// question here is the other one — "is the dictation screen on screen" — and
+    /// `MainTabView` already answers it with exactly this comparison: `RecordingView` is
+    /// mounted for every status but `.idle`, result and error included.
+    public static func dictationOwnsTheDisplay(_ status: DictationStatus) -> Bool {
+        status != .idle
+    }
+
+    /// The model whose preparation may be raised on screen right now, if any.
+    ///
+    /// - Parameters:
+    ///   - liveModel: the model currently in a user-facing preparation phase — the
+    ///     views' `liveActivePrepModel` — or nil when no preparation is in flight.
+    ///   - dictationStatus: the dictation status at the instant of the decision.
+    ///   - isPresenting: whether a preparation screen is already up. Preserves the
+    ///     "don't re-raise what is already raised" guard the call sites carried inline.
+    /// - Returns: the identifier to present, or nil to leave the screen alone.
+    public mutating func modelToPresent(
+        liveModel: String?,
+        dictationStatus: DictationStatus,
+        isPresenting: Bool
+    ) -> String? {
+        guard let liveModel else {
+            // No preparation in flight. Whatever was withheld is over, and a later
+            // preparation is a new event that gets judged on its own merits.
+            withheldModel = nil
+            return nil
+        }
+        guard !Self.dictationOwnsTheDisplay(dictationStatus) else {
+            // The load runs on regardless — it is only the screen that is refused.
+            withheldModel = liveModel
+            return nil
+        }
+        // The dictation is over and this is still the load it started under.
+        guard withheldModel != liveModel else { return nil }
+        guard !isPresenting else { return nil }
+        return liveModel
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/ModelPreparationGateTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/ModelPreparationGateTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+@testable import DictusCore
+
+/// Issue #458: a model load that started while the user was already dictating raised the
+/// preparation screen over the recording screen, mid-sentence. These tests hold the
+/// display rule that replaced it.
+final class ModelPreparationGateTests: XCTestCase {
+
+    private let model = "openai_whisper-small"
+    private let otherModel = "parakeet-tdt-0.6b-v3-coreml"
+
+    // MARK: - The ordinary case, which must keep working
+
+    /// Nothing else on screen: a live preparation is presented, exactly as before.
+    func testPresentsWhenDictationIsIdle() {
+        var gate = ModelPreparationGate()
+        XCTAssertEqual(
+            gate.modelToPresent(liveModel: model, dictationStatus: .idle, isPresenting: false),
+            model
+        )
+    }
+
+    /// Nothing to present when nothing is preparing.
+    func testPresentsNothingWithoutALivePreparation() {
+        var gate = ModelPreparationGate()
+        XCTAssertNil(
+            gate.modelToPresent(liveModel: nil, dictationStatus: .idle, isPresenting: false)
+        )
+    }
+
+    /// The guard the call sites used to carry inline, kept: a screen already up is not
+    /// re-raised over itself.
+    func testDoesNotRaiseWhatIsAlreadyPresented() {
+        var gate = ModelPreparationGate()
+        XCTAssertNil(
+            gate.modelToPresent(liveModel: model, dictationStatus: .idle, isPresenting: true)
+        )
+    }
+
+    // MARK: - The bug
+
+    /// Every status but `.idle` means the dictation screen is on screen, so every one of
+    /// them refuses. Driven off `allCases` so a status added later joins the sweep on its
+    /// own rather than silently defaulting to "go ahead".
+    func testRefusesForEveryNonIdleStatus() {
+        for status in DictationStatus.allCases where status != .idle {
+            var gate = ModelPreparationGate()
+            XCTAssertNil(
+                gate.modelToPresent(liveModel: model, dictationStatus: status, isPresenting: false),
+                "\(status.rawValue) must not raise a preparation screen"
+            )
+        }
+    }
+
+    /// The predicate on its own, since `MainTabView` uses it directly for its one-shot
+    /// URL and notification handlers.
+    func testDictationOwnsTheDisplayForEveryStatusButIdle() {
+        XCTAssertFalse(ModelPreparationGate.dictationOwnsTheDisplay(.idle))
+        for status in DictationStatus.allCases where status != .idle {
+            XCTAssertTrue(ModelPreparationGate.dictationOwnsTheDisplay(status))
+        }
+    }
+
+    // MARK: - No replay
+
+    /// The second half of the rule. The load refused during the recording is still
+    /// running when the dictation ends — and it stays off screen, because by then the
+    /// user is reading their transcription.
+    func testWithheldPreparationIsNotReplayedWhenTheDictationEnds() {
+        var gate = ModelPreparationGate()
+        XCTAssertNil(
+            gate.modelToPresent(liveModel: model, dictationStatus: .recording, isPresenting: false)
+        )
+        XCTAssertNil(
+            gate.modelToPresent(liveModel: model, dictationStatus: .transcribing, isPresenting: false)
+        )
+        XCTAssertNil(
+            gate.modelToPresent(liveModel: model, dictationStatus: .idle, isPresenting: false),
+            "the load withheld during the dictation must not pop after it"
+        )
+    }
+
+    /// …and the suppression is scoped to that one load. Once it ends, the screen is free
+    /// again — this is what keeps "tap a model in the Model Manager" working after a
+    /// dictation that happened to overlap a load.
+    func testANewPreparationAfterTheWithheldOneIsPresented() {
+        var gate = ModelPreparationGate()
+        XCTAssertNil(
+            gate.modelToPresent(liveModel: model, dictationStatus: .recording, isPresenting: false)
+        )
+        // The withheld load finishes.
+        XCTAssertNil(
+            gate.modelToPresent(liveModel: nil, dictationStatus: .idle, isPresenting: false)
+        )
+        // The user then asks for one themselves.
+        XCTAssertEqual(
+            gate.modelToPresent(liveModel: model, dictationStatus: .idle, isPresenting: false),
+            model
+        )
+    }
+
+    /// Suppression follows the identifier, not the fact that something was once refused:
+    /// a *different* model preparing after the dictation is a different event.
+    func testADifferentModelIsPresentedAfterAWithheldOne() {
+        var gate = ModelPreparationGate()
+        XCTAssertNil(
+            gate.modelToPresent(liveModel: model, dictationStatus: .recording, isPresenting: false)
+        )
+        XCTAssertEqual(
+            gate.modelToPresent(liveModel: otherModel, dictationStatus: .idle, isPresenting: false),
+            otherModel
+        )
+    }
+
+    /// The `.onAppear` case the latch exists for: the user switches to the Models tab
+    /// after the dictation, which re-asks the question about the same still-running load.
+    func testTabSwitchAfterTheDictationDoesNotRaiseTheWithheldLoad() {
+        var gate = ModelPreparationGate()
+        XCTAssertNil(
+            gate.modelToPresent(liveModel: model, dictationStatus: .recording, isPresenting: false)
+        )
+        for _ in 0..<3 {
+            XCTAssertNil(
+                gate.modelToPresent(liveModel: model, dictationStatus: .idle, isPresenting: false)
+            )
+        }
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/ModelPreparationGateTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/ModelPreparationGateTests.swift
@@ -112,6 +112,52 @@ final class ModelPreparationGateTests: XCTestCase {
         )
     }
 
+    // MARK: - Two preparations at once
+
+    /// The review finding on PR #477, and the reason the gate remembers a set rather than
+    /// the last refusal. `liveActivePrepModel` names one model but can alternate between
+    /// two in flight — a download of B while A prewarms. Refusing A and then B must not
+    /// forget A: A is still the load that started under the dictation.
+    func testAWithheldModelIsNotForgottenByASecondRefusal() {
+        var gate = ModelPreparationGate()
+        XCTAssertNil(
+            gate.modelToPresent(liveModel: model, dictationStatus: .recording, isPresenting: false)
+        )
+        XCTAssertNil(
+            gate.modelToPresent(liveModel: otherModel, dictationStatus: .recording, isPresenting: false)
+        )
+        XCTAssertNil(
+            gate.modelToPresent(liveModel: model, dictationStatus: .idle, isPresenting: false),
+            "the first refusal must survive the second one"
+        )
+        XCTAssertNil(
+            gate.modelToPresent(liveModel: otherModel, dictationStatus: .idle, isPresenting: false),
+            "and so must the second"
+        )
+    }
+
+    /// Both refusals are dropped together, and only when nothing is preparing any more.
+    /// Forgetting per model would clear a refusal whose load is still running, because
+    /// the live one alternates while two are in flight.
+    func testBothRefusalsAreClearedOnlyWhenNothingIsPreparing() {
+        var gate = ModelPreparationGate()
+        XCTAssertNil(
+            gate.modelToPresent(liveModel: model, dictationStatus: .recording, isPresenting: false)
+        )
+        XCTAssertNil(
+            gate.modelToPresent(liveModel: otherModel, dictationStatus: .recording, isPresenting: false)
+        )
+        // Both preparations end.
+        XCTAssertNil(
+            gate.modelToPresent(liveModel: nil, dictationStatus: .idle, isPresenting: false)
+        )
+        // Either one asked for afresh is a new event.
+        XCTAssertEqual(
+            gate.modelToPresent(liveModel: model, dictationStatus: .idle, isPresenting: false),
+            model
+        )
+    }
+
     /// The `.onAppear` case the latch exists for: the user switches to the Models tab
     /// after the dictation, which re-asks the question about the same still-running load.
     func testTabSwitchAfterTheDictationDoesNotRaiseTheWithheldLoad() {


### PR DESCRIPTION
Fixes the display rule behind #458. `refs #458` — the issue is closed by hand.

## What this was for

A dictation started **inside DictusApp** on 2026-08-30, on a device that had just been
installed. One to two seconds in, while the maintainer was still speaking, the recording
screen was **replaced** by the model preparation screen. It stayed there for eleven
seconds — the Core ML cache was gone, so the model load was slow — then went away and the
dictation finished correctly.

The audio was captured throughout. The screen was lying: it said "preparing" while the
microphone was live, which invites the user to stop talking or tap something. It is not a
rare case — it is the first dictation after installing or updating Dictus.

## To test by hand

Everything below needs a real device: the bug's trigger is a slow model load, and a
simulator has no ANE. Phase 4 verified the display rule itself in the simulator by forcing
the same two states; what it cannot produce is the real eleven-second load.

1. Install this branch on the iPhone (a fresh install, so the Core ML cache is discarded)
   and open Dictus. Let onboarding finish if it appears.
2. **Go to the Models tab once**, then come back to Home. This step is what arms the bug —
   see "the path" below. Without it nothing reproduces, on this build or on `develop`.
3. Start an in-app dictation immediately (Home → new dictation) and **keep talking for
   about twenty seconds**, without looking away.
   - Expected: the recording screen stays on screen for the whole dictation. The waveform
     keeps following your voice, the timer keeps counting, the red stop button stays.
   - Expected on `develop`, for comparison: the preparation screen takes over for as long
     as the load lasts.
4. Stop the dictation and wait for the transcription.
   - Expected: the transcription arrives as usual, and **no preparation screen pops up
     afterwards** — not while transcribing, not on the result screen.
5. Once back on Home, switch to the Models tab.
   - Expected: still no preparation screen, even if the load was still running.
6. In the Models tab, tap a model you do not have to download it.
   - Expected: the preparation screen appears as it always has, with its progress bar.
     (This path is untouched, and was checked in the simulator — screenshot in the report.)
7. From a keyboard, tap the mic while a model load is in flight, so Dictus opens on the
   preparation screen.
   - Expected: unchanged behaviour — the preparation screen opens and dismisses itself
     when the model is ready.

## The path, and the evidence that identified it

The issue left open which view raised the screen, and deliberately refused to design
around a guess. It is `ModelManagerView`'s `.fullScreenCover` (`ModelManagerView.swift:309`).

`ModelLoadingOverlay` has exactly three presenters:

- `MainTabView.swift:78` — **falsified twice.** Its three writers are all URL-driven and
  the device log shows no `urlComponents host=` line near the event; and it sits *earlier*
  in the same `ZStack` as `RecordingView`, so it draws underneath and can never replace
  the recording screen.
- `ModelDownloadPage.swift:171` — **falsified.** `OnboardingView` is a `switch` on one page
  at a time with `.id(currentPage)`, and no onboarding page records.
- `ModelManagerView.swift:309` — a `.fullScreenCover`, presented at window level, i.e.
  above the `RecordingView` that `MainTabView` puts in its `ZStack`. Its
  `.onChange(of: liveActivePrepModel)` fires on the **global** `modelLoadState == .loading`
  fallback (`ModelManagerView.swift:123`), and `startDictation`'s cold-start branch writes
  exactly that — `setModelLoadState(.loading, reason: "cold-start-load")` — *after* it has
  called `updateStatus(.recording)` (`DictationCoordinator.swift:694-698`). That is the
  17:58:12 → 17:58:14 ordering in the issue's log.

**Reproduced in the simulator** with a throwaway probe build (reverted; not in this branch)
that forced `coordinator.status = .recording` and then `modelLoadState = .loading`:

- Models tab never visited → nothing happens. SwiftUI builds a tab's body on first
  selection, so the `.onChange` does not exist yet.
- Models tab visited once, then back to Home → the preparation screen covers the recording
  screen, and the log prints
  `diagnosticProbe component=probe458 … action=overlayAppeared details=context=modelSelection`
  followed by `waveformAppeared refreshID=0 isProcessing=true` — the same second,
  self-driven waveform the device log shows.

So the precondition is that the Models tab has been visited at least once in the process.
After that the body stays alive and keeps reacting from whichever tab is frontmost.

## What changed

**`DictusCore/Sources/DictusCore/ModelPreparationGate.swift`** (new) — the rule, in one
place: a preparation screen is never raised while a dictation is not idle, and a
preparation withheld that way is never replayed once the dictation ends. It carries one
named predicate (`dictationOwnsTheDisplay`) plus the memory of what it refused, because the
views raise the screen from `.onChange` *and* from `.onAppear` and the two must agree. In
`DictusCore` because it is a decision about two booleans and a string — nothing from the
app target — which puts it where `swift test` reaches it.

`status != .idle` and not `DictationSessionLivenessPolicy.isActive`: that policy is false
for `.ready` and `.failed` and is what the watchdogs judge staleness with. The question
here is "is the dictation screen on screen", which is the condition `MainTabView` already
uses to mount `RecordingView`.

**Call sites.** `ModelManagerView` and `ModelDownloadPage` route both reactive entry points
through the gate. `MainTabView`'s `.prepare` URL branch and its notification twin are gated
on the predicate alone — `DictusApp.handleIncomingURL` posts that notification for the very
same URL, so they are one event and must not disagree. User-driven paths are untouched:
tapping a model, onboarding's "Install model" button, and `MainTabView.init`'s launch-intent
seed (a process being launched has no dictation to interrupt).

No new UI. The load already ran silently underneath; only the screen ever reported it.

## Acceptance criteria

| Criterion | Status | Evidence |
|---|---|---|
| The path is identified and written down | Done | Section above; simulator log line `overlayAppeared context=modelSelection` + screenshot of the reproduction |
| A dictation already recording is never replaced | Done (simulator) | Same probe on the fixed build: `modelLoadStateChanged … reason=probe-458` with **no** `overlayAppeared` and no second `waveformAppeared`; screenshot shows the recording screen intact |
| The recording state stays legible | Done | Nothing is shown, so `RecordingView` is what stays — waveform, timer and stop button |
| No replay after the dictation | Done (simulator) | After the fake dictation ended with the load still `.loading`: `waveformDisappeared`, then nothing. App back on Home, no cover |
| The user-driven paths keep working | Done (simulator) | Tapped a model card in the Models tab via `axe`; the preparation screen appeared with its progress bar |
| Checked on the field case (fresh install, cold Core ML cache) | **Not done** | Needs the ANE. Steps 1-5 of the manual list |

`cd DictusCore && swift test` — 1554 tests, 0 failures (9 new).
`swiftlint lint --strict` — 0 violations in 242 files.
`xcodebuild build -scheme DictusApp` — BUILD SUCCEEDED for the iOS Simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEFf4jKg2sCy4tc4is2tJ9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented model-preparation screens from appearing while dictation is active.
  * Prevented deferred preparation screens from reappearing automatically after dictation ends.
  * Avoided duplicate preparation overlays when a screen is already displayed.
  * Ensured multiple model preparations are handled correctly, without losing earlier requests or replaying active loads unexpectedly.

* **Tests**
  * Added coverage for dictation-state gating, duplicate-screen prevention, and preparation handling across multiple models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->