### PR TITLE
Answer an in-app record tap that lands during a model load (refs #484)

### DIFF
--- a/Dictus.xcodeproj/project.pbxproj
+++ b/Dictus.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		AA0000E4 /* SwipeBackOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1000E4 /* SwipeBackOverlayView.swift */; };
 		AA000300 /* CyclingLoadingText.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100300 /* CyclingLoadingText.swift */; };
 		AA000301 /* ModelLoadingOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100301 /* ModelLoadingOverlay.swift */; };
+		AA000484 /* ModelPreparationPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100484 /* ModelPreparationPresentation.swift */; };
 		AA000302 /* ModelLanguageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100302 /* ModelLanguageDetailView.swift */; };
 		AA0000F0 /* SpeechModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1000F0 /* SpeechModelProtocol.swift */; };
 		AA0000F1 /* ParakeetEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1000F1 /* ParakeetEngine.swift */; };
@@ -272,6 +273,7 @@
 		AA1000E4 /* SwipeBackOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeBackOverlayView.swift; sourceTree = "<group>"; };
 		AA100300 /* CyclingLoadingText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CyclingLoadingText.swift; sourceTree = "<group>"; };
 		AA100301 /* ModelLoadingOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelLoadingOverlay.swift; sourceTree = "<group>"; };
+		AA100484 /* ModelPreparationPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelPreparationPresentation.swift; sourceTree = "<group>"; };
 		AA100302 /* ModelLanguageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelLanguageDetailView.swift; sourceTree = "<group>"; };
 		AA1000F0 /* SpeechModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechModelProtocol.swift; sourceTree = "<group>"; };
 		AA1000F1 /* ParakeetEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParakeetEngine.swift; sourceTree = "<group>"; };
@@ -559,6 +561,7 @@
 				AA1000F3 /* SoundSettingsView.swift */,
 				AA100300 /* CyclingLoadingText.swift */,
 				AA100301 /* ModelLoadingOverlay.swift */,
+				AA100484 /* ModelPreparationPresentation.swift */,
 				SS100002 /* PaywallView.swift */,
 				AA361013 /* SmartModeListView.swift */,
 				SS100009 /* PaywallPresentation.swift */,
@@ -1034,6 +1037,7 @@
 				AA0000E4 /* SwipeBackOverlayView.swift in Sources */,
 				AA000300 /* CyclingLoadingText.swift in Sources */,
 				AA000301 /* ModelLoadingOverlay.swift in Sources */,
+				AA000484 /* ModelPreparationPresentation.swift in Sources */,
 				AA000302 /* ModelLanguageDetailView.swift in Sources */,
 				AA0000F2 /* SoundFeedbackService.swift in Sources */,
 				AA0000F3 /* SoundSettingsView.swift in Sources */,

--- a/DictusApp/DictationCoordinator+ModelLoad.swift
+++ b/DictusApp/DictationCoordinator+ModelLoad.swift
@@ -39,6 +39,25 @@ final class LaunchPreloadOutcome {
 
 extension DictationCoordinator {
 
+    /// What an in-app record button should do with a tap, right now (#484).
+    ///
+    /// WHY the buttons ask this instead of calling and finding out: `startDictation` refuses a
+    /// start while a load is in flight and returns `Void`, so a caller cannot learn that it was
+    /// refused — on device that read as a button answering twelve taps with nothing at all.
+    /// The rule itself is `RecordTapRouting`, in DictusCore where it is tested; what belongs
+    /// here is only the reading of its three inputs, from the same places the guard reads them,
+    /// so the two buttons cannot drift from each other or from the guard.
+    ///
+    /// WHY in this file and not next to the guard it mirrors: `DictationCoordinator.swift` is
+    /// at the file-length budget #146 calibrated against it, and this is model-load state.
+    var recordTapDecision: RecordTapRouting.Decision {
+        RecordTapRouting.decide(
+            dictationStatus: status,
+            isModelDownloaded: defaults.bool(forKey: SharedKeys.modelReady),
+            loadState: modelLoadState
+        )
+    }
+
     /// Load the active model at launch, under a deadline the app actually honours.
     ///
     /// WHY a deadline at all (issue #428): this path used to `await ensureEngineReady()`

--- a/DictusApp/Localizable.xcstrings
+++ b/DictusApp/Localizable.xcstrings
@@ -2380,6 +2380,17 @@
         }
       }
     },
+    "Tap again to start your dictation." : {
+      "comment" : "Completion line on the model preparation screen raised by an in-app record tap (issue #484). The keyboard's equivalent sends the user back to another app; this one never left Dictus.",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appuyez à nouveau pour démarrer votre dictée."
+          }
+        }
+      }
+    },
     "Tap and hold \\(Image(systemName: \"globe\")), then" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -2894,6 +2905,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "C'est prêt !"
+          }
+        }
+      }
+    },
+    "Your dictation cannot start yet: Dictus is preparing your model. This is usually an exceptional step." : {
+      "comment" : "Explanation on the model preparation screen raised by an in-app record tap (issue #484). Names why the tap did not start a recording.",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votre dictée ne peut pas encore démarrer : Dictus prépare votre modèle. Cette étape est normalement exceptionnelle."
           }
         }
       }

--- a/DictusApp/Views/HomeView.swift
+++ b/DictusApp/Views/HomeView.swift
@@ -14,6 +14,10 @@ struct HomeView: View {
     @EnvironmentObject var proStatus: ProStatusManager
     @EnvironmentObject var history: TranscriptionHistoryStore
     @ObservedObject var modelManager: ModelManager
+
+    /// Raises the model preparation screen when a tap arrives during a load (#484).
+    @Environment(\.presentModelPreparation) private var presentModelPreparation
+
     @State private var showCopiedFeedback = false
 
     /// Drives the history sheet (#70).
@@ -282,7 +286,16 @@ struct HomeView: View {
     /// A Button just starts dictation — the MainTabView overlay handles the full UI.
     private var testDictationLink: some View {
         Button {
-            coordinator.startDictation(origin: .app)
+            // A tap that lands during a model load gets the preparation screen instead of
+            // being swallowed by `startDictation`'s guard (#484). The button stays live and
+            // keeps its shape: `isModelReady` above says a model is on disk and elected, which
+            // is a different question from whether one is loading right now.
+            switch coordinator.recordTapDecision {
+            case .presentPreparation:
+                presentModelPreparation()
+            case .startDictation:
+                coordinator.startDictation(origin: .app)
+            }
         } label: {
             HStack {
                 Image(systemName: "waveform")

--- a/DictusApp/Views/MainTabView.swift
+++ b/DictusApp/Views/MainTabView.swift
@@ -30,13 +30,26 @@ struct MainTabView: View {
     /// Tracks whether the app was opened from the keyboard for cold start dictation.
     @State private var isColdStartMode: Bool
 
-    /// Active model preparation requested by the keyboard without starting a
-    /// recording. The overlay dismisses itself after its contextual ready state.
+    /// Active model preparation shown without starting a recording. The overlay dismisses
+    /// itself after its contextual ready state.
     ///
-    /// Its three writers are all URL-driven, and the two that can fire while the process
-    /// is already alive are gated on #458's rule below. `init`'s launch-intent seed is
-    /// not: a process being launched has no dictation to interrupt.
-    @State private var preparingModelID: String?
+    /// Three of its four writers are URL-driven — the keyboard asking for `intent=prepare` —
+    /// and the two of those that can fire while the process is already alive are gated on
+    /// #458's rule below. `init`'s launch-intent seed is not: a process being launched has no
+    /// dictation to interrupt. The fourth is `presentModelPreparation`, an in-app record tap
+    /// that landed during a load (#484), which carries its own context and its own gate.
+    ///
+    /// WHY the model and the context travel together in one value: the overlay's copy is
+    /// chosen from the context and names the model, so a context left behind by a previous
+    /// presentation would put "Return to your app and tap the microphone again." in front of
+    /// a user who never left Dictus. Storing them apart makes that a two-line mistake.
+    @State private var preparation: PreparationPresentation?
+
+    /// A preparation screen to show: which model, and why it is up.
+    private struct PreparationPresentation: Equatable {
+        let modelIdentifier: String
+        let context: ModelPreparationContext
+    }
 
     /// The paywall, opened from the keyboard (#404).
     ///
@@ -61,8 +74,13 @@ struct MainTabView: View {
     init() {
         let launchIntent = ColdStartLaunch.intent
         _isColdStartMode = State(initialValue: launchIntent == .record)
-        _preparingModelID = State(
-            initialValue: launchIntent == .prepare ? Self.persistedActiveModelIdentifier : nil
+        _preparation = State(
+            initialValue: launchIntent == .prepare
+                ? PreparationPresentation(
+                    modelIdentifier: Self.persistedActiveModelIdentifier,
+                    context: .keyboardColdStart
+                )
+                : nil
         )
     }
 
@@ -79,14 +97,14 @@ struct MainTabView: View {
 
     var body: some View {
         ZStack {
-            if let preparingModelID {
+            if let preparation {
                 ModelLoadingOverlay(
                     modelManager: modelManager,
-                    modelIdentifier: preparingModelID,
-                    context: .keyboardColdStart,
+                    modelIdentifier: preparation.modelIdentifier,
+                    context: preparation.context,
                     isPresented: Binding(
-                        get: { self.preparingModelID != nil },
-                        set: { if !$0 { self.preparingModelID = nil } }
+                        get: { self.preparation != nil },
+                        set: { if !$0 { self.preparation = nil } }
                     )
                 )
             } else if isColdStartMode {
@@ -182,7 +200,10 @@ struct MainTabView: View {
                 guard !ModelPreparationGate.dictationOwnsTheDisplay(coordinator.status) else {
                     return
                 }
-                preparingModelID = activeModelIdentifier
+                preparation = PreparationPresentation(
+                    modelIdentifier: activeModelIdentifier,
+                    context: .keyboardColdStart
+                )
                 return
             }
 
@@ -205,8 +226,22 @@ struct MainTabView: View {
             guard !ModelPreparationGate.dictationOwnsTheDisplay(coordinator.status) else {
                 return
             }
-            preparingModelID = activeModelIdentifier
+            preparation = PreparationPresentation(
+                modelIdentifier: activeModelIdentifier,
+                context: .keyboardColdStart
+            )
         }
+        // The fourth writer (#484): a record button inside the app, tapped while a model load
+        // was in flight. The decision to present rather than to call `startDictation` was
+        // already made at the button — `RecordTapRouting` in DictusCore, where it is tested —
+        // so this handler only presents. It is installed on the ZStack rather than on the
+        // TabView so `RecordingView`, a sibling and the second of the two buttons, sees it too.
+        .environment(\.presentModelPreparation, PresentModelPreparationAction {
+            preparation = PreparationPresentation(
+                modelIdentifier: activeModelIdentifier,
+                context: .appRecordTap
+            )
+        })
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .background {
                 isColdStartMode = false

--- a/DictusApp/Views/ModelLoadingOverlay.swift
+++ b/DictusApp/Views/ModelLoadingOverlay.swift
@@ -213,13 +213,31 @@ struct ModelLoadingOverlay: View {
                 .font(.dictusSubheading)
                 .foregroundStyle(.primary)
 
-            if activeContext.isPrepareOnly {
-                Text("Return to your app and tap the microphone again.")
+            if let completionInstruction {
+                Text(completionInstruction)
                     .font(.dictusCaption)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 32)
             }
+        }
+    }
+
+    /// What the user does next, once the model is ready.
+    ///
+    /// Only the two prepare-only contexts have anything to say here: they are the ones reached
+    /// from a tap that deliberately does NOT become a recording, so the screen owes the user
+    /// the action that does. Which sentence is a question about where they came from, not
+    /// about the prepare-only rule — hence `startedFromAnotherApp` and not `isPrepareOnly`
+    /// (#484). Onboarding and model selection dismiss into the screen the user was already on.
+    private var completionInstruction: LocalizedStringKey? {
+        switch activeContext {
+        case .onboarding, .modelSelection:
+            return nil
+        case .keyboardColdStart:
+            return "Return to your app and tap the microphone again."
+        case .appRecordTap:
+            return "Tap again to start your dictation."
         }
     }
 
@@ -244,7 +262,13 @@ struct ModelLoadingOverlay: View {
             }
 
             if !(showCompletion && activeContext.isPrepareOnly) {
-                Text(activeContext.isPrepareOnly
+                // WHICH OF THE TWO, and why it is not `isPrepareOnly` (#484): "stay on this
+                // page" is only sayable to someone who is on it. The keyboard cold start
+                // brings a user whose next move is to leave, so it asks for patience instead.
+                // The in-app tap does not — and staying in the foreground is what keeps the
+                // compile off the system's background throttle (#472), so it is the stronger
+                // of the two sentences and the right one here.
+                Text(activeContext.startedFromAnotherApp
                      ? "Please wait for preparation to finish."
                      : "Please stay on this page and do not leave the app.")
                     .font(.dictusCaption)
@@ -267,6 +291,11 @@ struct ModelLoadingOverlay: View {
             return "Dictus is preparing this model for offline dictation."
         case .keyboardColdStart:
             return "Your model needs to be prepared before this dictation. This is usually an exceptional step."
+        case .appRecordTap:
+            // Says out loud why the tap did nothing, which is the whole of #484: the button
+            // used to swallow it in silence. The keyboard's wording cannot be reused as is —
+            // it is written for someone who arrived from another app.
+            return "Your dictation cannot start yet: Dictus is preparing your model. This is usually an exceptional step."
         }
     }
 

--- a/DictusApp/Views/ModelPreparationPresentation.swift
+++ b/DictusApp/Views/ModelPreparationPresentation.swift
@@ -1,0 +1,38 @@
+// DictusApp/Views/ModelPreparationPresentation.swift
+// The environment action a record button uses to reach MainTabView's preparation screen (#484).
+import SwiftUI
+
+/// Raises the model preparation screen for a record tap that arrived during a load (#484).
+///
+/// WHY AN ENVIRONMENT ACTION AND NOT A PARAMETER: the state lives in `MainTabView`
+/// (`preparation`), and its two callers sit at different depths beneath it — `HomeView` inside
+/// a `NavigationStack` inside the `TabView`, `RecordingView` as a sibling in the same `ZStack`.
+/// `RecordingView` also has two construction sites outside that hierarchy (`TestDictationView`,
+/// a `#Preview`), and a required closure would force both to invent one. Reading it from the
+/// environment gives every caller the same call and no view a new signature.
+///
+/// WHY THE DEFAULT IS A NO-OP rather than a fatal error: a `RecordingView` built outside
+/// `MainTabView` genuinely has no root to present through, and the correct behaviour there is
+/// the one that shipped before this issue. Only `MainTabView` installs a real handler.
+struct PresentModelPreparationAction {
+    private let handler: () -> Void
+
+    init(_ handler: @escaping () -> Void) {
+        self.handler = handler
+    }
+
+    func callAsFunction() {
+        handler()
+    }
+}
+
+private struct PresentModelPreparationKey: EnvironmentKey {
+    static let defaultValue = PresentModelPreparationAction { }
+}
+
+extension EnvironmentValues {
+    var presentModelPreparation: PresentModelPreparationAction {
+        get { self[PresentModelPreparationKey.self] }
+        set { self[PresentModelPreparationKey.self] = newValue }
+    }
+}

--- a/DictusApp/Views/RecordingView.swift
+++ b/DictusApp/Views/RecordingView.swift
@@ -33,6 +33,10 @@ struct RecordingView: View {
 
     @EnvironmentObject var coordinator: DictationCoordinator
 
+    /// Raises the model preparation screen when a tap arrives during a load (#484).
+    /// A no-op outside `MainTabView`, which is the only view that owns that screen.
+    @Environment(\.presentModelPreparation) private var presentModelPreparation
+
     @State private var transcriptionResult: String?
     @State private var showResult = false
     @State private var showError = false
@@ -351,6 +355,14 @@ struct RecordingView: View {
     // MARK: - Actions
 
     private func startRecording() {
+        // Asked BEFORE the result state is cleared (#484): a tap that ends on the preparation
+        // screen has not started a dictation, and wiping the transcription the user is looking
+        // at on the way there would throw away a result for a recording that never happened.
+        guard case .startDictation = coordinator.recordTapDecision else {
+            presentModelPreparation()
+            return
+        }
+
         // Reset previous result state
         transcriptionResult = nil
         showResult = false

--- a/DictusCore/Sources/DictusCore/ModelPreparationContext.swift
+++ b/DictusCore/Sources/DictusCore/ModelPreparationContext.swift
@@ -2,18 +2,59 @@ import Foundation
 
 /// The user-facing flow that caused model preparation to be shown.
 ///
-/// The same preparation overlay is reused by onboarding, model selection, and
-/// the keyboard cold-start handoff. Keeping the context explicit lets each flow
-/// explain what is happening without duplicating the loading UI.
+/// The same preparation overlay is reused by onboarding, model selection, the
+/// keyboard cold-start handoff, and an in-app record tap that landed during a load.
+/// Keeping the context explicit lets each flow explain what is happening without
+/// duplicating the loading UI.
 public enum ModelPreparationContext: String, Codable, CaseIterable, Sendable {
     case onboarding
     case modelSelection
     case keyboardColdStart
 
-    /// Keyboard cold start is deliberately prepare-only: it must never begin
-    /// recording automatically after a potentially long wait.
+    /// A record button *inside Dictus* was tapped while a model load was in flight (#484).
+    ///
+    /// Before this case the tap was refused in silence by `startDictation`'s load guard —
+    /// twelve taps in eleven seconds, no overlay, no message, no disabled state — because
+    /// the guard's only route out was the keyboard's, and the keyboard is not where this
+    /// user is. It is `.keyboardColdStart`'s in-app twin and shares its one hard rule
+    /// (`isPrepareOnly`), but not its assumption that the user came from somewhere else.
+    case appRecordTap
+
+    /// Whether this preparation must never turn into a recording by itself.
+    ///
+    /// Both prepare-only contexts are reached from a *tap the user has already made*, and a
+    /// Turbo compile can take three and a half minutes (#432). Starting the microphone at
+    /// the end of a wait that long acts on an intent that has almost certainly expired, and
+    /// on a phone that may well be back in a pocket. The user taps again; nothing is queued.
+    ///
+    /// WHY a switch and not `self == …`: a fifth context must be forced to answer this
+    /// question rather than inherit `false` from the shape of an equality test.
     public var isPrepareOnly: Bool {
-        self == .keyboardColdStart
+        switch self {
+        case .onboarding, .modelSelection:
+            return false
+        case .keyboardColdStart, .appRecordTap:
+            return true
+        }
+    }
+
+    /// Whether the user reached this screen from *outside* Dictus.
+    ///
+    /// WHY THIS IS A SECOND BOOLEAN AND NOT `isPrepareOnly` (#484): the flag above used to
+    /// carry both "do not start recording by itself" and "you came here from another app",
+    /// which held only as long as the keyboard was the sole prepare-only entry point. The
+    /// two questions have different answers for `.appRecordTap`, and it is *this* one that
+    /// decides the completion sentence — "return to your app" is false for someone who never
+    /// left it — and which of the two waiting notices is shown. Staying in the foreground is
+    /// what keeps a compile off the system's background throttle (#472), so the in-app case
+    /// asks the user to stay on the page rather than merely to wait.
+    public var startedFromAnotherApp: Bool {
+        switch self {
+        case .keyboardColdStart:
+            return true
+        case .onboarding, .modelSelection, .appRecordTap:
+            return false
+        }
     }
 
 }

--- a/DictusCore/Sources/DictusCore/RecordTapRouting.swift
+++ b/DictusCore/Sources/DictusCore/RecordTapRouting.swift
@@ -1,0 +1,75 @@
+// DictusCore/Sources/DictusCore/RecordTapRouting.swift
+import Foundation
+
+/// What a record button *inside DictusApp* should do with a tap (#484).
+///
+/// WHY THIS EXISTS: `startDictation` refuses a non-URL start while
+/// `modelLoadState == .loading` and returns `Void`, so the caller cannot learn that it was
+/// refused. On device that read as a dead button — twelve taps in eleven seconds, every one
+/// logged as `dictationDeferred` and none of them producing a single pixel, because the
+/// published `DictationStatus` never left `.idle` and no view had anything to react to. The
+/// guard is right to refuse; what was missing is that the two in-app buttons never asked the
+/// question *before* calling, so they had nothing to show instead.
+///
+/// THE GUARD STAYS. This does not replace `startDictation`'s check — that one is the backstop
+/// for every other caller, the keyboard's Darwin path included. This asks the same question
+/// one frame earlier, in the one place that can answer it with a screen.
+///
+/// WHY THE ORDER BELOW MIRRORS THE GUARD'S, EXACTLY: `startDictation` tests liveness first,
+/// then `modelReady`, then the load state. Ask them in any other order and a tap that the
+/// coordinator would have answered with "No model downloaded" gets a preparation screen for a
+/// model that is not on the device.
+public enum RecordTapRouting {
+
+    /// What the button does with this tap.
+    public enum Decision: Equatable, Sendable {
+        /// Call `startDictation`. Includes every case the coordinator answers for itself —
+        /// a duplicate tap, a missing model — because those already have an answer.
+        case startDictation
+        /// Raise the model preparation screen instead of calling in.
+        case presentPreparation
+    }
+
+    /// - Parameters:
+    ///   - dictationStatus: the coordinator's published status at the instant of the tap.
+    ///   - isModelDownloaded: `SharedKeys.modelReady`, i.e. is there a model on disk at all.
+    ///   - loadState: `SharedKeys.modelLoadState`, the flag the guard reads.
+    public static func decide(
+        dictationStatus: DictationStatus,
+        isModelDownloaded: Bool,
+        loadState: ModelLoadState
+    ) -> Decision {
+        // WHY `canStartNewDictation` AND NOT `ModelPreparationGate.dictationOwnsTheDisplay`,
+        // which is #458's rule and is `status != .idle`:
+        //
+        // The gate answers "is a dictation on screen", and that is the right question for the
+        // three presenters it was written for, which raise the screen off a load-state change
+        // behind the user's back. This is the other kind of presentation — the user's own tap,
+        // whose entire meaning is "put that away and record again". The start-again mic on the
+        // result screen (`RecordingView`) is drawn at `.ready` or `.failed`, so the gate's
+        // predicate would refuse it and leave this exact bug in place on the second of the two
+        // entry points. And the tap it would be protecting already replaces that screen the
+        // moment the model *is* ready.
+        //
+        // So a user tap may raise preparation exactly when it could have started a dictation.
+        // Same list, one line later, in `startDictation` itself — which is why this delegates
+        // rather than restating it. `.recording`, `.transcribing` and `.processing` are the
+        // three it refuses, and they are the ones #458 and #484 both name: a dictation that is
+        // still running is never covered by a preparation screen.
+        guard ColdStartResolutionPolicy.canStartNewDictation(from: dictationStatus) else {
+            return .startDictation
+        }
+        // No model on the device is not a wait, it is an error, and the coordinator already
+        // words it ("No model downloaded. Open Dictus to download a model."). A preparation
+        // screen here would name a model that will never become ready and never dismiss.
+        guard isModelDownloaded else {
+            return .startDictation
+        }
+        switch loadState {
+        case .loading:
+            return .presentPreparation
+        case .idle, .ready:
+            return .startDictation
+        }
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/ModelPreparationContextTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/ModelPreparationContextTests.swift
@@ -3,10 +3,35 @@ import XCTest
 
 final class ModelPreparationContextTests: XCTestCase {
 
-    func testOnlyKeyboardColdStartUsesPrepareOnlyFlow() {
+    func testOnlyTapDrivenContextsUsePrepareOnlyFlow() {
         XCTAssertFalse(ModelPreparationContext.onboarding.isPrepareOnly)
         XCTAssertFalse(ModelPreparationContext.modelSelection.isPrepareOnly)
         XCTAssertTrue(ModelPreparationContext.keyboardColdStart.isPrepareOnly)
+        XCTAssertTrue(ModelPreparationContext.appRecordTap.isPrepareOnly)
+    }
+
+    // MARK: - The two halves `isPrepareOnly` used to conflate (#484)
+
+    /// The in-app tap is the case that separates them: it must not auto-start a recording,
+    /// and the user never left Dictus. A `startedFromAnotherApp` that tracked `isPrepareOnly`
+    /// would put "Return to your app and tap the microphone again." in front of someone who
+    /// is looking at Dictus.
+    func testOnlyTheKeyboardBringsTheUserFromAnotherApp() {
+        XCTAssertTrue(ModelPreparationContext.keyboardColdStart.startedFromAnotherApp)
+        XCTAssertFalse(ModelPreparationContext.appRecordTap.startedFromAnotherApp)
+        XCTAssertFalse(ModelPreparationContext.onboarding.startedFromAnotherApp)
+        XCTAssertFalse(ModelPreparationContext.modelSelection.startedFromAnotherApp)
+    }
+
+    /// Whatever else changes, the two flags must not collapse back into one: at least one
+    /// context has to disagree with itself across them, or the split has been undone.
+    func testTheTwoFlagsAreNotTheSameQuestion() {
+        XCTAssertTrue(
+            ModelPreparationContext.allCases.contains {
+                $0.isPrepareOnly != $0.startedFromAnotherApp
+            },
+            "isPrepareOnly and startedFromAnotherApp agree on every context — the #484 split is gone"
+        )
     }
 
     // MARK: - Gave up vs finished (#428, third review finding D)

--- a/DictusCore/Tests/DictusCoreTests/RecordTapRoutingTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/RecordTapRoutingTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import DictusCore
+
+/// The rule that answers a record tap arriving during a model load (#484).
+///
+/// The bug this replaces was a button that swallowed twelve taps in silence, so the tests
+/// that matter are the ones that pin *which* taps get a screen and which are handed to the
+/// coordinator — including the three statuses #458 says must never be covered.
+final class RecordTapRoutingTests: XCTestCase {
+
+    private func decide(
+        _ status: DictationStatus,
+        downloaded: Bool = true,
+        load: ModelLoadState = .loading
+    ) -> RecordTapRouting.Decision {
+        RecordTapRouting.decide(
+            dictationStatus: status,
+            isModelDownloaded: downloaded,
+            loadState: load
+        )
+    }
+
+    // MARK: - The bug
+
+    /// Home. `MainTabView` covers the tabs with `RecordingView` for every status but `.idle`,
+    /// so a Home tap is always this one.
+    func testAnIdleTapDuringALoadPresentsInsteadOfStarting() {
+        XCTAssertEqual(decide(.idle), .presentPreparation)
+    }
+
+    /// The start-again mic on the result screen — the second entry point, and the one the
+    /// gate's `status != .idle` would have refused. `.ready` is a finished dictation the user
+    /// is choosing to leave; `.failed` is the cold-start refusal they are retrying.
+    func testTheResultScreenTapPresentsToo() {
+        XCTAssertEqual(decide(.ready), .presentPreparation)
+        XCTAssertEqual(decide(.failed), .presentPreparation)
+    }
+
+    // MARK: - #458: a running dictation is never covered
+
+    func testALiveDictationIsNeverGivenAPreparationScreen() {
+        for status in [DictationStatus.recording, .transcribing, .processing] {
+            XCTAssertEqual(
+                decide(status), .startDictation,
+                "\(status.rawValue) is a dictation still running — #458 forbids covering it"
+            )
+        }
+    }
+
+    /// The refusal list is the coordinator's own, not a second one written here. If
+    /// `canStartNewDictation` ever changes its mind about a status, this notices.
+    func testTheRefusalListIsTheCoordinatorsList() {
+        for status in DictationStatus.allCases {
+            let mayStart = ColdStartResolutionPolicy.canStartNewDictation(from: status)
+            XCTAssertEqual(
+                decide(status), mayStart ? .presentPreparation : .startDictation,
+                "\(status.rawValue) routes differently from the dictation it would have started"
+            )
+        }
+    }
+
+    // MARK: - Everything that is not a load
+
+    /// The ordinary path. Nothing about this issue may touch a tap made with a ready model.
+    func testAReadyModelStartsDictationAsBefore() {
+        for status in DictationStatus.allCases {
+            XCTAssertEqual(decide(status, load: .ready), .startDictation)
+            XCTAssertEqual(decide(status, load: .idle), .startDictation)
+        }
+    }
+
+    /// No model on disk is an error the coordinator words, not a wait. A preparation screen
+    /// here would name a model that can never become ready, on a screen with no exit (#428).
+    func testNoModelDownloadedFallsThroughToTheCoordinatorsError() {
+        XCTAssertEqual(decide(.idle, downloaded: false), .startDictation)
+        XCTAssertEqual(decide(.ready, downloaded: false), .startDictation)
+    }
+}


### PR DESCRIPTION
refs #484

## What this was for

Tapping **New dictation** on Home while a model load is in flight did nothing at all — no
overlay, no message, no disabled state. Twelve taps in eleven seconds, every one refused in
silence, because `startDictation`'s load guard returns `Void` and the published
`DictationStatus` never leaves `.idle`, so no view has anything to react to.

The keyboard already has an answer to this situation (#262 routes a cold-start mic tap to the
model preparation screen). The in-app button is the same refusal with no such route, and it is
the one path where the user is already inside the app and could be shown the truth for free.
This adds that route, on both in-app entry points.

## To test by hand

The window this issue lives in only exists while a load is genuinely slow, which needs the ANE.
A simulator has none, so none of the steps below were run on device by the agent.

1. Models tab → select **Turbo**. The preparation screen comes up.
2. Force-quit Dictus before the compile finishes.
3. Reopen Dictus and stay on **Home**. Tap **New dictation**.
   → Expect the preparation screen, naming **Turbo** and its phase, not a dead button.
4. Read the two sentences at the bottom of that screen.
   → Expect *"Votre dictée ne peut pas encore démarrer : Dictus prépare votre modèle…"* and
   *"Restez sur cette page, ne quittez pas l'application."* — not *"Retournez dans votre
   application…"*, which belongs to the keyboard path.
5. Wait for the compile to finish without touching anything.
   → Expect *"Modèle prêt"* + *"Appuyez à nouveau pour démarrer votre dictée."*, then the screen
   dismisses on its own after ~1.5 s and lands back on Home. **Nothing starts recording.**
6. Tap **New dictation** again.
   → Expect an ordinary recording, exactly as before this change.
7. Second entry point. With a model ready, do one normal dictation and stop it, so the result
   screen is showing. Then Models tab → select a different model → immediately go back and tap
   the mic on the result screen while the new model loads.
   → Expect the same preparation screen. Note the transcription you were looking at is **not**
   wiped on the way there.
8. #458 non-regression. Fresh install (cold Core ML cache), open the app, start an in-app
   dictation immediately and keep talking.
   → Expect the recording screen to stay put for the whole dictation. No preparation screen
   over a live recording.
9. Keyboard path non-regression (#262). From another app, force-quit Dictus mid-compile, then
   tap the keyboard mic.
   → Expect Dictus to open on the preparation screen with *"Retournez dans votre application et
   appuyez à nouveau sur le micro."* — the keyboard's wording, unchanged.

## What changed

**DictusCore**
- `ModelPreparationContext.appRecordTap` — the new fourth context.
- `isPrepareOnly` split in two. It carried both *"do not start recording by itself"* and
  *"you came here from another app"*, which held only while the keyboard was the sole
  prepare-only entry point. `startedFromAnotherApp` now carries the second half and is what
  chooses the completion sentence and the waiting notice.
- `RecordTapRouting.decide(dictationStatus:isModelDownloaded:loadState:)` — the rule the two
  buttons ask before calling in. Mirrors the coordinator guard's order exactly, so a tap the
  coordinator would answer with "No model downloaded" is not given a preparation screen for a
  model that is not on the device.

**DictusApp**
- `DictationCoordinator.recordTapDecision` reads the three inputs from the same places the guard
  reads them. In `+ModelLoad.swift`: the coordinator's main file is at the file-length budget
  #146 calibrated against it, and adding there broke `swiftlint --strict`.
- `MainTabView.preparingModelID` → `preparation`, carrying the model **and** the context
  together so a stale context cannot name the wrong flow. Its three URL-driven writers keep
  `.keyboardColdStart`.
- `PresentModelPreparationAction`, a small environment action, is how both buttons reach that
  state. They sit at different depths under `MainTabView`, and `RecordingView` has two
  construction sites outside it (`TestDictationView`, a `#Preview`) that have no root to present
  through.
- `ModelLoadingOverlay` gains the `.appRecordTap` explanation and completion line, and picks its
  waiting notice from `startedFromAnotherApp`.
- Two new strings, EN source + FR, in `DictusApp/Localizable.xcstrings`.

**The guard at `DictationCoordinator.swift:598` is untouched** — it is the backstop for every
other caller, the keyboard's Darwin path included.

## Where this departs from the brief, and why

The brief states the new presentation "happens while the dictation is `.idle`, which the gate
already allows". That is true of Home. **It is false of `RecordingView`**, the second entry point
the brief requires: the start-again mic is drawn on the result/error stage, where the status is
`.ready` or `.failed`. `ModelPreparationGate.dictationOwnsTheDisplay` is `status != .idle`, so
routing that tap through it would refuse the presentation and leave the exact bug in place on
that button.

So the rule for a **user-initiated** presentation is not the gate's. The gate answers "is a
dictation on screen", which is right for the three presenters it was written for — they raise the
screen off a load-state change behind the user's back. A tap whose entire meaning is "put that
away and record again" is the other kind, and once the model is ready that same tap replaces the
result screen anyway.

`RecordTapRouting` therefore delegates to `ColdStartResolutionPolicy.canStartNewDictation` — a
user tap may raise preparation exactly when it could have started a dictation. `.recording`,
`.transcribing` and `.processing` are refused, and those are the three that #458's acceptance
("a dictation already **recording** is never replaced") and #484's both name. `ModelPreparationGate`
is unchanged and its tests are untouched. **This is the one decision worth a second opinion
before merge.**

## Acceptance criteria

| Criterion | Status | Evidence |
| --- | --- | --- |
| Home tap during a load raises the preparation screen | Logic verified, device pending | `testAnIdleTapDuringALoadPresentsInsteadOfStarting` |
| The start-again button on the result screen too | Logic verified, device pending | `testTheResultScreenTapPresentsToo` (`.ready` and `.failed`) |
| The screen names model and phase, copy fits an in-app user | **Verified** | Simulator probe: "Turbo / CHARGEMENT", the new explanation, "Restez sur cette page…" |
| Nothing auto-starts; the screen dismisses; the next tap is normal | Partly verified | No auto-start code exists anywhere in the path; `.appRecordTap.isPrepareOnly == true`; completion line rendered in the probe. The 1.5 s dismissal is `ModelLoadingOverlay`'s shipped behaviour, unchanged. Device pending |
| A dictation already recording is never covered (#458) | Logic verified, device pending | `testALiveDictationIsNeverGivenAPreparationScreen`; `ModelPreparationGateTests` untouched and green |
| `swift test` and `swiftlint --strict` green | **Verified** | 1578 tests, 1 skipped, 0 failures; 0 violations in 245 files |

Also built green: `DictusApp` and `DictusKeyboard` for iOS Simulator (iPhone 17 Pro, `-configuration Debug`).

## Notes

- The two screenshots above came from a throwaway probe that forced the overlay's state at the
  app root (a simulator has no ANE, so the slow load cannot occur naturally there). **The probe
  was reverted before pushing** — `git status` clean, no `TEMPORARY #484` string anywhere in the
  tree.
- `Localizable.xcstrings` shows only the 22 lines of the two added strings. The build did not
  rewrite the file this time; nothing else was staged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tapping the record button while the speech model is loading now opens the model preparation screen instead of being ignored.
  * Model preparation screens now provide instructions tailored to how preparation was started, including in-app recording.
  * Recording and test-dictation actions continue normally when the model is ready.

* **Bug Fixes**
  * Prevented accidental clearing of existing results when dictation cannot start during model loading.

* **Tests**
  * Added coverage for recording behavior and model preparation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->