### PR TITLE
Refuse a Parakeet bundle directory as a completed download (refs #438)

### DIFF
--- a/DictusApp/Models/ModelRepoDownloader.swift
+++ b/DictusApp/Models/ModelRepoDownloader.swift
@@ -82,14 +82,38 @@ final class ModelRepoDownloader {
         /// declared its download verified at the one moment it most likely was not.
         let requiredPaths: @Sendable (URL) -> [String]
 
-        /// Parakeet v3 repo. Matches FluidAudio's `Repo.parakeet.remotePath`,
-        /// its file selection, and mirrors `AsrModels.modelsExist` verification.
+        /// Parakeet v3 repo. Matches FluidAudio's `Repo.parakeet.remotePath` and its
+        /// file selection.
+        ///
+        /// Required paths moved to `ParakeetModelRepository` for issue #438, and they
+        /// deliberately stop mirroring `AsrModels.modelsExist`. That function checks
+        /// `fileExists` on the four bundle DIRECTORY names, which this tripwire used to
+        /// copy — and a directory is not a file. The bundles are created here as soon as
+        /// their first small file is published, and because `listRequiredFiles` walks the
+        /// repository breadth first, every bundle's `coremldata.bin` and `model.mil` are
+        /// on disk before any bundle's `weights/`. A transfer stopped inside
+        /// `Encoder.mlmodelc/weights/weight.bin` — 445 MB of the 482 MB payload, so where
+        /// an interruption almost always lands — therefore left four bundle directories
+        /// standing, none of them holding a model, and the tripwire waved them through to
+        /// `AsrModels.load`. FluidAudio's own cache check has the same blind spot, so the
+        /// mirror was faithful and worthless; the leaf list is the deliberate divergence.
+        ///
+        /// The bundle set stays FluidAudio's `ModelNames.ASR.requiredModels` rather than a
+        /// reading of the cache directory (which is what the WhisperKit configuration
+        /// below does): that cache holds one directory per `AsrModelVersion`, shared by
+        /// every model of the version, so what is on disk is not the same question as
+        /// what this download owed.
         static func parakeet() -> Configuration {
             Configuration(
                 repoPath: Repo.parakeet.remotePath,
                 directoryPatterns: ModelNames.ASR.requiredModels.map { "\($0)/" }.sorted(),
                 includesRootMetadata: true,
-                requiredPaths: { _ in ModelNames.ASR.requiredModels + [ModelNames.ASR.vocabularyFile] }
+                requiredPaths: { _ in
+                    ParakeetModelRepository.requiredDownloadPaths(
+                        requiredModelBundles: ModelNames.ASR.requiredModels,
+                        vocabularyFileName: ModelNames.ASR.vocabularyFile
+                    )
+                }
             )
         }
 
@@ -250,14 +274,21 @@ final class ModelRepoDownloader {
             onProgress: onProgress
         )
 
-        // Phase 5: parity tripwire — mirror each engine's own existence check
-        // (AsrModels.modelsExist for Parakeet, the CoreML bundle set for WhisperKit)
-        // so we fail loudly here (with a localized error) instead of silently
-        // handing an incomplete cache to the engine. If the repo layout ever
-        // drifts, this is the signal.
+        // Phase 5: the tripwire — every leaf file a finished download of this engine
+        // owes has to be on disk, so we fail loudly here (with a localized error)
+        // instead of silently handing an incomplete cache to the engine. If the repo
+        // layout ever drifts, this is the signal.
+        //
+        // A directory is not a file, and both engines learned that the hard way
+        // (#433, #438): a required path that names a `.mlmodelc` bundle is satisfied
+        // by the empty shell an interrupted download leaves. Both lists name leaf
+        // files now, and this check refuses a directory whatever they name, so the
+        // hole cannot be reopened from the list alone.
         for requiredPath in configuration.requiredPaths(cacheDir) {
             let path = cacheDir.appendingPathComponent(requiredPath)
-            guard FileManager.default.fileExists(atPath: path.path) else {
+            var isDirectory: ObjCBool = false
+            let exists = FileManager.default.fileExists(atPath: path.path, isDirectory: &isDirectory)
+            guard exists, !isDirectory.boolValue else {
                 throw DownloadError.missingRequiredFile(requiredPath)
             }
         }

--- a/DictusCore/Sources/DictusCore/ParakeetModelRepository.swift
+++ b/DictusCore/Sources/DictusCore/ParakeetModelRepository.swift
@@ -20,16 +20,69 @@ import Foundation
 /// `ModelNames.ASR` values, which keeps a single source of truth: if the dependency
 /// renames a bundle, the app picks the new name up at compile time and this check follows.
 ///
-/// WHY `coremldata.bin` is the completeness marker:
-/// It is exactly what FluidAudio's own loader verifies immediately before handing a
-/// bundle to `MLModel(contentsOf:)`. A `.mlmodelc` directory can exist while the
-/// download that was filling it was interrupted, so directory existence alone (what
-/// `AsrModels.modelsExist` checks) is not enough — a partial cache must read as absent,
-/// mirroring the compiled-bundle requirement #249 introduced for Whisper.
+/// WHY completeness is read from the files INSIDE a bundle (issues #252, #438):
+/// A `.mlmodelc` directory can exist while the download that was filling it was
+/// interrupted, so directory existence alone — which is all `AsrModels.modelsExist`
+/// checks — is not enough. `coremldata.bin` is not enough either: the repository is
+/// listed breadth first, so every bundle's small top-level files are published before
+/// any bundle's `weights/`, and a transfer stopped inside `Encoder.mlmodelc/weights/
+/// weight.bin` (445 MB of the 482 MB payload) leaves all four bundles holding their
+/// marker and none of them holding a model. `requiredBundleEntries` is what a bundle
+/// has to hold for the answer to mean anything.
 public enum ParakeetModelRepository {
 
     /// Marker file every compiled Core ML bundle contains once it is fully written.
     public static let compiledModelMarkerFile = "coremldata.bin"
+
+    /// Entries that must exist INSIDE a compiled Parakeet bundle for it to hold a model
+    /// rather than a shell.
+    ///
+    /// Established from the repository, not copied from WhisperKit (issue #438): the
+    /// tree of `FluidInference/parakeet-tdt-0.6b-v3-coreml` at revision `7dd20fe` was
+    /// read on 2026-09-02, and all four bundles FluidAudio requires — `Preprocessor`,
+    /// `Encoder`, `Decoder`, `JointDecision` — carry exactly these three, plus
+    /// `metadata.json` and `analytics/coremldata.bin`.
+    ///
+    /// Those last two are deliberately left out. Two other bundles in the same
+    /// repository (`Encoder_v2`, `ParakeetDecoder`) ship without `metadata.json`, which
+    /// makes it the least stable entry of the five, and requiring it catches nothing
+    /// `weights/weight.bin` does not already catch — the weights are the last bytes of
+    /// every bundle and 92% of the payload of the whole download.
+    public static let requiredBundleEntries = [
+        compiledModelMarkerFile,
+        "model.mil",
+        "weights/weight.bin"
+    ]
+
+    /// Repo-relative paths a completed Parakeet download must have left on disk: the
+    /// leaf files inside every required bundle, plus the vocabulary at the root.
+    ///
+    /// This is what `ModelRepoDownloader`'s final-verification tripwire checks, and it
+    /// is the same requirement `isCompiledModelBundle` below applies one bundle at a
+    /// time for the load guard: both read `requiredBundleEntries`, so the download's
+    /// promise and the load guard's belief cannot drift apart (same arrangement as
+    /// `WhisperModelRepository.requiredDownloadPaths`, issue #433).
+    ///
+    /// WHY a fixed list rather than the disk enumeration the WhisperKit side does: there
+    /// the set of bundles is a property of the variant and only knowable from the files.
+    /// Here it is `ModelNames.ASR.requiredModels`, a compile-time constant the caller
+    /// hands over — and the FluidAudio cache is one directory per `AsrModelVersion`
+    /// shared by every model of that version, so enumerating it would demand
+    /// completeness of bundles this downloader never fetched.
+    ///
+    /// - Parameters:
+    ///   - requiredModelBundles: names of the compiled `.mlmodelc` bundles the engine
+    ///     loads. Sorted here because the caller's set has no order, and a list that
+    ///     reorders itself between calls is one no test can pin down.
+    ///   - vocabularyFileName: name of the vocabulary file at the repository root.
+    public static func requiredDownloadPaths(
+        requiredModelBundles: Set<String>,
+        vocabularyFileName: String
+    ) -> [String] {
+        requiredModelBundles.sorted().flatMap { bundle in
+            requiredBundleEntries.map { entry in "\(bundle)/\(entry)" }
+        } + [vocabularyFileName]
+    }
 
     /// The cache directory when it holds a complete, loadable model set, otherwise `nil`.
     ///
@@ -80,7 +133,8 @@ public enum ParakeetModelRepository {
         }
     }
 
-    /// Whether the URL is a compiled Core ML bundle rather than a leftover directory.
+    /// Whether the URL is a compiled Core ML bundle holding a model, rather than a
+    /// directory an interrupted download left behind.
     public static func isCompiledModelBundle(
         _ bundleURL: URL,
         fileManager: FileManager = .default
@@ -90,8 +144,9 @@ public enum ParakeetModelRepository {
               isDirectory.boolValue else {
             return false
         }
-        let marker = bundleURL.appendingPathComponent(compiledModelMarkerFile)
-        return isRegularFile(marker, fileManager: fileManager)
+        return requiredBundleEntries.allSatisfy { entry in
+            isRegularFile(bundleURL.appendingPathComponent(entry), fileManager: fileManager)
+        }
     }
 
     /// Whether the path holds a file rather than a directory.

--- a/DictusCore/Tests/DictusCoreTests/ParakeetModelRepositoryTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/ParakeetModelRepositoryTests.swift
@@ -1,5 +1,5 @@
 // DictusCore/Tests/DictusCoreTests/ParakeetModelRepositoryTests.swift
-// Tests for the local Parakeet (FluidAudio) cache completeness check (issue #252).
+// Tests for the local Parakeet (FluidAudio) cache completeness check (issues #252, #438).
 import XCTest
 @testable import DictusCore
 
@@ -35,7 +35,9 @@ final class ParakeetModelRepositoryTests: XCTestCase {
     // MARK: - Helpers
 
     /// Writes the layout a completed download leaves behind: one directory per compiled
-    /// bundle, each holding `coremldata.bin`, plus the vocabulary file at the root.
+    /// bundle holding the entries `requiredBundleEntries` names, plus the vocabulary
+    /// file at the root. Mirrors the repository tree of
+    /// `FluidInference/parakeet-tdt-0.6b-v3-coreml` read on 2026-09-02.
     private func makeCompleteCache() throws {
         try FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
         for bundle in requiredBundles {
@@ -44,13 +46,42 @@ final class ParakeetModelRepositoryTests: XCTestCase {
         try Data("{}".utf8).write(to: cacheDirectory.appendingPathComponent(vocabularyFileName))
     }
 
-    private func makeCompiledBundle(_ name: String, includeMarker: Bool = true) throws {
+    /// - Parameters:
+    ///   - includeMarker: whether `coremldata.bin` lands.
+    ///   - includeWeights: whether `weights/weight.bin` lands. False is the shape of a
+    ///     transfer stopped inside the weights, which is where 92% of the payload is.
+    private func makeCompiledBundle(
+        _ name: String,
+        includeMarker: Bool = true,
+        includeWeights: Bool = true
+    ) throws {
         let bundle = cacheDirectory.appendingPathComponent(name, isDirectory: true)
         try FileManager.default.createDirectory(at: bundle, withIntermediateDirectories: true)
-        // metadata.json is written early in a download; coremldata.bin marks completion.
+        // The repository is listed breadth first, so a bundle's small top-level files
+        // are published before any bundle's weights.
         try Data("[]".utf8).write(to: bundle.appendingPathComponent("metadata.json"))
+        try Data("mil".utf8).write(to: bundle.appendingPathComponent("model.mil"))
         if includeMarker {
             try Data("bin".utf8).write(to: bundle.appendingPathComponent("coremldata.bin"))
+        }
+        if includeWeights {
+            let weights = bundle.appendingPathComponent("weights", isDirectory: true)
+            try FileManager.default.createDirectory(at: weights, withIntermediateDirectories: true)
+            try Data("weight".utf8).write(to: weights.appendingPathComponent("weight.bin"))
+        }
+    }
+
+    /// The tripwire's own check, applied to the cache under test: every required path
+    /// present as a regular file. Mirrors Phase 5 of `ModelRepoDownloader.download`.
+    private func firstMissingRequiredPath() -> String? {
+        ParakeetModelRepository.requiredDownloadPaths(
+            requiredModelBundles: requiredBundles,
+            vocabularyFileName: vocabularyFileName
+        ).first { relativePath in
+            var isDirectory: ObjCBool = false
+            let url = cacheDirectory.appendingPathComponent(relativePath)
+            let exists = FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
+            return !exists || isDirectory.boolValue
         }
     }
 
@@ -202,5 +233,135 @@ final class ParakeetModelRepositoryTests: XCTestCase {
                 cacheDirectory.appendingPathComponent("Absent.mlmodelc", isDirectory: true)
             )
         )
+    }
+
+    func testBundleWithoutItsWeightsIsNotACompiledBundle() throws {
+        // The shape of a transfer stopped inside `weights/weight.bin`: the directory is
+        // there, the marker is there, and there is no model in it.
+        try FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
+        try makeCompiledBundle("Encoder.mlmodelc", includeWeights: false)
+
+        XCTAssertFalse(
+            ParakeetModelRepository.isCompiledModelBundle(
+                cacheDirectory.appendingPathComponent("Encoder.mlmodelc", isDirectory: true)
+            )
+        )
+    }
+
+    func testBundleWithoutModelMilIsNotACompiledBundle() throws {
+        try FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
+        try makeCompiledBundle("Encoder.mlmodelc")
+        try FileManager.default.removeItem(
+            at: cacheDirectory
+                .appendingPathComponent("Encoder.mlmodelc", isDirectory: true)
+                .appendingPathComponent("model.mil")
+        )
+
+        XCTAssertFalse(
+            ParakeetModelRepository.isCompiledModelBundle(
+                cacheDirectory.appendingPathComponent("Encoder.mlmodelc", isDirectory: true)
+            )
+        )
+    }
+
+    // MARK: - Required download paths (issue #438)
+
+    func testRequiredDownloadPathsNameLeafFilesNeverBundleDirectories() {
+        let paths = ParakeetModelRepository.requiredDownloadPaths(
+            requiredModelBundles: requiredBundles,
+            vocabularyFileName: vocabularyFileName
+        )
+
+        // The whole of issue #438: the tripwire checked these against the file system,
+        // and a `.mlmodelc` entry is a directory that exists long before it holds a model.
+        for bundle in requiredBundles {
+            XCTAssertFalse(paths.contains(bundle), "\(bundle) is a directory, not a file")
+        }
+    }
+
+    func testRequiredDownloadPathsCoverEveryBundleAndTheVocabulary() {
+        let paths = ParakeetModelRepository.requiredDownloadPaths(
+            requiredModelBundles: requiredBundles,
+            vocabularyFileName: vocabularyFileName
+        )
+
+        // Pinned against the repository tree of
+        // `FluidInference/parakeet-tdt-0.6b-v3-coreml` at revision `7dd20fe`, read on
+        // 2026-09-02: all four bundles carry these three entries.
+        XCTAssertEqual(paths, [
+            "Decoder.mlmodelc/coremldata.bin",
+            "Decoder.mlmodelc/model.mil",
+            "Decoder.mlmodelc/weights/weight.bin",
+            "Encoder.mlmodelc/coremldata.bin",
+            "Encoder.mlmodelc/model.mil",
+            "Encoder.mlmodelc/weights/weight.bin",
+            "JointDecision.mlmodelc/coremldata.bin",
+            "JointDecision.mlmodelc/model.mil",
+            "JointDecision.mlmodelc/weights/weight.bin",
+            "Preprocessor.mlmodelc/coremldata.bin",
+            "Preprocessor.mlmodelc/model.mil",
+            "Preprocessor.mlmodelc/weights/weight.bin",
+            "parakeet_vocab.json"
+        ])
+    }
+
+    func testRequiredDownloadPathsAreOrderedTheSameOnEveryCall() {
+        // The caller hands over a `Set`, whose iteration order is not stable across
+        // instances, and a list that reorders itself is one no test can pin down.
+        let first = ParakeetModelRepository.requiredDownloadPaths(
+            requiredModelBundles: requiredBundles,
+            vocabularyFileName: vocabularyFileName
+        )
+        let second = ParakeetModelRepository.requiredDownloadPaths(
+            requiredModelBundles: Set(requiredBundles.shuffled()),
+            vocabularyFileName: vocabularyFileName
+        )
+
+        XCTAssertEqual(first, second)
+    }
+
+    func testACompletedDownloadSatisfiesEveryRequiredPath() throws {
+        try makeCompleteCache()
+
+        XCTAssertNil(firstMissingRequiredPath())
+        XCTAssertTrue(isComplete())
+    }
+
+    func testADownloadStoppedInsideTheEncoderWeightsFailsTheTripwire() throws {
+        // 445 MB of the 482 MB payload is `Encoder.mlmodelc/weights/weight.bin`, so this
+        // is where an interruption lands. Every bundle directory is on disk and holds its
+        // small top-level files; the encoder holds no model.
+        try FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
+        for bundle in requiredBundles {
+            try makeCompiledBundle(bundle, includeWeights: bundle != "Encoder.mlmodelc")
+        }
+        try Data("{}".utf8).write(to: cacheDirectory.appendingPathComponent(vocabularyFileName))
+
+        // What the tripwire used to check — the bundle directories and the vocabulary —
+        // is all present, which is why it passed.
+        for bundle in requiredBundles {
+            XCTAssertTrue(
+                FileManager.default.fileExists(
+                    atPath: cacheDirectory.appendingPathComponent(bundle).path
+                )
+            )
+        }
+
+        XCTAssertEqual(firstMissingRequiredPath(), "Encoder.mlmodelc/weights/weight.bin")
+        XCTAssertNil(resolvedCacheDirectory())
+    }
+
+    func testARequiredPathThatIsADirectoryFailsTheTripwire() throws {
+        // Phase 5 refuses a directory whatever the list names, so the hole cannot be
+        // reopened by a future list that names one.
+        try makeCompleteCache()
+        let weight = cacheDirectory
+            .appendingPathComponent("Encoder.mlmodelc", isDirectory: true)
+            .appendingPathComponent("weights", isDirectory: true)
+            .appendingPathComponent("weight.bin")
+        try FileManager.default.removeItem(at: weight)
+        try FileManager.default.createDirectory(at: weight, withIntermediateDirectories: true)
+
+        XCTAssertEqual(firstMissingRequiredPath(), "Encoder.mlmodelc/weights/weight.bin")
     }
 }


### PR DESCRIPTION
refs #438

## What this was for

The Parakeet download had a final check whose job is to refuse an incomplete cache before it reaches the engine, and it could not do that job. It listed what it required as the four `.mlmodelc` **bundle names**, and it tested them with `FileManager.fileExists`, which says yes to a directory. Those directories exist long before they hold a model. So a Parakeet download that stopped inside `Encoder.mlmodelc/weights/weight.bin` — 445 MB of the 482 MB payload, which is where an interruption almost always lands — passed the check and was handed to FluidAudio as a finished download.

What happens next is the part worth fixing: FluidAudio's own cache check has the exact same blind spot (`fileExists` on the same four directory names). It finds them, decides nothing needs downloading, throws while loading the model, and its catch block **deletes the whole model directory and downloads it again** — 482 MB, on the dictation hot path, with no progress bar and no way to cancel. That is precisely what #252 built a guard to prevent, and the guard was not strict enough to see it either.

## To test by hand

Everything below needs the physical iPhone: Parakeet's compile is Apple Silicon / ANE work, and interrupting a 482 MB transfer is not something a headless run can produce faithfully. Nothing here changes any UI, so there is nothing to look at; what you are checking is that the app refuses a broken download and still accepts a good one.

1. Install this branch on the iPhone, open Dictus, go to **Modèles**, and make sure **Parakeet** is already downloaded and working from before this branch. Do a short dictation with it.
   → Expected: dictation works exactly as it did. This is the one that matters: the completeness check got stricter, and a cache that was fine yesterday has to still read as fine today. If Dictus instead says the model is not installed, this PR is wrong and should not be merged.
2. Delete Parakeet from **Modèles**, then start downloading it again and let it run to 100%.
   → Expected: the download finishes and the model prepares as before. The stricter check must not fire on a healthy download.
3. Do a dictation with the freshly downloaded Parakeet.
   → Expected: normal transcription.
4. Delete Parakeet again, start the download, and **turn on airplane mode when the bar is somewhere between 10% and 90%** (that stretch is the encoder weights).
   → Expected: the download stops with an error and offers to retry. What must never happen is the model landing in **Téléchargés** as if it were finished.
5. Turn airplane mode back off and retry the download from the model card.
   → Expected: it resumes rather than restarting from zero, and finishes.
6. Repeat step 4, but instead of airplane mode, **force quit Dictus** (swipe up in the app switcher) mid-download. Reopen Dictus and go to **Modèles**.
   → Expected: Parakeet is NOT under Téléchargés, and its card offers to download or resume. Then tap the microphone in the keyboard and try to dictate with whatever model is active.
   → Expected: no long silent freeze while something re-downloads half a gigabyte in the background. This is the failure this PR closes off.
7. Export the debug log (Réglages → Debug) after steps 4 and 6.
   → Expected: no `modelDownloadCompleted` line for `parakeet-tdt-0.6b-v3` from either interrupted attempt.

If you want to see the tripwire itself fire rather than trust it, there is no user-facing way to do it: it now sits behind the transfer's own accounting, which usually fails first. Its job is the case where the transfer *believes* it succeeded — see "One thing this does not claim" below.

## What changed

**`DictusCore/Sources/DictusCore/ParakeetModelRepository.swift`** — one declaration of what a complete Parakeet bundle holds, and a repo-relative path list built from it.

`requiredBundleEntries` is `coremldata.bin`, `model.mil`, `weights/weight.bin`. Established from the repository, not copied from the WhisperKit fix, as the issue asked. The tree of `FluidInference/parakeet-tdt-0.6b-v3-coreml` at revision `7dd20fe` was read on 2026-09-02: all four bundles FluidAudio requires — `Preprocessor`, `Encoder`, `Decoder`, `JointDecision` — carry those three, plus `metadata.json` and `analytics/coremldata.bin`. The last two are deliberately left out. `Encoder_v2` and `ParakeetDecoder` in the same repository ship without `metadata.json`, which makes it the least stable entry of the five, and requiring it catches nothing the weights do not already catch. (This is the same reasoning that kept `model.mlmodel` out of the WhisperKit list, reached independently rather than inherited.)

`requiredDownloadPaths(requiredModelBundles:vocabularyFileName:)` turns that into the leaf paths a finished download owes. It is a fixed list rather than the disk enumeration the WhisperKit side does, and the difference is deliberate: there the set of bundles is a property of the variant and only knowable from the files, while here it is `ModelNames.ASR.requiredModels`, a compile-time constant the caller hands over. The FluidAudio cache is also one directory per `AsrModelVersion` shared by every model of that version, so enumerating it would demand completeness of bundles this downloader never fetched.

`isCompiledModelBundle` now requires every entry instead of the marker alone.

**`DictusApp/Models/ModelRepoDownloader.swift`** — `Configuration.parakeet()` takes its required paths from that function, and Phase 5 refuses a path that resolves to a directory whatever the list names. Both engines have now shipped a required-path list that named a directory (#433 for WhisperKit, this one for Parakeet), and a check that cannot tell a file from a directory will accept the third.

## The three questions the issue asked to establish

1. **The leaf entries a compiled Parakeet bundle must hold** — read off the repository tree, listed above with the reason two entries are excluded.
2. **Does `AsrModels.modelsExist` have the same weakness** — yes. FluidAudio 0.12.4, `AsrModels.swift:366-381`: `fileExists` on the four bundle directory names plus the vocabulary. The mirror was faithful and worthless, so this diverges from it deliberately, and the divergence is written down at the call site.
3. **Is the vocabulary a real file** — yes. `ModelNames.ASR.vocabularyFile` is `parakeet_vocab.json`, 151 122 bytes at the repository root, and it is the file `AsrModels.loadVocabulary` actually reads (`Names.vocabulary(for:)` returns it for every version). Fine as declared, unchanged.

## Beyond the acceptance criteria, declared

The three criteria name the tripwire only. Hardening `isCompiledModelBundle`, which is the load-path guard from #252, goes one step past them. It is in this PR because it is the same defect one layer down, its failure mode is the worse of the two (the 482 MB wipe-and-re-download described at the top), and leaving it would have left two disagreeing definitions of "complete" in the same file with the weaker one believed — the mistake PR #435's review round was spent on. It is one constant and one `allSatisfy`, and it is removable on its own if you want only the narrow fix.

Its risk is the mirror image: a stricter load guard could report a genuinely complete cache as absent and send someone with 482 MB on disk back to the model manager. Evidence against it is criterion 4 below.

## One thing this does not claim

PR #468 changed the mechanism the issue describes. The downloader no longer creates a file's parent directory before requesting its bytes; `BackgroundModelDownloadService.publish` creates it when a **complete** file is moved into place. The defect survived anyway — the repository is listed breadth first, so every bundle's small top-level files are published before any bundle's `weights/`, and a stopped transfer leaves four bundle directories holding their markers and no model — but the bundle is no longer *empty* as the issue says, it is hollow.

The other consequence of #468 is that an interrupted transfer now fails inside the transfer's own accounting, before Phase 5 is reached. So this PR does not fix a crash a user is hitting today on the interrupt path; it repairs the backstop for the case the accounting cannot see — a repository listing that comes back short of a file, or a cache that changed under a manifest — where the tripwire is the only thing standing between an incomplete cache and FluidAudio's wipe-and-re-download. That is what the tripwire's own comment says it is for.

## Acceptance criteria and evidence

| # | Criterion | Status | Evidence |
| --- | --- | --- | --- |
| 1 | A download interrupted inside a bundle's weights fails the tripwire instead of passing it | **Verified (unit)** | `testADownloadStoppedInsideTheEncoderWeightsFailsTheTripwire` builds that exact on-disk shape, asserts all four bundle directories exist (which is why the old list passed), and asserts the required-path check stops on `Encoder.mlmodelc/weights/weight.bin`. `testARequiredPathThatIsADirectoryFailsTheTripwire` covers Phase 5's new refusal of a directory |
| 2 | A completed download still passes, verified against the real repository file list | **Verified** | All 13 required paths checked against the live repository listing at revision `7dd20fe` (2026-09-02): 13/13 present. Then checked against a real complete Parakeet cache on the Mac (`~/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3-coreml`, downloaded 2026-08-25 and previously loaded): 13/13 present as regular files, byte sizes identical to the repository. Plus `testACompletedDownloadSatisfiesEveryRequiredPath` |
| 3 | The required entries come from the repository tree or FluidAudio's own code, not assumption | **Verified** | Tree API readings above, pinned in `testRequiredDownloadPathsCoverEveryBundleAndTheVocabulary`. Bundle set and vocabulary name read from FluidAudio's `ModelNames.ASR` at the call site rather than restated |
| 4 | The stricter load guard does not refuse a healthy cache | **Partly verified** | The real Mac cache in criterion 2 satisfies every entry. Not verified on the iPhone — step 1 of the manual list |
| 5 | A real interrupted Parakeet download behaves | **Not verified** | Needs the device. Steps 4-7 of the manual list |

Commands run in the worktree:

- `cd DictusCore && swift test` — **1553 tests, 1 skipped, 0 failures**. `ParakeetModelRepositoryTests` goes from 13 tests to 20
- `swiftlint lint --strict` — **0 violations, 0 serious in 241 files**
- `xcodebuild -project Dictus.xcodeproj -scheme DictusApp -destination 'generic/platform=iOS Simulator' -derivedDataPath build/DerivedData build` — **BUILD SUCCEEDED**, producing `DictusApp.app`, `DictusKeyboard.appex`, `DictusWidgets.appex` and `DictusCore.o`
- FluidAudio resolved at `0.12.4` (revision `9830ce83`), which is the checkout every line quoted above was read from

Not merged: the 1.8.1 TestFlight cut is pending and nothing may land before it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model download verification to confirm that all required model files are present.
  * Incomplete downloads, missing weight files, and directories in place of required files are now correctly detected.
  * Model availability checks now provide more reliable results for partially downloaded or corrupted model bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->