### PR TITLE
Stop the mic pill fading out during the wait it exists for (refs #396)

### DIFF
--- a/DictusCore/Sources/DictusCore/Design/AnimatedMicButton.swift
+++ b/DictusCore/Sources/DictusCore/Design/AnimatedMicButton.swift
@@ -36,8 +36,8 @@ public struct AnimatedMicButton: View {
     /// mode instead of merely saying that one exists.
     ///
     /// It never replaces anything the status owns. Recording stays red and the two
-    /// post-recording stages stay in their washed accent, because those describe what
-    /// the phone is doing right now and outrank a setting — a red mic must mean
+    /// post-recording stages stay in the accent, because those describe what the
+    /// phone is doing right now and outrank a setting — a red mic must mean
     /// recording on every screen of this product.
     public let badge: SmartModeBadge?
 
@@ -142,9 +142,9 @@ public struct AnimatedMicButton: View {
     /// The mode's glyph on a white disc, straddling the button's lower-right edge.
     ///
     /// White and not a tint of the button: the disc has to survive every fill the
-    /// status can put behind it — accent blue at rest, red while recording, a washed
-    /// highlight while transcribing — and white is the only value that reads on all
-    /// three without becoming a fourth colour in the product.
+    /// status can put behind it — accent blue at rest and while transcribing, red
+    /// while recording — and white is the only value that reads on both without
+    /// becoming a third colour in the product.
     ///
     /// It straddles the edge rather than sitting inside it so the silhouette itself
     /// changes. That is the whole point of the badge: the signal has to survive being
@@ -258,12 +258,30 @@ public struct AnimatedMicButton: View {
 
     // MARK: - Helpers
 
+    /// WHY the two post-recording stages are not washed any more (#396):
+    /// they used to fill with `.dictusAccentHighlight.opacity(0.5)`, which on a
+    /// light iOS keyboard composited to 1.51:1 against the glass ring around it
+    /// and put its white glyph at 1.63:1 — measured, not estimated, on an
+    /// iPhone 17 screenshot. That is the state the user looks at for the longest
+    /// wait in the product, and it is the state a frustrated user taps while
+    /// `isTappable` is false. The one moment the button most needs to say
+    /// "something is happening" is the moment it faded out.
+    ///
+    /// The wash is not what named the state — the shimmer sweep is, and it reads
+    /// *better* on the opaque fill (1.53:1 peak against it, versus 1.16:1 before,
+    /// on a light keyboard). Opaque accent takes the shape to 3.46:1 and the glyph
+    /// to 3.73:1, which is exactly where idle and recording already sit. So this
+    /// is not a new colour on the pill; it is the accent the pill already wears,
+    /// stopped from being diluted in the one state that diluted it.
     private var buttonFillColor: Color {
         switch status {
         case .recording:
             return .dictusRecording
         case .transcribing, .processing:
-            return .dictusAccentHighlight.opacity(0.5)
+            // Same value as `default` on purpose, and spelled out rather than
+            // folded into it: the next reader has to see that these two stages
+            // were considered and deliberately left un-washed.
+            return .dictusAccent
         default:
             return .dictusAccent
         }
@@ -357,5 +375,19 @@ public struct AnimatedMicButton: View {
     }
     .padding()
     .background(Color(hex: 0x0A1628))
+}
+
+/// The host #396 was reported against: a light iOS keyboard, whose toolbar backdrop
+/// measures #D2D2D8 on an iPhone 17 running iOS 26.5. The dark previews above cannot
+/// show the problem — it never existed there. Put the three states side by side here
+/// and the transcribing pill has to hold its edges against the two that already did.
+#Preview("Pill on a light keyboard") {
+    VStack(spacing: 40) {
+        AnimatedMicButton(status: .idle, isPill: true) {}
+        AnimatedMicButton(status: .transcribing, isPill: true) {}
+        AnimatedMicButton(status: .recording, isPill: true) {}
+    }
+    .padding()
+    .background(Color(hex: 0xD2D2D8))
 }
 #endif


### PR DESCRIPTION
## What this was for

During the two stages that follow a recording — transcription, and since #361 the LLM polish — the mic pill filled with `.dictusAccentHighlight.opacity(0.5)`. On a light iOS keyboard that wash left the pill's shape at **1.51:1** against the glass ring it sits in and its white glyph at **1.63:1**. WCAG asks 3:1 for a non-text UI component.

That is the state the user looks at for the longest wait in the product, and it is the state a frustrated user taps while `isTappable` is false. The one moment the button most needs to say "something is happening" was the moment it faded out. Dark keyboards were never affected.

The fix is the one #396 proposes and the one `claudedocs/79-smart-mode-visual-coherence.md` already writes into its colour table: fill opaque `#3D7EFF` and let the shimmer sweep carry "in progress". This is **not** a recolour — it is the accent the pill already wears at rest, stopped from being diluted in the one state that diluted it. #79 block B's decision that the pill's colour axis is closed is untouched.

## To test by hand

Everything below needs a human eye or a physical device. The contrast numbers are computed and the extension was smoke-checked in a simulator, but `.transcribing` is not reachable there — no model is installed, so dictation fails before the state is entered.

1. **Device smoke — the extension launches.** Install the branch on the iPhone, open any app with a text field, long-press the globe and pick Dictus. *Expect:* the Dictus keyboard draws, mic pill blue on the right. A green build does not prove this.
2. **Light host, transcribe.** In a light-appearance host (Notes in light mode, or Réglages → Luminosité → Clair), dictate a sentence of ~10 s and watch the pill through the wait. *Expect:* the pill stays a solid blue with visible edges for the whole wait — it must not look like the greyed-out pill of the "Accès complet requis" bar. Before this change it washed out to a pale blue.
3. **The shimmer still reads.** During the same wait, watch for the light sweep crossing the pill left to right every 1.5 s. *Expect:* still clearly a moving highlight. Its peak now sits at 1.53:1 against the fill in both appearances — up from 1.16:1 on a light keyboard, **down from 1.97:1 on a dark one**. Dark mode is the one to judge: if the sweep has become too subtle there, say so.
4. **Idle vs transcribing are still distinguishable.** Note the pill just before you dictate and during the wait. The fill is now the same in both. *Expect:* the two still read apart, by three channels — the shimmer moves, the ring stops breathing and goes static, and the button stops responding to taps. If they read as the same state, that is the finding this change most needs.
5. **Recording is unchanged.** Start a dictation. *Expect:* red pill, ring pulsing 1.0→1.3. Identical to before.
6. **The success flash is unchanged.** Watch the moment the text is inserted. *Expect:* the same brief green flash over the blue. (It fires when the status is already `.ready`, so it was never drawn over the washed fill — but confirm by eye.)
7. **A Smart Mode is armed.** Long-press the mic, arm Notes, dictate. *Expect:* the white badge disc on the pill's lower-right edge is as legible during the wait as it was before — it now sits on a darker, more saturated blue.
8. **The app's own mic.** Open DictusApp, dictate from the Recording screen. *Expect:* the 72 pt circle behaves the same way. It shares `AnimatedMicButton`, so it changed too — on the app's dark background this is strictly more contrast, not less.

## What changed

One file, `DictusCore/Sources/DictusCore/Design/AnimatedMicButton.swift`:

- `buttonFillColor`, `.transcribing`/`.processing`: `.dictusAccentHighlight.opacity(0.5)` → `.dictusAccent`. The case is kept spelled out rather than folded into `default`, with a comment, so the next reader sees the two stages were considered and deliberately left un-washed.
- Two doc comments that described "a washed highlight while transcribing" — on `badge` and on `armedBadge` — refreshed, since they no longer describe the code.
- A `#Preview("Pill on a light keyboard")` on the measured `#D2D2D8` backdrop. Every existing preview is on `#0A1628`, where the problem never existed and the change is invisible.

`AnimatedMicButton` lives in DictusCore and has one definition. Its consumers were mapped before editing: the keyboard toolbar mic (`ToolbarView.swift:323`, pill), the keyboard's full-access bar (`ToolbarView.swift:606`, pinned `.idle`, unaffected), and the app's `RecordingView.swift:341/345` (circle). Only the first and the app's post-recording circle reach these two stages. `MicButtonDisabled.swift` is a separate grey view and is untouched.

## Acceptance criteria

The bases below are **measured pixels**, not assumptions: a screenshot of the real Dictus keyboard in Safari on an iPhone 17 / iOS 26.5, read along scan row y=1676. That scan also settles a question the issue did not ask — what the pill's *adjacent* colour actually is:

```
960:#D3D3DA … 970:#A3B7E3  980:#F6F6FA  990:#3D7EFF … 1150:#3D7EFF  1160:#F6F6FA  1170:#A3B7E3  1180:#D3D3DA
 └ keyboard backdrop        └ ring glass  └ pill fill                              └ ring glass  └ backdrop
```

The pill does not touch the keyboard backdrop. It is ringed by 5 pt of glass which composites to **`#F6F6FA`** on a light keyboard and **`#1A1A1C`** on a dark one. That glass is the adjacent colour SC 1.4.11 asks about.

| | before | after | |
|---|---|---|---|
| **AC1** pill vs ring glass `#F6F6FA`, light | 1.51:1 | **3.46:1** | ✅ |
| **AC1** pill vs ring glass `#1A1A1C`, dark | 2.67:1 | **4.66:1** | ✅ |
| AC1 pill vs raw backdrop `#D2D2D8`, light | 1.08:1 | 2.48:1 | ⚠ see below |
| AC1 pill vs raw backdrop `#1B1B1D`, dark | 2.64:1 | 4.61:1 | ✅ |
| **AC2** white glyph vs pill, light | 1.63:1 | **3.73:1** | ✅ |
| **AC2** white glyph vs pill, dark | 6.52:1 | 3.73:1 | ✅ (above 3:1, and lower than before) |
| **AC3** shimmer peak vs fill, light | 1.16:1 | 1.53:1 | ✅ improved |
| **AC3** shimmer peak vs fill, dark | 1.97:1 | 1.53:1 | ⚠ regressed, still visible |
| **AC4** recording red, success flash | — | unchanged | ✅ |

Arithmetic, so it can be checked. WCAG relative luminance `L = 0.2126R + 0.7152G + 0.0722B` on linearised sRGB; ratio `(L₁+0.05)/(L₂+0.05)`.

- Before, light: `0.5·#6BA3FF + 0.5·#F6F6FA = #B0CCFC`, L=0.5944. Against `#F6F6FA`, L=0.9241 → `0.9741/0.6444 = 1.51`. White glyph → `1.05/0.6444 = 1.63`.
- After: `#3D7EFF`, L=0.2313. Against `#F6F6FA` → `0.9741/0.2813 = 3.46`. Against `#1A1A1C`, L=0.0104 → `0.2813/0.0604 = 4.66`. White glyph → `1.05/0.2813 = 3.73`.
- Shimmer peak: `0.3·white + 0.7·fill`. Over `#3D7EFF` → `#77A5FF`, L=0.3805 → `0.4305/0.2813 = 1.53`. Before, over `#B0CCFC` (L=0.5944) → `#C8DBFD` → `1.16`.

**AC4 in detail.** `showSuccessFlash` is raised in `handleStatusChange(from: .transcribing, to: .ready)`, so by the time it draws, `status` is `.ready` and `buttonFillColor` returns the `default` branch. The flash was never composited over the washed fill; its rendered value (`#2DA99E`) is byte-identical before and after. The `.recording` branch is untouched.

### The one number that does not clear 3:1, stated plainly

Against the **raw keyboard backdrop** rather than the ring, the light case reaches 2.48:1, not 3:1. This is worth reading before treating it as a shortfall:

- No opaque colour can clear 3:1 on both. A white glyph at ≥3:1 needs L ≤ 0.300; clearing 3:1 on `#D2D2D8` needs L ≤ 0.184; clearing 3:1 on the darkest measured dark backdrop needs L ≥ 0.135. The window is 0.135–0.184 and it closes entirely if the host's dark backdrop is any lighter than about `#2A2A2C`. `#3D7EFF` is L=0.231; `#2563EB` is L=0.153 and would clear light at 3.45:1 while failing dark at 2.70:1.
- `#EF4444`, the recording red the issue requires unchanged, is L=0.229 → **2.50:1** on the same backdrop, and idle `#3D7EFF` is 2.48:1. Under that reading no state this button can be in has ever met 3:1 on a light keyboard. Meeting it for `.transcribing` alone would make the waiting state darker than the recording state.
- The only fill that would close it is a second, darker blue on the pill — precisely the recolour #79 block B ruled out.

So the change takes `.transcribing` to exact parity with `.idle` and `.recording` and removes a washout that was specific to this one state. Going further is a design decision about the pill's colour identity, and it belongs to whoever owns that, not to this PR.

## Verification

- `swiftlint lint --strict` → `Found 0 violations, 0 serious in 241 files.`
- `cd DictusCore && swift test` → `Executed 1545 tests, with 1 test skipped and 0 failures`
- `xcodebuild build` for `DictusApp`, `DictusKeyboard`, `DictusCore` (iPhone 17 simulator) → `** BUILD SUCCEEDED **` for all three
- Simulator smoke, headless: the changed build installed, the Dictus keyboard was reached by long-pressing the globe, and the toolbar rendered. Scan row y=1676 after the change is quoted above — the idle pill is still exactly `#3D7EFF` and the ring is still `#F6F6FA`, so nothing regressed around the edit.

**Not verified:** the `.transcribing` state itself was never rendered. A simulator has no model installed, so dictation fails before that state is entered, and the Dictus keys are not in the accessibility tree. Every claim about how it looks in motion is arithmetic on measured bases, and item 3 of the manual list is the check that settles it.

## Notes

- #397 was filed from the same pass and is deliberately **not** in this PR. This change neither helps nor blocks it: #397 is about accessibility actions for arming, and nothing here touches the badge, the gesture or the accessibility tree.
- The ring is left alone, as the issue says it can be. Worth knowing for whoever picks it up: the ring stroke during these two stages measures `#A3B7E3` on a light keyboard — 1.44:1 against its own glass. If the wait state is revisited, the ring is where the remaining headroom is, and it costs no change to the pill's identity.

refs #396
