### PR TITLE
Land the polished text on the home card: return to idle, and stop deleting a refused result (refs #467, #495)

### DIFF
--- a/DictusApp/DictationCoordinator.swift
+++ b/DictusApp/DictationCoordinator.swift
@@ -321,7 +321,10 @@ class DictationCoordinator: ObservableObject {
             defaults.removeObject(forKey: SharedKeys.lastTranscriptionTimestamp)
             defaults.removeObject(forKey: SharedKeys.lastTranscriptionPolicy)
             defaults.removeObject(forKey: SharedKeys.lastTranscriptionDuration)
-            defaults.removeObject(forKey: SharedKeys.lastPolishedTranscription)
+            // Through the channel since #495: the polished text and the flag saying
+            // whether it was typed are one answer, and a sweep that took only half of
+            // it would leave the flag to describe the next dictation.
+            PolishedTextChannel.clear(in: defaults)
             defaults.synchronize()
         }
         if let pending = PendingDictationChannel.current, pending.isExpired() {

--- a/DictusApp/DictationHandoff.swift
+++ b/DictusApp/DictationHandoff.swift
@@ -247,9 +247,12 @@ extension DictationCoordinator {
         defaults.set(token, forKey: SharedKeys.handoffToken)
         defaults.set(Date().timeIntervalSince1970, forKey: SharedKeys.lastTranscriptionTimestamp)
         defaults.set(DictationStatus.ready.rawValue, forKey: SharedKeys.dictationStatus)
-        // The previous dictation's polished text, if the keyboard left one behind.
-        // Cleared here so `polishDidFinish` cannot be answered with a stale string.
-        defaults.removeObject(forKey: SharedKeys.lastPolishedTranscription)
+        // The previous dictation's answer, if the keyboard left one behind. Cleared
+        // here so `polishDidFinish` cannot be answered with a stale string — and since
+        // #495 the "was it typed" flag goes with it, which is why this is one call and
+        // not two `removeObject`s: a flag outliving its text would claim an insertion
+        // for whatever landed next.
+        PolishedTextChannel.clear(in: defaults)
         defaults.synchronize()
 
         DarwinNotificationCenter.post(DarwinNotificationName.statusChanged)
@@ -330,33 +333,48 @@ extension DictationCoordinator {
             PersistentLog.log(.polishHandoff(step: "finished", outcome: "stale-token", chars: 0))
             return
         }
-        let typed = defaults.string(forKey: SharedKeys.lastPolishedTranscription)
+        // What the keyboard produced, and whether the document received it — two facts
+        // since #495, where they used to be one. A refused insertion produces text too,
+        // and reading only "was something typed" is what deleted it.
+        let ending = PolishedTextChannel.read(from: defaults)
         // Captured before `endPolishHandoff` clears it. On the early path there is no
-        // typed text and there never will be, so the raw this dictation handed over is
-        // the only honest preview.
+        // produced text and there never will be, so the raw this dictation handed over
+        // is the only honest preview.
         let raw = polishHandoffPreview
         // Captured for the same reason `raw` is: `endPolishHandoff` clears it.
         let historyID = polishHandoffHistoryID
         endPolishHandoff(abandonedAs: nil)
-        // `typed` is nil when the keyboard refused to insert (decision 7), or when it
-        // has not tried yet. The dictation still ended for display purposes, so the
-        // Island still comes home — on the raw, because nothing was typed to preview.
-        if let typed {
-            lastResult = typed
-            // The history card catches up with what was actually typed (#70). A
-            // refusal leaves the raw standing, which is the honest record: the
-            // dictation happened, and the history is where the user recovers text
-            // their document never received.
+        // Nil when the generation produced nothing — a mode that failed, a watchdog
+        // that cancelled one — or when the keyboard has not tried yet. The dictation
+        // still ended for display purposes, so the Island still comes home, on the raw,
+        // because there is nothing else to preview.
+        if let produced = ending.text {
+            // Whether or not it was typed (#495). On a refusal the document received
+            // nothing, which makes this card the dictation's only copy — showing the
+            // raw there told the user their armed Smart Mode had failed, when it had
+            // succeeded and the result had been thrown away.
+            lastResult = produced
+            // The history record catches up with the same text (#70).
+            //
+            // **This reverses what stood here.** The old rule left the raw on a
+            // refusal, on the argument that the raw was the honest record of a
+            // dictation the document never received. That was written when the raw was
+            // the only text the dictation had. It is not: the polish ran and succeeded,
+            // and the history is the same kind of recovery surface as the card — the
+            // place a user goes for text their document never got. Recording the
+            // version they did not ask for there is the same defect one surface over.
             if let historyID {
-                TranscriptionHistoryStore.shared.updateText(id: historyID, to: typed)
+                TranscriptionHistoryStore.shared.updateText(id: historyID, to: produced)
             }
         }
         PersistentLog.log(.polishHandoff(
             step: "finished",
-            outcome: typed == nil ? "not-inserted" : "inserted",
-            chars: typed?.count ?? 0
+            // Three-valued since #495. `inserted` still means the document received it
+            // and nothing else does — that field is the instrument that diagnosed #467.
+            outcome: ending.logOutcome,
+            chars: ending.text?.count ?? 0
         ))
-        LiveActivityManager.shared.endWithResult(preview: typed ?? raw ?? lastResult)
+        LiveActivityManager.shared.endWithResult(preview: ending.text ?? raw ?? lastResult)
         // And this process has nothing left to show (#467). The `.ready` written at
         // hand-off was true about the app and never taken back, so `MainTabView` —
         // which mounts `RecordingView` for every status but `.idle` — left the
@@ -373,9 +391,9 @@ extension DictationCoordinator {
         //
         // There is nothing to present instead: the text is in the user's document and
         // `HomeView`'s card, which re-reads `lastResult` in `body`, is the copy
-        // surface. A refusal takes this path too — `lastResult` is then the raw the
-        // hand-off wrote, and the honest record ends up on the home card rather than
-        // under a recording screen the user did not ask for.
+        // surface. A refusal takes this path too, and since #495 the card is the whole
+        // point there — the document received nothing, so that card is the only place
+        // the dictation still exists.
         if PolishHandoffConclusion.returnsToIdle(from: status) {
             updateStatus(.idle)
         }

--- a/DictusApp/DictationHandoff.swift
+++ b/DictusApp/DictationHandoff.swift
@@ -357,6 +357,28 @@ extension DictationCoordinator {
             chars: typed?.count ?? 0
         ))
         LiveActivityManager.shared.endWithResult(preview: typed ?? raw ?? lastResult)
+        // And this process has nothing left to show (#467). The `.ready` written at
+        // hand-off was true about the app and never taken back, so `MainTabView` —
+        // which mounts `RecordingView` for every status but `.idle` — left the
+        // recording overlay standing over the home screen. Every later visit to
+        // DictusApp landed on it, and its result card is a one-shot `@State` copy
+        // taken at `.ready`, which is the instant `lastResult` deliberately still
+        // holds the raw. The user's document had the polished text; the screen the
+        // app opened on had the raw.
+        //
+        // Returning here rather than leaving it to the watchdog, which is the only
+        // thing that ever cleared it: on the clean path the watchdog is cancelled two
+        // lines up, so the `.ready` used to survive until the *next* dictation reset
+        // it. Same write, same rule, on the ending that actually happens.
+        //
+        // There is nothing to present instead: the text is in the user's document and
+        // `HomeView`'s card, which re-reads `lastResult` in `body`, is the copy
+        // surface. A refusal takes this path too — `lastResult` is then the raw the
+        // hand-off wrote, and the honest record ends up on the home card rather than
+        // under a recording screen the user did not ask for.
+        if PolishHandoffConclusion.returnsToIdle(from: status) {
+            updateStatus(.idle)
+        }
     }
 
     /// The keyboard never got back to us.
@@ -389,7 +411,11 @@ extension DictationCoordinator {
         // `ready` nobody consumed is what the next keyboard appearance would restore
         // its state from, and this process has stopped believing anything is in
         // flight.
-        if status == .ready {
+        //
+        // Through the shared rule since #467, which gave the same write to the ending
+        // that normally happens. The two conclusions of one hand-off have to leave the
+        // same thing behind.
+        if PolishHandoffConclusion.returnsToIdle(from: status) {
             updateStatus(.idle)
         }
         // And it withdraws the dictation, which is the half that was missing. Telling

--- a/DictusApp/Views/RecordingView.swift
+++ b/DictusApp/Views/RecordingView.swift
@@ -194,6 +194,26 @@ struct RecordingView: View {
             handleStatusChange(newStatus)
             advanceDisplayedStatus(to: newStatus)
         }
+        // The result can change after the status that revealed it (#467). On the
+        // keyboard hand-off path `.ready` is published while `lastResult` still holds
+        // the raw, on purpose — it is what the card should show if the keyboard never
+        // reports back — and the polished text replaces it seconds later, with no
+        // status change to carry it. A card snapshotted once at `.ready` therefore
+        // kept the raw for as long as it was on screen.
+        //
+        // #467's actual fix is that a completed hand-off now returns the app to
+        // `.idle`, which takes this screen down before the polished text arrives. This
+        // is the belt: the card cannot go stale if the screen is up for any other
+        // reason, and it costs one observer.
+        //
+        // A nil is deliberately not adopted. `startDictation` nils `lastResult` on
+        // every entry path, and blanking a card the user is reading is not what that
+        // write means — `startRecording` below clears the card itself when the reset
+        // is this screen's own.
+        .onChange(of: coordinator.lastResult) { _, newResult in
+            guard showResult, let newResult, !newResult.isEmpty else { return }
+            transcriptionResult = newResult
+        }
         // A screen that appears mid-dictation adopts the stage in flight at once,
         // rather than starting from `.idle` and pretending to enter it.
         .onAppear {

--- a/DictusCore/Sources/DictusCore/PolishHandoffConclusion.swift
+++ b/DictusCore/Sources/DictusCore/PolishHandoffConclusion.swift
@@ -1,0 +1,40 @@
+// DictusCore/Sources/DictusCore/PolishHandoffConclusion.swift
+// What DictusApp's own status becomes when a keyboard hand-off ends (#467).
+
+import Foundation
+
+/// Whether the end of a keyboard hand-off returns DictusApp to `.idle`.
+///
+/// WHY THIS EXISTS: since #361 a keyboard dictation ends in the extension, and DictusApp
+/// learns of it through `polishDidFinish`. Until #467 the app's own `status` was left at
+/// the `.ready` it wrote when it handed the raw over, and `MainTabView` mounts
+/// `RecordingView` for every status but `.idle` — so every later visit to DictusApp
+/// landed on the recording overlay, covering the home screen and its correct card.
+/// Measured on device 2026-09-04: `polishHandoff step=finished` at 14:01:50 with no
+/// `→ idle` after it, and the next dictation two seconds later still clearing a `.ready`.
+///
+/// WHY IT IS A RULE AND NOT AN `if` AT THE CALL SITE: a hand-off has two endings — the
+/// keyboard reporting in, and the watchdog concluding it never will — and they have to
+/// agree about what they leave behind. The predicate was already written out at the
+/// watchdog; #467 gave it a second caller.
+///
+/// THE CLASSIFICATION, which is the part with content: only `.ready` is a status this
+/// process wrote *about the hand-off* and can therefore take back. `.failed` is a
+/// sentence the user still has to read and outlives the dictation that produced it, and
+/// the four live statuses belong to a dictation that has replaced this one — clearing
+/// either would be the class of bug #260 and #261 are made of, arrived at from the app's
+/// side. The switch is exhaustive so a status added later has to be classified rather
+/// than silently swallowed (#267).
+public enum PolishHandoffConclusion {
+
+    /// - Parameter status: the coordinator's status at the moment the hand-off concluded.
+    /// - Returns: whether that status should be replaced by `.idle`.
+    public static func returnsToIdle(from status: DictationStatus) -> Bool {
+        switch status {
+        case .ready:
+            return true
+        case .idle, .requested, .recording, .transcribing, .processing, .failed:
+            return false
+        }
+    }
+}

--- a/DictusCore/Sources/DictusCore/PolishedTextChannel.swift
+++ b/DictusCore/Sources/DictusCore/PolishedTextChannel.swift
@@ -1,0 +1,118 @@
+// DictusCore/Sources/DictusCore/PolishedTextChannel.swift
+// What the keyboard produced, and whether the document received it (#495).
+
+import Foundation
+
+/// The end of a keyboard dictation, as the keyboard writes it and DictusApp reads it.
+///
+/// WHY THIS EXISTS: until #495 the App Group carried one value — the polished text —
+/// and its absence meant two different things. "The keyboard typed nothing" and "the
+/// keyboard produced nothing" are not the same event, and conflating them threw away a
+/// generation that had already succeeded. Measured on device 2026-09-05: `outcome:
+/// success` with 181 characters of English in the polish debug, and
+/// `polishHandoff step=finished outcome=not-inserted chars=0` in the log at the same
+/// second, because the insertion was refused (#391) and `finish` deleted the text on
+/// its way out. The user's document received nothing, so the home card was their only
+/// copy of that dictation, and it held the French they had armed a translation away
+/// from.
+///
+/// WHY A TYPE AND NOT A SECOND KEY WRITTEN BESIDE THE FIRST: the flag is only useful
+/// while it is never left behind. A stale `true` from a previous dictation claims an
+/// insertion that did not happen, and two keys touched by four call sites in two
+/// targets is exactly the shape where one site updates one key. Writing and clearing
+/// them together, behind one type, makes that unrepresentable — the same argument
+/// `DictationErrorChannel` makes about its own read, and `PendingDictationChannel`
+/// about who may clear a pending record.
+///
+/// The rule, in one line: **the text alone decides whether anything was produced; the
+/// flag only ever says where it went.** `read` returns `.nothing` when there is no
+/// text, whatever the flag says, so a flag that somehow survived on its own cannot
+/// invent an insertion.
+public enum PolishedTextChannel {
+
+    /// How the dictation ended.
+    public enum Ending: Equatable, Sendable {
+        /// The keyboard produced text and typed it into the user's document.
+        case inserted(String)
+        /// The keyboard produced text and refused to type it — the user had left the
+        /// field, dismissed the keyboard, or the host would not name the document
+        /// (#391). The refusal is correct; the text is still the dictation's only
+        /// copy, and DictusApp is where the user recovers it (#495).
+        case refused(String)
+        /// The keyboard produced nothing: an armed mode that failed, a generation that
+        /// returned empty, a watchdog that cancelled one. The raw DictusApp already
+        /// holds is the honest outcome here.
+        case nothing
+
+        /// The text this dictation produced, typed or not. Nil only for `.nothing`.
+        public var text: String? {
+            switch self {
+            case .inserted(let text), .refused(let text):
+                return text
+            case .nothing:
+                return nil
+            }
+        }
+
+        /// The `outcome` field of the `polishHandoff step=finished` log line.
+        ///
+        /// Three values since #495, and the two that existed before keep exactly the
+        /// meaning they had: `inserted` is a dictation the document received, and it
+        /// must never appear for one nothing typed — that field is the instrument that
+        /// diagnosed #467, and a fix that made it lie would cost more than the bug.
+        ///
+        /// WHY `refused-with-text` and not something shorter: the label has to survive
+        /// the greps already used on these captures, so it deliberately contains
+        /// neither `not-inserted` nor `inserted` as a substring. Grepping either of the
+        /// old labels still returns exactly the lines it used to.
+        public var logOutcome: String {
+            switch self {
+            case .inserted:
+                return "inserted"
+            case .refused:
+                return "refused-with-text"
+            case .nothing:
+                return "not-inserted"
+            }
+        }
+    }
+
+    /// Write what this dictation produced and where it went.
+    ///
+    /// Called from the keyboard, immediately before `polishDidFinish` is posted: a bare
+    /// Darwin notification says only "some polish finished", and the app decides on what
+    /// it reads next.
+    public static func record(_ ending: Ending, in defaults: UserDefaults = AppGroup.defaults) {
+        guard let text = ending.text else {
+            clear(in: defaults)
+            return
+        }
+        defaults.set(text, forKey: SharedKeys.lastPolishedTranscription)
+        defaults.set(ending == .inserted(text), forKey: SharedKeys.lastPolishedWasInserted)
+        defaults.synchronize()
+    }
+
+    /// Drop both halves. Called wherever the polished text was already being dropped —
+    /// DictusApp clearing the previous dictation's answer as it hands a new one over,
+    /// and the launch sweep — because a flag outliving the text it describes is the one
+    /// way this channel can lie.
+    public static func clear(in defaults: UserDefaults = AppGroup.defaults) {
+        defaults.removeObject(forKey: SharedKeys.lastPolishedTranscription)
+        defaults.removeObject(forKey: SharedKeys.lastPolishedWasInserted)
+        defaults.synchronize()
+    }
+
+    /// What the keyboard left behind.
+    ///
+    /// Answering `.nothing` for a missing text is what makes the flag unable to speak on
+    /// its own. Callers still have to establish that the answer belongs to *their*
+    /// hand-off — `SharedKeys.lastPolishedHandoffToken` is what says so.
+    public static func read(from defaults: UserDefaults = AppGroup.defaults) -> Ending {
+        guard let text = defaults.string(forKey: SharedKeys.lastPolishedTranscription) else {
+            return .nothing
+        }
+        return defaults.bool(forKey: SharedKeys.lastPolishedWasInserted)
+            ? .inserted(text)
+            : .refused(text)
+    }
+}

--- a/DictusCore/Sources/DictusCore/SharedKeys.swift
+++ b/DictusCore/Sources/DictusCore/SharedKeys.swift
@@ -146,10 +146,23 @@ public enum SharedKeys {
     /// yet typed. Read and written only through `PendingDictationChannel`, which is
     /// where the rule about who clears it lives.
     public static let pendingDictation = "dictus.pendingDictation"
-    /// String: the final text the keyboard typed, written back just before the
+    /// String: the final text the keyboard produced, written back just before the
     /// insertion so DictusApp can show the polished version rather than the raw one
     /// in its Live Activity preview and its last-transcription card (#361 decision 6).
+    ///
+    /// Since #495 its presence means the text *exists*, not that it was typed — a
+    /// refused insertion produces text too, and deleting it left the user's only copy
+    /// of that dictation on the raw. `lastPolishedWasInserted` below is what says where
+    /// it went. Read and written only through `PolishedTextChannel`, which is where the
+    /// rule about the two keys moving together lives.
     public static let lastPolishedTranscription = "dictus.lastPolishedTranscription"
+    /// Bool: whether the text in `lastPolishedTranscription` reached the user's
+    /// document, or was produced and refused (#391, #495).
+    ///
+    /// Never read on its own — a flag that outlived its text would claim an insertion
+    /// that did not happen, so `PolishedTextChannel.read` ignores it unless there is a
+    /// text beside it, and the two keys are only ever written and cleared together.
+    public static let lastPolishedWasInserted = "dictus.lastPolishedWasInserted"
     /// String: a fresh identifier DictusApp writes with each hand-off, which the
     /// keyboard carries and echoes back on `polishDidFinish`.
     ///

--- a/DictusCore/Tests/DictusCoreTests/PolishHandoffConclusionTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/PolishHandoffConclusionTests.swift
@@ -1,0 +1,50 @@
+// DictusCore/Tests/DictusCoreTests/PolishHandoffConclusionTests.swift
+// Tests for the status a concluded keyboard hand-off leaves behind (#467).
+
+import XCTest
+@testable import DictusCore
+
+final class PolishHandoffConclusionTests: XCTestCase {
+
+    /// The state the device capture found: `.ready` written at hand-off, never taken
+    /// back, so `MainTabView` kept the recording overlay mounted over the home screen.
+    func testReadyIsTakenBack() {
+        XCTAssertTrue(PolishHandoffConclusion.returnsToIdle(from: .ready))
+    }
+
+    /// A failure is a sentence the user still has to read, and it outlives the
+    /// dictation that produced it.
+    func testFailedIsLeftStanding() {
+        XCTAssertFalse(PolishHandoffConclusion.returnsToIdle(from: .failed))
+    }
+
+    /// A dictation that has replaced this one owns the status now. Concluding the old
+    /// hand-off must not tear the new one down.
+    func testALiveDictationIsLeftStanding() {
+        for status in [DictationStatus.requested, .recording, .transcribing, .processing] {
+            XCTAssertFalse(
+                PolishHandoffConclusion.returnsToIdle(from: status),
+                "concluding a hand-off cleared \(status.rawValue)"
+            )
+        }
+    }
+
+    /// Nothing to take back, so nothing is written — this is what keeps the watchdog
+    /// and the clean ending from logging a status change apiece for one dictation.
+    func testIdleIsNotRewritten() {
+        XCTAssertFalse(PolishHandoffConclusion.returnsToIdle(from: .idle))
+    }
+
+    /// `.ready` is the only status the hand-off itself produces, so it has to be the
+    /// only one taken back. Swept over `allCases` so a status added later joins the
+    /// assertion instead of slipping past a hand-written list.
+    func testReadyIsTheOnlyStatusTakenBack() {
+        for status in DictationStatus.allCases {
+            XCTAssertEqual(
+                PolishHandoffConclusion.returnsToIdle(from: status),
+                status == .ready,
+                "unclassified status \(status.rawValue)"
+            )
+        }
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/PolishedTextChannelTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/PolishedTextChannelTests.swift
@@ -1,0 +1,123 @@
+// DictusCore/Tests/DictusCoreTests/PolishedTextChannelTests.swift
+// Tests for the pair the keyboard leaves behind: what it produced, and where it went
+// (#495).
+
+import XCTest
+@testable import DictusCore
+
+final class PolishedTextChannelTests: XCTestCase {
+
+    /// A suite of its own: these tests write the same keys the keyboard writes, and the
+    /// shared App Group suite is live state on a developer machine.
+    private let suiteName = "dictus.tests.polishedTextChannel"
+    private var defaults = UserDefaults.standard
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    // MARK: - Round trip
+
+    func testAnInsertedTextIsReadBackAsInserted() {
+        PolishedTextChannel.record(.inserted("Hello there. "), in: defaults)
+
+        XCTAssertEqual(PolishedTextChannel.read(from: defaults), .inserted("Hello there. "))
+    }
+
+    /// The case #495 exists for: the generation succeeded, the insertion was refused,
+    /// and the text is still the dictation's only copy.
+    func testARefusedTextIsReadBackAsRefusedAndNotAsNothing() {
+        PolishedTextChannel.record(.refused("Okay, and so there I'm going to do the famous test"), in: defaults)
+
+        XCTAssertEqual(
+            PolishedTextChannel.read(from: defaults),
+            .refused("Okay, and so there I'm going to do the famous test")
+        )
+    }
+
+    func testNothingIsReadBackAsNothing() {
+        PolishedTextChannel.record(.nothing, in: defaults)
+
+        XCTAssertEqual(PolishedTextChannel.read(from: defaults), .nothing)
+    }
+
+    func testAnEmptyChannelReadsAsNothing() {
+        XCTAssertEqual(PolishedTextChannel.read(from: defaults), .nothing)
+    }
+
+    // MARK: - The flag can never speak on its own
+
+    /// Recording `.nothing` over a previous answer takes the flag with it. Left behind,
+    /// it would claim an insertion for whatever text landed next.
+    func testRecordingNothingClearsAPreviousInsertion() {
+        PolishedTextChannel.record(.inserted("typed"), in: defaults)
+        PolishedTextChannel.record(.nothing, in: defaults)
+
+        XCTAssertEqual(PolishedTextChannel.read(from: defaults), .nothing)
+        XCTAssertFalse(defaults.bool(forKey: SharedKeys.lastPolishedWasInserted))
+    }
+
+    func testClearTakesBothHalves() {
+        PolishedTextChannel.record(.inserted("typed"), in: defaults)
+        PolishedTextChannel.clear(in: defaults)
+
+        XCTAssertEqual(PolishedTextChannel.read(from: defaults), .nothing)
+        XCTAssertNil(defaults.string(forKey: SharedKeys.lastPolishedTranscription))
+        XCTAssertFalse(defaults.bool(forKey: SharedKeys.lastPolishedWasInserted))
+    }
+
+    /// The defensive half of the rule, forced by writing the keys apart the way only a
+    /// bug could: a flag with no text beside it says nothing at all.
+    func testAFlagLeftBehindWithNoTextCannotClaimAnInsertion() {
+        defaults.set(true, forKey: SharedKeys.lastPolishedWasInserted)
+
+        XCTAssertEqual(PolishedTextChannel.read(from: defaults), .nothing)
+    }
+
+    /// And the mirror: a text whose flag went missing is read as refused, never as
+    /// inserted. The channel fails towards "the document did not get this".
+    func testATextWithNoFlagIsReadAsRefused() {
+        defaults.set("orphan", forKey: SharedKeys.lastPolishedTranscription)
+
+        XCTAssertEqual(PolishedTextChannel.read(from: defaults), .refused("orphan"))
+    }
+
+    // MARK: - The log vocabulary
+
+    func testTheThreeEndingsCarryTheThreeLabels() {
+        XCTAssertEqual(PolishedTextChannel.Ending.inserted("a").logOutcome, "inserted")
+        XCTAssertEqual(PolishedTextChannel.Ending.refused("a").logOutcome, "refused-with-text")
+        XCTAssertEqual(PolishedTextChannel.Ending.nothing.logOutcome, "not-inserted")
+    }
+
+    /// `outcome=inserted` must never appear for a dictation nothing typed. That field
+    /// is the instrument that diagnosed #467.
+    func testOnlyAnInsertionIsLabelledInserted() {
+        for ending in [PolishedTextChannel.Ending.refused("a"), .nothing] {
+            XCTAssertNotEqual(ending.logOutcome, "inserted", "\(ending) claimed an insertion")
+        }
+    }
+
+    /// The labels have to survive the greps already used on these captures: neither old
+    /// label may match the new one, in either direction.
+    func testTheNewLabelIsDisjointFromTheOldOnes() {
+        let refused = PolishedTextChannel.Ending.refused("a").logOutcome
+        XCTAssertFalse(refused.contains("not-inserted"))
+        XCTAssertFalse(refused.contains("inserted"))
+    }
+
+    // MARK: - The text, typed or not
+
+    func testTheProducedTextIsReadableWhicheverWayItEnded() {
+        XCTAssertEqual(PolishedTextChannel.Ending.inserted("a").text, "a")
+        XCTAssertEqual(PolishedTextChannel.Ending.refused("a").text, "a")
+        XCTAssertNil(PolishedTextChannel.Ending.nothing.text)
+    }
+}

--- a/DictusKeyboard/KeyboardPolishCoordinator.swift
+++ b/DictusKeyboard/KeyboardPolishCoordinator.swift
@@ -194,13 +194,17 @@ final class KeyboardPolishCoordinator {
         // whose transformation never ran: typing its raw here would insert French
         // under "→ EN", which is exactly what `PolishTask.isSmart` forbids — and this
         // is the path nobody watches, because it has never fired in any device
-        // session. The other two sites are `run(_:)` above and `finish(text:insert:)`.
+        // session. The other two sites are `run(_:)` above and
+        // `finish(reporting:inserting:)`.
         if let mode = pending.smartMode {
             PersistentLog.log(.smartModeRefused(
                 mode: mode.id, outcome: "recovered", reason: "no-generation"
             ))
             PersistentLog.log(.polishHandoff(step: "recovered", outcome: "smart-refused", chars: pending.raw.count))
-            finish(text: nil, insert: false)
+            // Nothing to report and nothing to type: no generation ever ran for this
+            // record, so the raw DictusApp already holds is all this dictation has
+            // (#495 changed only the branch where a result exists).
+            finish(reporting: nil, inserting: nil)
             announce(
                 SmartModeFailure(
                     modeIdentifier: mode.id,
@@ -214,7 +218,10 @@ final class KeyboardPolishCoordinator {
         }
 
         PersistentLog.log(.polishHandoff(step: "recovered", outcome: "raw", chars: pending.raw.count))
-        finish(text: DictationTail.apply(pending.raw, policy: pending.policy), insert: true)
+        // Typed, so the app is told the same string the document received — the tailed
+        // one, which is what `lastResult` has always carried on the inserted paths.
+        let recovered = DictationTail.apply(pending.raw, policy: pending.policy)
+        finish(reporting: recovered, inserting: recovered)
         // The dictation this record carries ran Normal because a mode was resolved
         // away, and it is still owed the sentence (#423). After `finish`, for the
         // same reason as in `run(_:)`.
@@ -273,7 +280,18 @@ final class KeyboardPolishCoordinator {
                 reason = current == nil ? "no-identifier" : "different-document"
             }
             PersistentLog.log(.polishInsertionRefused(reason: reason, ageMs: pending.ageMs))
-            finish(text: nil, insert: false)
+            // The refusal is about the document, not about the text (#495). This branch
+            // runs *after* the generation returned, so `outcome.text` is usually a
+            // finished polish — measured at 2,769 ms and 181 characters of English on
+            // the capture that filed the issue — and it used to be deleted here. The
+            // document received nothing, which is correct and stays; that makes
+            // DictusApp's card the dictation's only copy, and it was showing the raw.
+            //
+            // No `DictationTail`: the tail is a separator that keeps chained dictations
+            // from sticking together in a host field. Nothing was typed, so there is
+            // nothing to separate, and the card is a copy surface — a trailing `". "`
+            // would be pasted into wherever the user takes the text next.
+            finish(reporting: outcome.text, inserting: nil)
             return
         }
 
@@ -292,9 +310,14 @@ final class KeyboardPolishCoordinator {
         let degraded = outcome.isDegraded
 
         if let polished = outcome.text {
-            finish(text: DictationTail.apply(polished, policy: pending.policy), insert: true)
+            // The insertion was not refused above, so the app hears the same string the
+            // document receives, tail included.
+            let tailed = DictationTail.apply(polished, policy: pending.policy)
+            finish(reporting: tailed, inserting: tailed)
         } else {
-            finish(text: nil, insert: false)
+            // A mode that produced nothing insertable. There is no text to report
+            // either, so DictusApp stays on the raw — the honest outcome (#79).
+            finish(reporting: nil, inserting: nil)
         }
 
         // After `finish`, never before: a successful insertion clears the toolbar's
@@ -477,7 +500,9 @@ final class KeyboardPolishCoordinator {
         activePolish = nil
         stageWatchdog = nil
         PendingDictationChannel.clear()
-        finish(text: nil, insert: false)
+        // The generation was cancelled a line above, so there is nothing to report and
+        // nothing to type. DictusApp concludes on the raw it handed over.
+        finish(reporting: nil, inserting: nil)
     }
 
     /// Tell DictusApp the dictation is over for display purposes, without touching the
@@ -545,19 +570,36 @@ final class KeyboardPolishCoordinator {
     /// End the dictation: hand the final text back to DictusApp, tell it we are done,
     /// and type — in that order, so the app's Live Activity preview is the text the
     /// user is about to see rather than the raw it handed over.
-    private func finish(text: String?, insert: Bool) {
-        if let text, insert {
-            defaults.set(text, forKey: SharedKeys.lastPolishedTranscription)
+    ///
+    /// **Two decisions, two parameters (#495).** What DictusApp is told and what the
+    /// document receives used to travel on one `insert` flag, and that flag deleted the
+    /// text on its way past: a generation the user's document was refused was also a
+    /// generation the app never heard about, so the home card fell back to the raw and
+    /// the dictation's only surviving copy was the version the user had not asked for.
+    /// They are the same string on every path that types — the tailed text goes to both
+    /// — and they differ only where the insertion is refused with a result in hand.
+    ///
+    /// - Parameters:
+    ///   - reported: what this dictation produced, for DictusApp to show and store.
+    ///     Nil when the generation produced nothing, which leaves the app on the raw it
+    ///     already holds.
+    ///   - inserted: what to type into the host document, or nil to type nothing.
+    private func finish(reporting reported: String?, inserting inserted: String?) {
+        // Before `postDidFinish`, never after, for the reason `postDidFinish` gives
+        // about the token: a bare Darwin notification says only "some polish finished",
+        // and the app decides on what it reads next.
+        if let reported {
+            PolishedTextChannel.record(inserted == nil ? .refused(reported) : .inserted(reported))
         } else {
-            defaults.removeObject(forKey: SharedKeys.lastPolishedTranscription)
+            PolishedTextChannel.record(.nothing)
         }
         postDidFinish()
 
-        guard let text, insert else {
+        guard let inserted else {
             KeyboardState.shared.endLocalProcessingStage()
             return
         }
-        KeyboardState.shared.insertDictation(text)
+        KeyboardState.shared.insertDictation(inserted)
     }
 
     // MARK: - Reading what travelled


### PR DESCRIPTION
Two issues, one PR, because they share a surface — the home card — and one device test. **#467** is why the card is in front of the user at all; **#495** is why the text on it is the right one.

## What this was for

**#467 — the app opened on a stale overlay.** After a keyboard dictation, opening DictusApp landed on the recording overlay showing the **raw** transcription, while the host document had the polished text. Confirmed on device 2026-09-04 (`rev c08136f`, Translate → English armed, spoken French): the document got the English, the screen the app opened on showed the French. The home card was never the defect — it shows the polished text and always did. It was **covered** by a recording overlay that a completed keyboard hand-off never took down.

**#495 — a refused insertion threw away the text it had produced.** When the keyboard refuses to insert (the user left the field, switched app, dismissed the keyboard), the polished text was already generated and then deliberately deleted. The app was told "nothing was typed", fell back to the raw, and the card showed French where the user armed Translate → English. Confirmed on device 2026-09-05, on this branch at `f4d9a3d`: `outcome: success`, `engineMs: 2769`, 181 characters of English in the polish debug — and `polishHandoff step=finished outcome=not-inserted chars=0` in the log at the same second. The Smart Mode did not fail. It succeeded and the result was discarded.

Together: the document received nothing on that path, so the home card is the user's **only** copy of that dictation — and #467 is what makes them land on it.

## To test by hand

Nothing below was verified at runtime. Both fixes need a real keyboard dictation with polish, which the simulator cannot produce headlessly. Phase 4 covered the build, the tests and the lint only.

**#467's overlay fix was validated on device at `f4d9a3d`; the three commits added since then un-validate this PR, so steps 3, 8 and 9 re-cover it.**

Arm **Translate → English** in the keyboard's mic fan (long-press the mic) and keep it armed throughout, so raw and polished are unmistakably different.

1. In Notes, dictate a sentence **in French** with the Dictus keyboard. Let it insert. → The document receives the English.
2. Switch to DictusApp. → You land on the **home dashboard**, not on the recording screen (centred card, "Touchez le texte pour copier", X top-left, mic below). **(#467)**
3. Read the "Dernière transcription" card. → The **English**, same as the document. Tap it → "Copié !", and pasting gives the English. **(#467)**
4. Now the refusal. In Notes, start a dictation in French and **leave the app while it is transcribing** (swipe home, or switch app). → Nothing is typed anywhere. **(#495)**
5. Open DictusApp. → Home dashboard, and the card holds the **English** — the text the refused insertion produced. Before this branch it held the French. **(#495, criterion 1)**
6. Tap the card. → Pasting yields the English. **(criterion 1)**
7. Check the log for that dictation. → `polishInsertionRefused` with its reason (`off-screen`, `no-identifier` or `different-document`), and `polishHandoff step=finished outcome=refused-with-text chars=<n>`. **`outcome=inserted` must not appear.** **(criteria 2 and 3)**
8. A refusal that produced nothing: dictate something very short or let a mode fail, with the keyboard away from the field. → The card holds the **raw**, and the log says `outcome=not-inserted chars=0`. **(criterion 4)**
9. A normal keyboard dictation that inserts, end to end. → Document gets the English, card gets the English, log says `outcome=inserted`. **(criterion 5)**
10. Dictate **from inside DictusApp** ("Nouvelle dictée"). → The recording screen stays up when it finishes and shows its result; the X dismisses it. This path must be unchanged. **(criterion 5)**
11. Force-quit and relaunch. → No transcription card at all.

## What changed

### #467 — three commits (`4d1f089`, `ead5e22`, `f4d9a3d`)

1. **`PolishHandoffConclusion` (DictusCore).** Which status a concluded hand-off may take back. Only `.ready` — a `.failed` is a sentence the user still has to read, and the four live statuses belong to a dictation that has replaced this one.
2. **`polishHandoffFinished` returns the app to `.idle`.** `MainTabView` mounts `RecordingView` on `status != .idle`, and nothing ever wrote `.idle` on the path where the keyboard reports in — only `cancelDictation`, the overlay's own X, and the polish watchdog. The watchdog's own `.ready` check moves to the same rule, so the two endings of one hand-off leave the same thing behind.
3. **`RecordingView` tracks `coordinator.lastResult`** instead of snapshotting it once at `.ready`. The belt.

The cause, in three moves: `.ready` is published on the keyboard path while `lastResult` still deliberately holds the raw (so the `@State` copy is taken at the raw by construction); the polished text arrives later with no status change to carry it, so it reaches no observer; and the overlay was still mounted. The device log settles the third — `step=finished` at 14:01:50, then `from=ready to=clearing-for-new` at 14:01:52, with no `→ idle` between them.

### #495 — three commits (`a42644e`, `62b0471`, `727ac36`)

1. **`PolishedTextChannel` (DictusCore).** The pair — what the keyboard produced, and whether the document received it — behind one type, the way `PendingDictationChannel` and `DictationErrorChannel` own their keys. A type rather than a bare second key because the brief's own requirement is that the flag is *never left behind*: a stale `true` claims an insertion that did not happen, and two keys touched by four call sites in two targets is the shape where one site updates one key. `record` writes both, `clear` clears both, and `read` answers `.nothing` without a text whatever the flag says — so a flag can never speak on its own.

2. **`finish(text:insert:)` becomes `finish(reporting:inserting:)`.** The two decisions — what the app is told, what the document receives — were riding one flag, and that flag is what deleted the text. They are the same string on every path that types and differ only at the refusal. The refusal branch now passes `outcome.text`, which it already had in hand:

   ```swift
   PersistentLog.log(.polishInsertionRefused(reason: reason, ageMs: pending.ageMs))
   finish(reporting: outcome.text, inserting: nil)
   ```

   **No `DictationTail`** on that path: nothing was typed, so there is nothing to separate, and a trailing `". "` would follow the text into wherever the user pastes it.

3. **The four consumers.** `lastResult` and the history `updateText` take the produced text whether or not it was typed; the log outcome is three-valued; the Live Activity follows `lastResult`. Both clearing sites (`DictationHandoff` on hand-off, the launch sweep) go through the channel.

Only one of the four `finish(…nil, nil)` sites ever had text — the refusal. The other three (recovery with an armed mode and no generation, a generation that returned nothing, the stage watchdog) genuinely have none, and the raw stays the right outcome there. Verified by reading each.

### What deliberately did not change

- **`mayInsert` and the refusal itself.** Untouched, with its three reasons and its `polishInsertionRefused` line. Typing into a document the user did not choose is what this product refuses everywhere (#391).
- **The keyboard's toolbar message.** The refusal branch still returns before the `announce` block.
- **`outcome=inserted`.** Produced only by `.inserted`, which is written only by a `finish` that goes on to call `insertDictation`. A test asserts that neither other ending can carry that label, and `refused-with-text` deliberately contains neither `not-inserted` nor `inserted` as a substring, so the greps already used on these captures keep returning exactly the lines they used to.
- **The inserted path and the in-app path.** Byte for byte, apart from the `finish` signature.

## The history reversal, stated plainly

#495's brief reverses the rule that stood at `DictationHandoff.swift:346-349`: a refusal used to leave the **raw** in a subscriber's history record, as "the honest record". It now gets the **polished** text, like the card. The old reasoning was written when the raw was the only text the dictation had; it is not, and the history is the same kind of recovery surface as the card — the place a user goes for text their document never received. The comment has been rewritten to say what it now does and why.

**This path is unexercised in the shipping build and could not be tested.** `TranscriptionHistoryStore.append` returns nil without the Pro entitlement, so `polishHandoffHistoryID` is nil and `updateText` is never reached. The change is correct by reading and unverifiable by running, on device or otherwise.

## Known asymmetry, reported not fixed

On the inserted path `lastResult` receives the **tailed** text, so the home card carries a trailing separator; the new refused path writes the **untailed** text. The inconsistency predates #495, is invisible at the card's three-line cap, and changing the inserted path would alter behaviour validated on `f4d9a3d`. Named here as the issue asks; not fixed.

## Acceptance criteria

**#467**

| # | criterion | status |
|---|---|---|
| 1 | home card shows what the document received | **manual** — step 3 |
| 2 | cause named with its evidence | **met** — above |
| 3 | a refused insertion still leaves the raw | **superseded by #495** — it now leaves the *polished* text when one exists, and the raw when none does (step 8). The change is deliberate and is #495's whole point. |
| 4 | copying the card yields the polished text | **manual** — steps 3 and 6 |
| 5 | history path | see the reversal above |
| 6 | device, mixed-language | **manual** |

**#495**

| # | criterion | status |
|---|---|---|
| 1 | card shows the English, copying yields the English | **manual** — steps 5 and 6 |
| 2 | document still receives nothing, `polishInsertionRefused` still logged | **met by construction** (`mayInsert` untouched), visible at step 7 |
| 3 | three endings distinguished, `inserted` never lies | **met + tested** in DictusCore; visible at steps 7, 8, 9 |
| 4 | a refusal that produced nothing still leaves the raw | **met by construction** (`.nothing`), step 8 |
| 5 | inserted path and in-app path unchanged | **met by construction**, steps 9 and 10 |
| 6 | the PR says what happens to a subscriber's history, and that it could not be exercised | **met** — above |
| 7 | device, mixed-language | **manual** |

## Verification run

```
xcodebuild build -scheme DictusApp -destination 'platform=iOS Simulator,id=1720B34A…'
  ** BUILD SUCCEEDED **           (builds the embedded keyboard, widgets and DictusCore)

cd DictusCore && swift test
  Executed 1625 tests, with 1 test skipped and 0 failures (0 unexpected) in 14.921s

swiftlint lint --strict
  Done linting! Found 0 violations, 0 serious in 249 files.
```

Seventeen new tests: five on `PolishHandoffConclusion` (including a sweep over `DictationStatus.allCases`), twelve on `PolishedTextChannel` — the round trip for all three endings, the clearing rule, both halves of "a flag can never speak on its own", and the three log labels including the grep-disjointness.

Not unit-testable here, and not faked: the `RecordingView` and `MainTabView` behaviour, and the `finish` / `polishHandoffFinished` call-site wiring. `swift test` covers DictusCore only and there is no host-app test target, so assertions there would restate the code rather than exercise it.

`Localizable.xcstrings` was not regenerated and nothing else was left dirty.

refs #467, refs #495


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Polished transcription results now remain visible even when insertion into the active document is declined.
  * Recording results update reliably when polished text arrives, preventing stale result cards.
  * Dictation handoff cleanup now keeps transcription text and insertion status synchronized.
  * Dictation status returns to idle more consistently after keyboard handoff completion.
  * Empty or incomplete handoff results no longer appear as successful insertions.
  * Dictation history now records polished text even when document insertion is refused.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->