### PR TITLE
Tell the user when a model download has lost the network (refs #492)

### DIFF
--- a/Dictus.xcodeproj/project.pbxproj
+++ b/Dictus.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		AA000050 /* ModelManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100050 /* ModelManager.swift */; };
 		AA000052 /* ModelRepoDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100052 /* ModelRepoDownloader.swift */; };
 		AA000449 /* BackgroundModelDownloadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100449 /* BackgroundModelDownloadService.swift */; };
+		AA000492 /* DownloadConnectivityWatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100492 /* DownloadConnectivityWatch.swift */; };
 		AA000051 /* ModelManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100051 /* ModelManagerView.swift */; };
 		AA000060 /* ToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA100060 /* ToolbarView.swift */; };
 		AA00006L /* KeyboardPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10006L /* KeyboardPanelView.swift */; };
@@ -232,6 +233,7 @@
 		AA100050 /* ModelManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelManager.swift; sourceTree = "<group>"; };
 		AA100052 /* ModelRepoDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelRepoDownloader.swift; sourceTree = "<group>"; };
 		AA100449 /* BackgroundModelDownloadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundModelDownloadService.swift; sourceTree = "<group>"; };
+		AA100492 /* DownloadConnectivityWatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadConnectivityWatch.swift; sourceTree = "<group>"; };
 		AA100051 /* ModelManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelManagerView.swift; sourceTree = "<group>"; };
 		AA100060 /* ToolbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarView.swift; sourceTree = "<group>"; };
 		AA10006L /* KeyboardPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPanelView.swift; sourceTree = "<group>"; };
@@ -588,6 +590,7 @@
 				AA100050 /* ModelManager.swift */,
 				AA100052 /* ModelRepoDownloader.swift */,
 				AA100449 /* BackgroundModelDownloadService.swift */,
+				AA100492 /* DownloadConnectivityWatch.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1013,6 +1016,7 @@
 				AA000050 /* ModelManager.swift in Sources */,
 				AA000052 /* ModelRepoDownloader.swift in Sources */,
 				AA000449 /* BackgroundModelDownloadService.swift in Sources */,
+				AA000492 /* DownloadConnectivityWatch.swift in Sources */,
 				AA000051 /* ModelManagerView.swift in Sources */,
 				AA000071 /* TestDictationView.swift in Sources */,
 				AA000090 /* MainTabView.swift in Sources */,

--- a/DictusApp/Models/BackgroundModelDownloadService.swift
+++ b/DictusApp/Models/BackgroundModelDownloadService.swift
@@ -527,8 +527,18 @@ final class BackgroundModelDownloadService: NSObject, @unchecked Sendable {
     /// transport failures, and this is not one — `DownloadStallPolicy` has already
     /// established that the device has no route at all, so a retry two seconds later can
     /// only park a second time and spend the user's remaining attempts saying nothing.
-    /// Nothing is lost by stopping: every chunk that landed is on disk and in the
-    /// manifest, so the Retry the user now has resumes at the byte the transfer reached.
+    ///
+    /// WHAT STOPPING COSTS, exactly. Every chunk that LANDED is on disk and in the
+    /// manifest, so the Retry resumes at the last chunk boundary — not at the byte the
+    /// progress bar was showing. The chunks still in flight are cancelled with the run and
+    /// their bytes are gone: `didFinishDownloadingTo` fires on success alone, so a
+    /// cancelled task's partial file is one the system deletes and nothing here ever sees.
+    /// At 32 MB a chunk and two in flight that is up to 64 MB re-paid on the retry, and on
+    /// a file whose first chunk had not landed yet it legitimately reads as 0%. Measured
+    /// on device on 2026-09-06: a cut inside the first chunk of a 176 MB `weight.bin`
+    /// re-paid 49 MB. Cancelling is not what loses them — a chunk delivered to a run
+    /// `finish` has already removed from `runs` is dropped by the guard in
+    /// `didFinishDownloadingTo` anyway — but the choice to fail the run is.
     ///
     /// WHY ONLY RUNS WITH A CONTINUATION. A run nobody is awaiting is one `restore()`
     /// rebuilt and no screen has claimed yet. There is nowhere to deliver an error, and

--- a/DictusApp/Models/BackgroundModelDownloadService.swift
+++ b/DictusApp/Models/BackgroundModelDownloadService.swift
@@ -127,10 +127,10 @@ final class BackgroundModelDownloadService: NSObject, @unchecked Sendable {
     /// only thing that can notice a transfer iOS has parked (issue #492): a background
     /// session that loses connectivity delivers no callback at all, so the state machine
     /// below is never told and never fails. Runs only while there is a run to watch.
-    private lazy var connectivity = DownloadConnectivityWatch { [weak self] snapshot in
+    private lazy var connectivity = DownloadConnectivityWatch { [weak self] observed in
         guard let self else { return }
         self.queue.addOperation { [weak self] in
-            self?.reportOfflineStalls(snapshot)
+            self?.reportOfflineStalls(observed: observed)
         }
     }
 
@@ -533,14 +533,25 @@ final class BackgroundModelDownloadService: NSObject, @unchecked Sendable {
     /// WHY ONLY RUNS WITH A CONTINUATION. A run nobody is awaiting is one `restore()`
     /// rebuilt and no screen has claimed yet. There is nowhere to deliver an error, and
     /// a stall the user cannot see is a stall not worth reporting.
-    private func reportOfflineStalls(_ snapshot: DownloadConnectivitySnapshot, now: Date = Date()) {
+    ///
+    /// WHY THE READING IS RE-ASKED HERE. `observed` was taken on the watcher's queue and
+    /// this runs on the session's delegate queue, behind whatever that queue was already
+    /// doing — a 32 MB append, a burst of `didWriteData`. The gap matters because the
+    /// moment connectivity returns is exactly the moment this queue fills up: every parked
+    /// task resumes at once. A reading taken while the device was offline can therefore
+    /// arrive here after it is online again, and `now` — sampled when this runs, not when
+    /// the tick was raised — can meanwhile have passed the grace period. Judged on its own
+    /// it would cancel a download that is working. `conditions` is asked again, one line
+    /// before the decision, and it governs.
+    private func reportOfflineStalls(observed: DownloadStallConditions, now: Date = Date()) {
+        let current = connectivity.conditions
         // A copy: `finish` mutates `runs`.
         for run in Array(runs.values) where !run.isFinished && !run.continuations.isEmpty {
-            guard DownloadStallPolicy.hasStalled(
+            guard DownloadStallPolicy.shouldReportStall(
                 now: now,
                 lastProgressAt: run.lastProgressDate,
-                foregroundSince: snapshot.foregroundSince,
-                offlineSince: snapshot.offlineSince,
+                observed: observed,
+                current: current,
                 grace: Self.offlineStallGrace
             ) else { continue }
 

--- a/DictusApp/Models/BackgroundModelDownloadService.swift
+++ b/DictusApp/Models/BackgroundModelDownloadService.swift
@@ -77,6 +77,11 @@ final class BackgroundModelDownloadService: NSObject, @unchecked Sendable {
     /// Attempts per file before the whole download fails (backoff 2s/4s/8s).
     static let maxAttemptsPerFile = 3
 
+    /// Seconds the app must be foregrounded, with no network path and no byte arriving,
+    /// before the transfer is reported as stalled (issue #492). Owned by
+    /// `DownloadStallPolicy`, which is also where the choice of value is argued.
+    static let offlineStallGrace = DownloadStallPolicy.offlineGrace
+
     // MARK: - Singleton
 
     static let shared = BackgroundModelDownloadService()
@@ -118,6 +123,17 @@ final class BackgroundModelDownloadService: NSObject, @unchecked Sendable {
     /// events. Must be called on the main thread once the events are drained.
     private var backgroundCompletionHandler: (@Sendable () -> Void)?
 
+    /// Watches the foreground and the network route while a transfer is live, and is the
+    /// only thing that can notice a transfer iOS has parked (issue #492): a background
+    /// session that loses connectivity delivers no callback at all, so the state machine
+    /// below is never told and never fails. Runs only while there is a run to watch.
+    private lazy var connectivity = DownloadConnectivityWatch { [weak self] snapshot in
+        guard let self else { return }
+        self.queue.addOperation { [weak self] in
+            self?.reportOfflineStalls(snapshot)
+        }
+    }
+
     // MARK: - Public API
 
     /// Runs (or joins) the transfer of one model and returns when every file is on disk.
@@ -141,7 +157,12 @@ final class BackgroundModelDownloadService: NSObject, @unchecked Sendable {
                 let run = adopt(manifest: manifest, destination: destination)
                 run.observers.append(onProgress)
                 run.continuations.append(continuation)
+                // A caller that has just joined gets the full offline grace period,
+                // whatever this run was doing before it arrived — a run rebuilt by
+                // `restore()` minutes ago must not be declared stalled on the first tick.
+                run.lastProgressDate = Date()
                 run.emitProgress(force: true)
+                connectivity.start()
                 pump(run)
             }
         }
@@ -491,11 +512,61 @@ final class BackgroundModelDownloadService: NSObject, @unchecked Sendable {
         }
     }
 
+    /// Fails every live transfer that the device has no route to move, while somebody
+    /// is watching it (issue #492).
+    ///
+    /// WHY IT HAS TO BE US. A background `URLSession` waits for connectivity by
+    /// definition. Lose the network mid-download and iOS parks the tasks: no bytes, no
+    /// `didCompleteWithError`, nothing for the state machine above to act on. Measured on
+    /// device on 2026-09-05, airplane mode produced three minutes and twelve seconds of
+    /// complete silence under a frozen progress bar, and the only way out was a force
+    /// quit. `timeoutIntervalForRequest` does not cover it: that is an idle timeout on a
+    /// running task, and a parked task is not running.
+    ///
+    /// WHY `finish` AND NOT `retryOrFail`. The attempt budget exists for transient
+    /// transport failures, and this is not one — `DownloadStallPolicy` has already
+    /// established that the device has no route at all, so a retry two seconds later can
+    /// only park a second time and spend the user's remaining attempts saying nothing.
+    /// Nothing is lost by stopping: every chunk that landed is on disk and in the
+    /// manifest, so the Retry the user now has resumes at the byte the transfer reached.
+    ///
+    /// WHY ONLY RUNS WITH A CONTINUATION. A run nobody is awaiting is one `restore()`
+    /// rebuilt and no screen has claimed yet. There is nowhere to deliver an error, and
+    /// a stall the user cannot see is a stall not worth reporting.
+    private func reportOfflineStalls(_ snapshot: DownloadConnectivitySnapshot, now: Date = Date()) {
+        // A copy: `finish` mutates `runs`.
+        for run in Array(runs.values) where !run.isFinished && !run.continuations.isEmpty {
+            guard DownloadStallPolicy.hasStalled(
+                now: now,
+                lastProgressAt: run.lastProgressDate,
+                foregroundSince: snapshot.foregroundSince,
+                offlineSince: snapshot.offlineSince,
+                grace: Self.offlineStallGrace
+            ) else { continue }
+
+            let path = run.manifest.currentFileIndex.map { run.pathOfFile($0) } ?? "?"
+            PersistentLog.log(.modelDownloadOffline(
+                name: run.manifest.modelIdentifier,
+                path: path,
+                secondsWithoutProgress: Int(now.timeIntervalSince(run.lastProgressDate))
+            ))
+            // The parked tasks go with the run. Left alive they would deliver their
+            // chunks into a run that no longer exists, which drops them anyway, and the
+            // bytes would be paid for twice.
+            run.cancelAllTasks()
+            finish(run, error: ModelRepoDownloader.DownloadError.stalled(
+                path: path,
+                timeoutSeconds: Int(Self.offlineStallGrace)
+            ))
+        }
+    }
+
     /// Ends a run: everyone waiting is told, and the model is no longer in flight.
     private func finish(_ run: DownloadRun, error: Error?) {
         guard !run.isFinished else { return }
         run.isFinished = true
         runs.removeValue(forKey: run.manifest.modelIdentifier)
+        if runs.isEmpty { connectivity.stop() }
         let continuations = run.continuations
         run.continuations.removeAll()
         run.observers.removeAll()
@@ -669,6 +740,8 @@ extension BackgroundModelDownloadService: URLSessionDownloadDelegate {
         guard let tag = ModelDownloadTaskTag.decode(downloadTask.taskDescription),
               let run = run(for: tag) else { return }
         run.liveChunkBytes[tag.chunkIndex] = totalBytesWritten
+        // Every byte is proof the transfer is alive, whatever `NWPathMonitor` believes.
+        run.lastProgressDate = Date()
         run.emitProgress(force: false)
     }
 
@@ -817,6 +890,9 @@ private final class DownloadRun {
     var liveChunkBytes: [Int: Int64] = [:]
     /// Consecutive failures on the current file. Reset by any chunk that lands.
     var attempts = 0
+    /// When a byte last arrived, for the offline stall predicate (issue #492). Set at
+    /// creation so a run that has not received anything yet still gets a grace period.
+    var lastProgressDate = Date()
     var isFinished = false
 
     var continuations: [CheckedContinuation<Void, Error>] = []

--- a/DictusApp/Models/DownloadConnectivityWatch.swift
+++ b/DictusApp/Models/DownloadConnectivityWatch.swift
@@ -5,18 +5,6 @@ import Network
 import UIKit
 import DictusCore
 
-/// What the world outside the transfer looked like at one instant.
-///
-/// Both values are `nil` until something real has been observed. That is deliberate:
-/// "not read yet" must never look like "the user is watching" or "the network is gone",
-/// because either mistake is a false alarm on the very screen this exists to protect.
-struct DownloadConnectivitySnapshot: Sendable {
-    /// When the app last reached the foreground, or `nil` when it is backgrounded.
-    let foregroundSince: Date?
-    /// When the device last lost every network path, or `nil` when it has one.
-    let offlineSince: Date?
-}
-
 /// Watches the two conditions `DownloadStallPolicy` needs — is the user looking, and is
 /// there a route — and ticks a callback while a download is running.
 ///
@@ -32,6 +20,11 @@ struct DownloadConnectivitySnapshot: Sendable {
 /// `BackgroundModelDownloadService` starts this when a run begins and stops it when the
 /// last one ends.
 ///
+/// WHY THE TICK IS ONLY A QUESTION. A tick is raised here and acted on elsewhere, later,
+/// so what it carries is a reading of the past by the time anyone reads it. `conditions`
+/// is the present, readable from any thread, and it is what the decision is taken on —
+/// see `DownloadStallPolicy.conditionsHeldContinuously` for what goes wrong otherwise.
+///
 /// WHY `NWPathMonitor` IS RECREATED ON EVERY START. A cancelled monitor cannot be
 /// restarted, and the alternative — keeping one alive for the whole process — would run
 /// a system observer for the great majority of sessions that download nothing.
@@ -45,7 +38,7 @@ final class DownloadConnectivityWatch: @unchecked Sendable {
     static let tickInterval: TimeInterval = 2
 
     private let interval: TimeInterval
-    private let onTick: @Sendable (DownloadConnectivitySnapshot) -> Void
+    private let onTick: @Sendable (DownloadStallConditions) -> Void
 
     /// Serialises every member below, and is the queue the monitor, the timer and the
     /// lifecycle handlers all report on. One thread of control, which is what makes
@@ -56,8 +49,12 @@ final class DownloadConnectivityWatch: @unchecked Sendable {
     private var timer: DispatchSourceTimer?
     private var lifecycleObservers: [NSObjectProtocol] = []
 
-    private var foregroundSince: Date?
-    private var offlineSince: Date?
+    /// The two conditions as they stand. Written on `queue` like everything else, but read
+    /// from anywhere — which is the whole point of it, and why it is the one member that
+    /// needs a lock rather than a queue.
+    private var conditionsStorage = DownloadStallConditions.unknown
+    private let conditionsLock = NSLock()
+
     /// Whether a lifecycle notification has been handled yet. The initial reading of
     /// `UIApplication.applicationState` needs a hop to the main thread, and a transition
     /// can land first; when it has, the reading is stale before it arrives and is dropped.
@@ -65,10 +62,28 @@ final class DownloadConnectivityWatch: @unchecked Sendable {
 
     init(
         interval: TimeInterval = DownloadConnectivityWatch.tickInterval,
-        onTick: @escaping @Sendable (DownloadConnectivitySnapshot) -> Void
+        onTick: @escaping @Sendable (DownloadStallConditions) -> Void
     ) {
         self.interval = interval
         self.onTick = onTick
+    }
+
+    /// The conditions right now, for a caller about to act on a tick it was handed
+    /// earlier. Safe to call from any thread.
+    var conditions: DownloadStallConditions {
+        conditionsLock.lock()
+        defer { conditionsLock.unlock() }
+        return conditionsStorage
+    }
+
+    /// Applies a change to the conditions. Called on `queue`, which is what serialises
+    /// the read-modify-write; the lock is there for the readers on other threads.
+    private func updateConditions(
+        _ body: (DownloadStallConditions) -> DownloadStallConditions
+    ) {
+        conditionsLock.lock()
+        defer { conditionsLock.unlock() }
+        conditionsStorage = body(conditionsStorage)
     }
 
     deinit {
@@ -104,8 +119,7 @@ final class DownloadConnectivityWatch: @unchecked Sendable {
                 NotificationCenter.default.removeObserver(observer)
             }
             lifecycleObservers.removeAll()
-            foregroundSince = nil
-            offlineSince = nil
+            updateConditions { _ in .unknown }
             hasObservedLifecycle = false
         }
     }
@@ -140,7 +154,12 @@ final class DownloadConnectivityWatch: @unchecked Sendable {
             let isForegrounded = UIApplication.shared.applicationState != .background
             self?.queue.async { [weak self] in
                 guard let self, !hasObservedLifecycle else { return }
-                foregroundSince = isForegrounded ? Date() : nil
+                updateConditions {
+                    DownloadStallConditions(
+                        foregroundSince: isForegrounded ? Date() : nil,
+                        offlineSince: $0.offlineSince
+                    )
+                }
             }
         }
     }
@@ -148,12 +167,14 @@ final class DownloadConnectivityWatch: @unchecked Sendable {
     private func setForegrounded(_ isForegrounded: Bool) {
         queue.async { [self] in
             hasObservedLifecycle = true
-            if isForegrounded {
+            updateConditions { conditions in
                 // Only the transition sets the onset — a duplicate notification must not
                 // push the deadline back and hand the user another 15 s of frozen bar.
-                if foregroundSince == nil { foregroundSince = Date() }
-            } else {
-                foregroundSince = nil
+                let onset = isForegrounded ? (conditions.foregroundSince ?? Date()) : nil
+                return DownloadStallConditions(
+                    foregroundSince: onset,
+                    offlineSince: conditions.offlineSince
+                )
             }
         }
     }
@@ -167,10 +188,12 @@ final class DownloadConnectivityWatch: @unchecked Sendable {
             // be brought up, so the transfer is not necessarily dead and this is not the
             // moment to tell the user their connection is gone.
             let isOffline = path.status == .unsatisfied
-            if isOffline {
-                if offlineSince == nil { offlineSince = Date() }
-            } else {
-                offlineSince = nil
+            updateConditions { conditions in
+                let onset = isOffline ? (conditions.offlineSince ?? Date()) : nil
+                return DownloadStallConditions(
+                    foregroundSince: conditions.foregroundSince,
+                    offlineSince: onset
+                )
             }
         }
         monitor.start(queue: queue)
@@ -182,10 +205,7 @@ final class DownloadConnectivityWatch: @unchecked Sendable {
         timer.schedule(deadline: .now() + interval, repeating: interval, leeway: .milliseconds(500))
         timer.setEventHandler { [weak self] in
             guard let self else { return }
-            onTick(DownloadConnectivitySnapshot(
-                foregroundSince: foregroundSince,
-                offlineSince: offlineSince
-            ))
+            onTick(conditions)
         }
         timer.resume()
         self.timer = timer

--- a/DictusApp/Models/DownloadConnectivityWatch.swift
+++ b/DictusApp/Models/DownloadConnectivityWatch.swift
@@ -1,0 +1,193 @@
+// DictusApp/Models/DownloadConnectivityWatch.swift
+// The two facts outside a transfer that say whether a stall is worth reporting (#492).
+import Foundation
+import Network
+import UIKit
+import DictusCore
+
+/// What the world outside the transfer looked like at one instant.
+///
+/// Both values are `nil` until something real has been observed. That is deliberate:
+/// "not read yet" must never look like "the user is watching" or "the network is gone",
+/// because either mistake is a false alarm on the very screen this exists to protect.
+struct DownloadConnectivitySnapshot: Sendable {
+    /// When the app last reached the foreground, or `nil` when it is backgrounded.
+    let foregroundSince: Date?
+    /// When the device last lost every network path, or `nil` when it has one.
+    let offlineSince: Date?
+}
+
+/// Watches the two conditions `DownloadStallPolicy` needs — is the user looking, and is
+/// there a route — and ticks a callback while a download is running.
+///
+/// WHY IT EXISTS (issue #492). The model transfer runs in a background `URLSession`,
+/// which parks its tasks when connectivity goes away rather than failing them. No
+/// delegate callback fires, so the transfer itself cannot notice that it has stopped;
+/// the only way to find out is to ask somebody else. `NWPathMonitor` is that somebody
+/// for the route, `UIApplication`'s lifecycle notifications for the foreground.
+///
+/// WHY A TICK AND NOT AN EVENT. Neither condition changing is what makes a stall
+/// reportable — it is time passing while both hold and no byte arrives. A timer is the
+/// only thing that observes that, and it runs only while there is a transfer to watch:
+/// `BackgroundModelDownloadService` starts this when a run begins and stops it when the
+/// last one ends.
+///
+/// WHY `NWPathMonitor` IS RECREATED ON EVERY START. A cancelled monitor cannot be
+/// restarted, and the alternative — keeping one alive for the whole process — would run
+/// a system observer for the great majority of sessions that download nothing.
+final class DownloadConnectivityWatch: @unchecked Sendable {
+
+    /// How often the callback runs while a download is live.
+    ///
+    /// Two seconds against a 15 s grace period bounds the delay between the predicate
+    /// becoming true and the user hearing about it at 17 s, and costs one wake-up every
+    /// two seconds during a transfer that is already moving megabytes.
+    static let tickInterval: TimeInterval = 2
+
+    private let interval: TimeInterval
+    private let onTick: @Sendable (DownloadConnectivitySnapshot) -> Void
+
+    /// Serialises every member below, and is the queue the monitor, the timer and the
+    /// lifecycle handlers all report on. One thread of control, which is what makes
+    /// `@unchecked Sendable` true here.
+    private let queue = DispatchQueue(label: "solutions.pivi.dictus.download-connectivity")
+
+    private var monitor: NWPathMonitor?
+    private var timer: DispatchSourceTimer?
+    private var lifecycleObservers: [NSObjectProtocol] = []
+
+    private var foregroundSince: Date?
+    private var offlineSince: Date?
+    /// Whether a lifecycle notification has been handled yet. The initial reading of
+    /// `UIApplication.applicationState` needs a hop to the main thread, and a transition
+    /// can land first; when it has, the reading is stale before it arrives and is dropped.
+    private var hasObservedLifecycle = false
+
+    init(
+        interval: TimeInterval = DownloadConnectivityWatch.tickInterval,
+        onTick: @escaping @Sendable (DownloadConnectivitySnapshot) -> Void
+    ) {
+        self.interval = interval
+        self.onTick = onTick
+    }
+
+    deinit {
+        monitor?.cancel()
+        timer?.cancel()
+        for observer in lifecycleObservers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    /// Begins watching. Idempotent: a second call while running does nothing, so every
+    /// caller can start it without knowing whether another download already has.
+    func start() {
+        queue.async { [self] in
+            guard monitor == nil else { return }
+            observeLifecycle()
+            observeNetworkPath()
+            startTicking()
+        }
+    }
+
+    /// Stops watching and forgets both conditions, so the next download starts from
+    /// "nothing observed yet" rather than from a reading that may be minutes old.
+    func stop() {
+        queue.async { [self] in
+            monitor?.cancel()
+            monitor = nil
+            timer?.cancel()
+            timer = nil
+            for observer in lifecycleObservers {
+                NotificationCenter.default.removeObserver(observer)
+            }
+            lifecycleObservers.removeAll()
+            foregroundSince = nil
+            offlineSince = nil
+            hasObservedLifecycle = false
+        }
+    }
+
+    // MARK: - Observation (private queue only)
+
+    private func observeLifecycle() {
+        let center = NotificationCenter.default
+        lifecycleObservers = [
+            center.addObserver(
+                forName: UIApplication.didBecomeActiveNotification,
+                object: nil,
+                queue: nil
+            ) { [weak self] _ in
+                self?.setForegrounded(true)
+            },
+            // Deliberately NOT `willResignActive`: that fires for a control centre pull
+            // or a notification banner, and the user is still looking at the download.
+            // Only entering the background means there is nobody to tell.
+            center.addObserver(
+                forName: UIApplication.didEnterBackgroundNotification,
+                object: nil,
+                queue: nil
+            ) { [weak self] _ in
+                self?.setForegrounded(false)
+            }
+        ]
+
+        // The state right now, for the download that starts without a transition to
+        // announce it. Read on the main thread because `applicationState` requires it.
+        DispatchQueue.main.async { [weak self] in
+            let isForegrounded = UIApplication.shared.applicationState != .background
+            self?.queue.async { [weak self] in
+                guard let self, !hasObservedLifecycle else { return }
+                foregroundSince = isForegrounded ? Date() : nil
+            }
+        }
+    }
+
+    private func setForegrounded(_ isForegrounded: Bool) {
+        queue.async { [self] in
+            hasObservedLifecycle = true
+            if isForegrounded {
+                // Only the transition sets the onset — a duplicate notification must not
+                // push the deadline back and hand the user another 15 s of frozen bar.
+                if foregroundSince == nil { foregroundSince = Date() }
+            } else {
+                foregroundSince = nil
+            }
+        }
+    }
+
+    private func observeNetworkPath() {
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard let self else { return }
+            // `.unsatisfied` is the only status that means no route at all.
+            // `.requiresConnection` says a link (a VPN, an on-demand interface) can still
+            // be brought up, so the transfer is not necessarily dead and this is not the
+            // moment to tell the user their connection is gone.
+            let isOffline = path.status == .unsatisfied
+            if isOffline {
+                if offlineSince == nil { offlineSince = Date() }
+            } else {
+                offlineSince = nil
+            }
+        }
+        monitor.start(queue: queue)
+        self.monitor = monitor
+    }
+
+    private func startTicking() {
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + interval, repeating: interval, leeway: .milliseconds(500))
+        timer.setEventHandler { [weak self] in
+            guard let self else { return }
+            onTick(DownloadConnectivitySnapshot(
+                foregroundSince: foregroundSince,
+                offlineSince: offlineSince
+            ))
+        }
+        timer.resume()
+        self.timer = timer
+    }
+}

--- a/DictusCore/Sources/DictusCore/DownloadStallPolicy.swift
+++ b/DictusCore/Sources/DictusCore/DownloadStallPolicy.swift
@@ -1,0 +1,98 @@
+// DictusCore/Sources/DictusCore/DownloadStallPolicy.swift
+// When a parked model download is worth telling the user about (#492).
+import Foundation
+
+/// Decides whether a model download that has stopped moving is a failure the user
+/// should be shown, or a pause they have no reason to hear about.
+///
+/// WHY THIS EXISTS (issue #492). The transfer runs in a
+/// `URLSessionConfiguration.background` session, and a background session waits for
+/// connectivity by definition: lose the network mid-download and iOS parks the tasks
+/// instead of failing them. Nothing is delivered, nothing is logged, and the progress
+/// bar stops at the byte it reached. Measured on device on 2026-09-05: three minutes and
+/// twelve seconds of airplane mode produced not one line from the download layer, and
+/// the only way out was a force quit. `timeoutIntervalForRequest` does not cover it —
+/// that is an IDLE timeout on a running task, and a parked task is not idling, it is
+/// not running.
+///
+/// WHY NOT A WALL-CLOCK TIMEOUT. A plain "no progress for N seconds" detector is what
+/// issue #449 removed, and for a good reason: it fired on a user who simply left Dictus
+/// for a minute, and the retry it triggered restarted a 445 MB file from byte zero. The
+/// same detector was, at the same time, the only thing that caught a real network loss.
+/// Both went at once, which is how #492 was created by fixing #449.
+///
+/// WHAT SEPARATES THE TWO. Not the duration — the two look identical on a stopwatch.
+/// Three clauses, all of which have to hold at the same time:
+///
+/// 1. **No progress** for the grace period. Necessary, and on its own worth nothing.
+/// 2. **The app is foregrounded.** A backgrounded app has a user who is somewhere else;
+///    there is nothing to show them and nothing they could do about it. This is the
+///    clause a legitimate backgrounding fails.
+/// 3. **There is no network path.** `NWPathMonitor` answers this, and it is the clause
+///    that makes the report actionable: "check your connection" is only useful advice
+///    when the connection is in fact gone.
+///
+/// WHY THE CLOCK STARTS AT THE LATEST ONSET. Each clause carries the moment it started
+/// holding, and the grace period is measured from the last of them. Otherwise a clause
+/// could be satisfied retroactively: a user who spent three minutes in another app with
+/// the network off would come back to an error that fired the instant they looked at the
+/// screen, having never been given the grace period while they could see it. The rule is
+/// that all three must hold *continuously* for the whole grace period, and the maximum
+/// of the three onsets is where that window can first have started.
+public enum DownloadStallPolicy {
+
+    /// Seconds all three clauses must hold before a parked transfer is reported.
+    ///
+    /// WHY 15 AND NOT 30. Thirty seconds was the old idle-byte timeout (#207), chosen to
+    /// avoid killing a slow-but-live foreground transfer, and it has nothing to say about
+    /// this predicate: a live transfer fails clause 3 whatever its speed. The only thing
+    /// left for the grace period to absorb is a *transient* unsatisfied reading — a
+    /// Wi-Fi to cellular handover, a lift, a router blink — all of which are a few
+    /// seconds. Fifteen clears them with room to spare, and is short enough that a user
+    /// who has just turned on airplane mode still connects the message to what they did.
+    public static let offlineGrace: TimeInterval = 15
+
+    /// The instant at which a parked transfer becomes reportable, or `nil` when it never
+    /// will under the state given.
+    ///
+    /// - Parameters:
+    ///   - lastProgressAt: when a byte last arrived for this transfer.
+    ///   - foregroundSince: when the app last reached the foreground, `nil` when it is
+    ///     backgrounded or has not been observed yet.
+    ///   - offlineSince: when the device last lost every network path, `nil` when a path
+    ///     exists or has not been observed yet.
+    ///   - grace: how long all three clauses must hold.
+    /// - Returns: the deadline, or `nil` when a clause is not met at all.
+    public static func deadline(
+        lastProgressAt: Date,
+        foregroundSince: Date?,
+        offlineSince: Date?,
+        grace: TimeInterval = offlineGrace
+    ) -> Date? {
+        guard let foregroundSince, let offlineSince else { return nil }
+        let latestOnset = max(lastProgressAt, foregroundSince, offlineSince)
+        return latestOnset.addingTimeInterval(max(0, grace))
+    }
+
+    /// Whether the transfer should be reported to the user as of `now`.
+    ///
+    /// `nil` for either onset means "not in that state, or not known yet", and both
+    /// answer false — an unread `NWPathMonitor` must never look like an outage.
+    public static func hasStalled(
+        now: Date,
+        lastProgressAt: Date,
+        foregroundSince: Date?,
+        offlineSince: Date?,
+        grace: TimeInterval = offlineGrace
+    ) -> Bool {
+        guard let deadline = deadline(
+            lastProgressAt: lastProgressAt,
+            foregroundSince: foregroundSince,
+            offlineSince: offlineSince,
+            grace: grace
+        ) else {
+            return false
+        }
+        return now >= deadline
+    }
+}

--- a/DictusCore/Sources/DictusCore/DownloadStallPolicy.swift
+++ b/DictusCore/Sources/DictusCore/DownloadStallPolicy.swift
@@ -39,6 +39,26 @@ import Foundation
 /// screen, having never been given the grace period while they could see it. The rule is
 /// that all three must hold *continuously* for the whole grace period, and the maximum
 /// of the three onsets is where that window can first have started.
+/// The two conditions outside a transfer that `DownloadStallPolicy` reads, as one value.
+///
+/// Each field is the instant its condition started holding, and `nil` means it does not
+/// hold — or has not been observed yet, which must answer the same way: an unread network
+/// monitor may never look like an outage.
+public struct DownloadStallConditions: Sendable, Equatable {
+    /// When the app last reached the foreground, `nil` when it is backgrounded.
+    public let foregroundSince: Date?
+    /// When the device last lost every network path, `nil` when it has one.
+    public let offlineSince: Date?
+
+    public init(foregroundSince: Date?, offlineSince: Date?) {
+        self.foregroundSince = foregroundSince
+        self.offlineSince = offlineSince
+    }
+
+    /// Nothing observed yet — the state a watcher starts in and returns to when it stops.
+    public static let unknown = DownloadStallConditions(foregroundSince: nil, offlineSince: nil)
+}
+
 public enum DownloadStallPolicy {
 
     /// Seconds all three clauses must hold before a parked transfer is reported.
@@ -94,5 +114,63 @@ public enum DownloadStallPolicy {
             return false
         }
         return now >= deadline
+    }
+
+    /// Whether the two conditions a watcher reported are still the ones holding now.
+    ///
+    /// WHY THIS EXISTS. A watcher reads the conditions on its own queue and whatever acts
+    /// on that reading runs somewhere else, later — so the decision is always taken on a
+    /// reading of the past. That gap is not theoretical here: the queue the decision runs
+    /// on is the download session's delegate queue, and the moment the network comes back
+    /// is exactly the moment it fills up, because every parked task resumes at once and
+    /// starts delivering bytes. A reading taken while the device was offline can therefore
+    /// arrive for judgement after the device is online again, and be judged against a
+    /// clock that has meanwhile passed the grace period. Acting on it would cancel a
+    /// download that is, at that instant, working — the false alarm issue #449 removed,
+    /// reached through another door.
+    ///
+    /// WHY IDENTITY OF THE ONSETS AND NOT A TIME COMPARISON. Both fields are the instant
+    /// a condition started holding, written once per transition and never edited. So the
+    /// same value in both readings means the condition was never interrupted between
+    /// them, and a different one means it stopped and started again — which restarts the
+    /// grace period, whatever the two instants happen to be. `nil` in `current` means it
+    /// simply stopped. All three are refused.
+    ///
+    /// Conditions that started holding only *after* the reading are refused too: `current`
+    /// then carries an onset `observed` never had. Nothing is lost by that — the next tick
+    /// reports them, two seconds later, on a reading of their own.
+    public static func conditionsHeldContinuously(
+        observed: DownloadStallConditions,
+        current: DownloadStallConditions
+    ) -> Bool {
+        observed.foregroundSince != nil
+            && observed.offlineSince != nil
+            && observed == current
+    }
+
+    /// The whole decision one watcher tick makes: whether a transfer that has stopped
+    /// moving should be reported to the user.
+    ///
+    /// The only entry point a caller acting on a tick should use. `observed` is what the
+    /// watcher read when it raised the tick; `current` is what it says at the moment the
+    /// decision is being taken, which is the one that governs — a reading of the past may
+    /// raise the question but never answers it.
+    public static func shouldReportStall(
+        now: Date,
+        lastProgressAt: Date,
+        observed: DownloadStallConditions,
+        current: DownloadStallConditions,
+        grace: TimeInterval = offlineGrace
+    ) -> Bool {
+        guard conditionsHeldContinuously(observed: observed, current: current) else {
+            return false
+        }
+        return hasStalled(
+            now: now,
+            lastProgressAt: lastProgressAt,
+            foregroundSince: current.foregroundSince,
+            offlineSince: current.offlineSince,
+            grace: grace
+        )
     }
 }

--- a/DictusCore/Sources/DictusCore/LogEvent.swift
+++ b/DictusCore/Sources/DictusCore/LogEvent.swift
@@ -144,6 +144,16 @@ public enum LogEvent: Sendable {
     /// disk. `tasks=0 models=1` is the force-quit shape: iOS cancelled the transfers
     /// and the bytes on disk are what the retry starts from.
     case modelDownloadSessionRestored(tasks: Int, models: Int)
+    /// A transfer was parked by the system for want of a network path, while the user
+    /// was looking at it, and was reported to them rather than left silent (#492).
+    ///
+    /// This line is the one whose absence created the issue: a background session
+    /// waiting for connectivity delivers no callback at all, so three minutes of
+    /// airplane mode produced an empty log under a frozen progress bar. Its presence
+    /// says the download stopped because the device had no route — not because the
+    /// server was slow and not because the app was backgrounded, both of which the
+    /// predicate in `DownloadStallPolicy` excludes before this is emitted.
+    case modelDownloadOffline(name: String, path: String, secondsWithoutProgress: Int)
 
     // MARK: Keyboard
     case keyboardDidAppear
@@ -400,7 +410,8 @@ public enum LogEvent: Sendable {
              .modelDownloadProgress, .modelDownloadStalled, .modelDownloadSizeMismatch,
              .modelReconciledFromDisk,
              .modelDownloadResumed, .modelDownloadRangeRejected, .modelDownloadChunk,
-             .modelDownloadIntegrityFailed, .modelDownloadSessionRestored:
+             .modelDownloadIntegrityFailed, .modelDownloadSessionRestored,
+             .modelDownloadOffline:
             return .model
         case .keyboardDidAppear, .keyboardDidDisappear, .keyboardMicTapped, .keyboardTextInserted,
              .keyRepeatStarted, .keyRepeatStopped,
@@ -471,7 +482,8 @@ public enum LogEvent: Sendable {
              .coldStartDarwinFallback, .coldStartStranded, .modelPrewarmTimeout,
              .audioInterruptionBegan, .audioMediaServicesReset,
              .modelDownloadStalled, .audioHapticsAllowanceFailed,
-             .modelDownloadSizeMismatch, .modelDownloadRangeRejected:
+             .modelDownloadSizeMismatch, .modelDownloadRangeRejected,
+             .modelDownloadOffline:
             return .warning
 
         // Info (normal operations: starts, completes, selections, configs)
@@ -659,6 +671,7 @@ public enum LogEvent: Sendable {
         case .modelDownloadChunk: return "modelDownloadChunk"
         case .modelDownloadIntegrityFailed: return "modelDownloadIntegrityFailed"
         case .modelDownloadSessionRestored: return "modelDownloadSessionRestored"
+        case .modelDownloadOffline: return "modelDownloadOffline"
         case .polishEngineFailed: return "polishEngineFailed"
         case .polishEngineUnavailable: return "polishEngineUnavailable"
         case .polishHandoff: return "polishHandoff"
@@ -769,6 +782,8 @@ public enum LogEvent: Sendable {
             return "name=\(name) path=\(path) reason=\(reason)"
         case .modelDownloadSessionRestored(let tasks, let models):
             return "tasks=\(tasks) models=\(models)"
+        case .modelDownloadOffline(let name, let path, let secondsWithoutProgress):
+            return "name=\(name) path=\(path) noProgress=\(secondsWithoutProgress)s"
 
         // Keyboard (no content parameters -- privacy)
         case .keyboardDidAppear, .keyboardDidDisappear,

--- a/DictusCore/Tests/DictusCoreTests/DownloadStallPolicyTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/DownloadStallPolicyTests.swift
@@ -176,4 +176,119 @@ final class DownloadStallPolicyTests: XCTestCase {
     func testShippedGracePeriodIsFifteenSeconds() {
         XCTAssertEqual(DownloadStallPolicy.offlineGrace, 15)
     }
+
+    // MARK: - A reading of the past never decides (the race CodeRabbit found on PR #508)
+
+    /// The shape of the bug, in one test: a reading taken while the app was foregrounded
+    /// and offline, judged later against a clock that has passed the grace period. Read on
+    /// its own — which is what the first version of this fix did — it says "report". It
+    /// must not, because by then the app is in the background.
+    func testAReadingIsRefusedWhenTheAppHasSinceBackgrounded() {
+        let observed = DownloadStallConditions(foregroundSince: at(0), offlineSince: at(0))
+        let current = DownloadStallConditions(foregroundSince: nil, offlineSince: at(0))
+
+        // What deciding from the reading alone would have answered.
+        XCTAssertTrue(DownloadStallPolicy.hasStalled(
+            now: at(20),
+            lastProgressAt: at(0),
+            foregroundSince: observed.foregroundSince,
+            offlineSince: observed.offlineSince,
+            grace: grace
+        ))
+        // What the decision answers.
+        XCTAssertFalse(DownloadStallPolicy.shouldReportStall(
+            now: at(20),
+            lastProgressAt: at(0),
+            observed: observed,
+            current: current,
+            grace: grace
+        ))
+    }
+
+    /// The same, for the clause that costs the most: the network came back between the
+    /// reading and the decision. Cancelling here would show an error to a user whose
+    /// connection is working — and this is the likeliest case of the two, because every
+    /// parked task resumes at once and floods the queue the decision is waiting on.
+    func testAReadingIsRefusedWhenTheNetworkHasSinceReturned() {
+        let observed = DownloadStallConditions(foregroundSince: at(0), offlineSince: at(0))
+        let current = DownloadStallConditions(foregroundSince: at(0), offlineSince: nil)
+
+        XCTAssertTrue(DownloadStallPolicy.hasStalled(
+            now: at(20),
+            lastProgressAt: at(0),
+            foregroundSince: observed.foregroundSince,
+            offlineSince: observed.offlineSince,
+            grace: grace
+        ))
+        XCTAssertFalse(DownloadStallPolicy.shouldReportStall(
+            now: at(20),
+            lastProgressAt: at(0),
+            observed: observed,
+            current: current,
+            grace: grace
+        ))
+    }
+
+    /// An outage that ended and began again is a new outage, and gets a new grace period.
+    /// The onsets are what say so: same field, different instant.
+    func testAReadingIsRefusedWhenTheOutageStoppedAndStartedAgain() {
+        XCTAssertFalse(DownloadStallPolicy.shouldReportStall(
+            now: at(20),
+            lastProgressAt: at(0),
+            observed: DownloadStallConditions(foregroundSince: at(0), offlineSince: at(0)),
+            current: DownloadStallConditions(foregroundSince: at(0), offlineSince: at(18)),
+            grace: grace
+        ))
+    }
+
+    /// Conditions that only started holding after the reading are refused as well: the
+    /// tick that carries them saw nothing. The next one, two seconds later, sees them.
+    func testAReadingThatSawNothingCannotReportOnLaterConditions() {
+        XCTAssertFalse(DownloadStallPolicy.shouldReportStall(
+            now: at(20),
+            lastProgressAt: at(0),
+            observed: .unknown,
+            current: DownloadStallConditions(foregroundSince: at(0), offlineSince: at(0)),
+            grace: grace
+        ))
+    }
+
+    /// Nothing changed between the reading and the decision, and the grace period has run
+    /// out: this is the airplane-mode case, and it still reports.
+    func testAnUnchangedReadingStillReports() {
+        let conditions = DownloadStallConditions(foregroundSince: at(0), offlineSince: at(2))
+        XCTAssertTrue(DownloadStallPolicy.shouldReportStall(
+            now: at(20),
+            lastProgressAt: at(0),
+            observed: conditions,
+            current: conditions,
+            grace: grace
+        ))
+    }
+
+    /// Unchanged, but the grace period has not run out yet. The revalidation must not
+    /// become a way around the clock.
+    func testAnUnchangedReadingStillWaitsForTheGracePeriod() {
+        let conditions = DownloadStallConditions(foregroundSince: at(0), offlineSince: at(2))
+        XCTAssertFalse(DownloadStallPolicy.shouldReportStall(
+            now: at(16),
+            lastProgressAt: at(0),
+            observed: conditions,
+            current: conditions,
+            grace: grace
+        ))
+    }
+
+    /// And a byte that landed while the tick was queued disarms it, whatever both
+    /// readings say about the route.
+    func testProgressWhileTheTickWasQueuedDisarmsIt() {
+        let conditions = DownloadStallConditions(foregroundSince: at(0), offlineSince: at(2))
+        XCTAssertFalse(DownloadStallPolicy.shouldReportStall(
+            now: at(20),
+            lastProgressAt: at(19),
+            observed: conditions,
+            current: conditions,
+            grace: grace
+        ))
+    }
 }

--- a/DictusCore/Tests/DictusCoreTests/DownloadStallPolicyTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/DownloadStallPolicyTests.swift
@@ -1,0 +1,179 @@
+// DictusCore/Tests/DictusCoreTests/DownloadStallPolicyTests.swift
+// The three clauses that tell a network loss from a backgrounding (#492).
+import XCTest
+@testable import DictusCore
+
+final class DownloadStallPolicyTests: XCTestCase {
+
+    private let epoch = Date(timeIntervalSince1970: 1_757_000_000)
+    private let grace: TimeInterval = 15
+
+    private func at(_ seconds: TimeInterval) -> Date {
+        epoch.addingTimeInterval(seconds)
+    }
+
+    // MARK: - The case the issue is about
+
+    /// Airplane mode, user watching: all three clauses hold, and the grace period runs out.
+    func testReportsWhenForegroundedAndOfflineWithNoProgress() {
+        XCTAssertTrue(DownloadStallPolicy.hasStalled(
+            now: at(20),
+            lastProgressAt: at(0),
+            foregroundSince: at(0),
+            offlineSince: at(2),
+            grace: grace
+        ))
+    }
+
+    // MARK: - The case #449 removed, which must not come back
+
+    /// A plain backgrounding: the network is fine and nobody is looking. This is the
+    /// false alarm the old wall-clock detector produced, and the whole reason the
+    /// predicate has three clauses.
+    func testSilentWhenBackgroundedWithANetworkPath() {
+        XCTAssertFalse(DownloadStallPolicy.hasStalled(
+            now: at(600),
+            lastProgressAt: at(0),
+            foregroundSince: nil,
+            offlineSince: nil,
+            grace: grace
+        ))
+    }
+
+    /// Backgrounded AND offline: still nothing to say, because there is nobody to say
+    /// it to and nothing they could do from another app.
+    func testSilentWhenBackgroundedEvenWithNoNetworkPath() {
+        XCTAssertFalse(DownloadStallPolicy.hasStalled(
+            now: at(600),
+            lastProgressAt: at(0),
+            foregroundSince: nil,
+            offlineSince: at(5),
+            grace: grace
+        ))
+    }
+
+    /// Foregrounded, no bytes for ten minutes, but the device has a route: a slow or
+    /// wedged server is not this predicate's business, and reporting it would be the
+    /// wall-clock timeout again under another name.
+    func testSilentWhenForegroundedWithANetworkPath() {
+        XCTAssertFalse(DownloadStallPolicy.hasStalled(
+            now: at(600),
+            lastProgressAt: at(0),
+            foregroundSince: at(0),
+            offlineSince: nil,
+            grace: grace
+        ))
+    }
+
+    // MARK: - The clock starts at the latest onset
+
+    /// Three minutes in another app with the network off, then a return: the grace
+    /// period starts at the return, not at the last byte. Firing on the first frame
+    /// would give the user an error for a window they never saw.
+    func testGracePeriodRestartsOnReturningToTheForeground() {
+        XCTAssertFalse(DownloadStallPolicy.hasStalled(
+            now: at(181),
+            lastProgressAt: at(0),
+            foregroundSince: at(180),
+            offlineSince: at(1),
+            grace: grace
+        ))
+        XCTAssertTrue(DownloadStallPolicy.hasStalled(
+            now: at(195),
+            lastProgressAt: at(0),
+            foregroundSince: at(180),
+            offlineSince: at(1),
+            grace: grace
+        ))
+    }
+
+    /// The same rule for the path: a download that was running fine and lost the
+    /// network a second ago gets the full grace period from the loss.
+    func testGracePeriodRestartsWhenTheNetworkDrops() {
+        XCTAssertFalse(DownloadStallPolicy.hasStalled(
+            now: at(101),
+            lastProgressAt: at(95),
+            foregroundSince: at(0),
+            offlineSince: at(100),
+            grace: grace
+        ))
+        XCTAssertTrue(DownloadStallPolicy.hasStalled(
+            now: at(115),
+            lastProgressAt: at(95),
+            foregroundSince: at(0),
+            offlineSince: at(100),
+            grace: grace
+        ))
+    }
+
+    /// A byte that arrives after the network reading is the latest onset, and it is the
+    /// one that matters: bytes are proof the transfer is alive whatever a monitor says.
+    func testProgressResetsTheGracePeriod() {
+        XCTAssertFalse(DownloadStallPolicy.hasStalled(
+            now: at(110),
+            lastProgressAt: at(100),
+            foregroundSince: at(0),
+            offlineSince: at(50),
+            grace: grace
+        ))
+    }
+
+    // MARK: - Boundary and shape
+
+    func testFiresExactlyAtTheDeadlineAndNotOneInstantBefore() {
+        let arguments = (
+            lastProgressAt: at(0),
+            foregroundSince: at(0),
+            offlineSince: at(0)
+        )
+        XCTAssertFalse(DownloadStallPolicy.hasStalled(
+            now: at(grace - 0.001),
+            lastProgressAt: arguments.lastProgressAt,
+            foregroundSince: arguments.foregroundSince,
+            offlineSince: arguments.offlineSince,
+            grace: grace
+        ))
+        XCTAssertTrue(DownloadStallPolicy.hasStalled(
+            now: at(grace),
+            lastProgressAt: arguments.lastProgressAt,
+            foregroundSince: arguments.foregroundSince,
+            offlineSince: arguments.offlineSince,
+            grace: grace
+        ))
+    }
+
+    func testDeadlineIsTheLatestOnsetPlusTheGracePeriod() {
+        XCTAssertEqual(
+            DownloadStallPolicy.deadline(
+                lastProgressAt: at(10),
+                foregroundSince: at(40),
+                offlineSince: at(25),
+                grace: grace
+            ),
+            at(55)
+        )
+    }
+
+    /// An unread `NWPathMonitor` reports `nil`, not an outage: nothing may fire before
+    /// the first real reading of either clause.
+    func testNoDeadlineWhileEitherClauseIsUnknown() {
+        XCTAssertNil(DownloadStallPolicy.deadline(
+            lastProgressAt: at(0),
+            foregroundSince: nil,
+            offlineSince: at(0),
+            grace: grace
+        ))
+        XCTAssertNil(DownloadStallPolicy.deadline(
+            lastProgressAt: at(0),
+            foregroundSince: at(0),
+            offlineSince: nil,
+            grace: grace
+        ))
+    }
+
+    /// The shipped grace period, asserted so a change to it is a deliberate edit to a
+    /// test and not a silent one-character change to a constant.
+    func testShippedGracePeriodIsFifteenSeconds() {
+        XCTAssertEqual(DownloadStallPolicy.offlineGrace, 15)
+    }
+}

--- a/DictusCore/Tests/DictusCoreTests/LogPrivacyTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/LogPrivacyTests.swift
@@ -53,6 +53,11 @@ final class LogPrivacyTests: XCTestCase {
                 reason: "sha256 mismatch"
             ),
             .modelDownloadSessionRestored(tasks: 0, models: 1),
+            .modelDownloadOffline(
+                name: "parakeet-tdt-0.6b-v3",
+                path: "Encoder.mlmodelc/weights/weight.bin",
+                secondsWithoutProgress: 15
+            ),
             .modelSelected(name: "base"),
             .modelCompilationStarted(name: "base"),
             .modelCompilationCompleted(name: "base", durationMs: 5000),


### PR DESCRIPTION
Refs #492.

## What this was for

Lose the network in the middle of a model download and Dictus stops, silently, forever.
No error, no Retry, no log line — the progress bar just freezes at the byte it reached,
and the only way out is a force quit. That is what the device session of 2026-09-05
recorded: airplane mode at 08:07:22, then three minutes and twelve seconds in which the
download layer wrote nothing at all, ending in `appLaunched` because the app was killed
by hand. This is the onboarding path, where a first-run user meets a 483 MB download.

Before #468 the same interruption produced an error screen with a Retry within seconds.
That detector was a wall-clock timeout, and #449 removed it for a good reason: it also
fired on a user who simply left Dictus for a minute, and the retry it triggered restarted
a 445 MB file from byte zero. Both alarms went at once — the false one and the true one.

The fix is not a longer timeout. It is a timeout that knows what it is looking at.

## To test by hand

**Done by the maintainer on 2026-09-06 — all four acceptance criteria passed on device**
(`rev c2489bc@HEAD`, iPhone 15 Pro Max, iOS 26.6.1; evidence in the table below). The list
is kept for the re-test after the race fix in 54d6c94, which touches the decision but not
the predicate that produced those results.

Everything here needs a **physical device**: the simulator does not suspend an app the way
a device does, and its network path is the Mac's, so airplane mode cannot be simulated.
Install this branch, and in Réglages > Journal de débogage tap "Effacer" before each run.

1. **Airplane mode mid-download (acceptance criterion 1).** Fresh install. Start the
   Parakeet download from onboarding, wait until the bar passes 10%, then switch on
   airplane mode and *stay on the download screen*.
   *Expect:* within about twenty seconds the bar stops and the message
   "Le téléchargement s'est interrompu. Vérifiez votre connexion Internet et réessayez."
   appears, with the install button back as a Retry. In the exported log:
   `modelDownloadOffline name=parakeet-tdt-0.6b-v3 path=… noProgress=15s` — 15 s or a
   little more, see "Where N comes from" for why the field reads wider than the grace
   period — then `modelDownloadFailed`. If you sit there for a minute and nothing appears,
   the fix has not worked and the issue should be reopened.
2. **Retry after the network returns.** Still on that screen, switch airplane mode off and
   tap the install button again.
   *Expect:* the download resumes from the last **chunk boundary** that landed, not from
   the byte the bar was showing. Chunks are 32 MB and two are in flight, so an interruption
   discards up to 64 MB of bytes that had not yet landed — and on a file whose first chunk
   was still in flight, that legitimately reads as 0%. What must **not** happen is the whole
   file restarting after chunks had already landed: check the log for `modelDownloadChunk`
   indices recorded before the cut and requested again. A
   `modelDownloadResumed … offset=<N>MB source=manifest` line appears when the resume starts
   anywhere but byte zero, and its absence simply means the cut fell inside the first chunk.
3. **Two minutes in the background (acceptance criterion 2, the #449 regression).** Fresh
   install. Start the download again, wait until the bar passes 10%, then go to the home
   screen and leave Dictus alone for **two minutes** with the network on. Come back.
   *Expect:* the bar is at or above where you left it, never 0%, and there is **no** error
   message and **no** `modelDownloadOffline` or `modelDownloadFailed` line in the log. This
   is the false alarm #449 removed, and it must not have come back. It is the same test
   that proved #468, extended from 60 s to two minutes because that is what #492 asks for.
4. **Background *and* offline (the clause that makes the difference).** Start a download,
   pass 10%, go to the home screen, then switch on airplane mode while Dictus is in the
   background. Wait a minute. Switch airplane mode off, then return to Dictus.
   *Expect:* no error at any point — nothing was reported while the user could not see it,
   and by the time they return there is a route again. The download resumes.
5. **A brief network blip does not raise an alarm.** During a download, on the screen,
   switch airplane mode on and off again within about five seconds.
   *Expect:* nothing user-visible; the transfer resumes on its own. Fifteen seconds is
   the grace period precisely so a handover or a lift does not become an error.
6. **Cellular, once.** Repeat step 1 on cellular rather than Wi-Fi.
   *Expect:* the same message in the same time. (Airplane mode kills both radios, so this
   is really a check that nothing about the cellular path changes the answer.)

## Where N comes from

**N = 15 seconds**, plus at most one 2-second tick, so **the message appears within 17
seconds of the moment the last of the three conditions came true** — which on a network
loss is the `NWPathMonitor` reading, not the last byte.

That distinction is worth reading twice, because the log does not print it. The grace
period runs from `max(lastProgress, foregroundSince, offlineSince)`
(`DownloadStallPolicy.deadline`), while the `noProgress` field on the
`modelDownloadOffline` line is measured from the last byte alone. The bytes stop when the
radio goes; the path is declared down a beat later. So `noProgress` always reads **15 s or
a little more**, and how much more is the lag between those two events — which no code
here bounds, and which measured between 0 and 3 s across four device runs (15, 16, 17 and
18 s). Treat that field as an observation, not as a guarantee. The guarantee is the 17 s
above.

The number is not the old 30 s carried over. Thirty seconds was chosen for an *idle-byte*
timeout on a foreground session (#207), where the risk being managed was killing a
transfer that was slow but alive. This predicate cannot make that mistake: a live transfer
has a network path, and the predicate requires there to be none. So the only thing the
grace period still has to absorb is a **transient** `unsatisfied` reading — a Wi-Fi to
cellular handover, a lift, a router blink — and those are a few seconds. Fifteen clears
them with room to spare, and is short enough that a user who has just switched on airplane
mode still connects the message to what they did. It is asserted in
`DownloadStallPolicyTests.testShippedGracePeriodIsFifteenSeconds`, so changing it is a
deliberate edit to a test rather than a one-character change to a constant.

Step 5 of the manual list is what bounds it from below; step 1 is what bounds it from above.

## What changed

**DictusCore (pure, unit tested)**

- `DownloadStallPolicy` — the predicate. Fires only when **no progress** AND **the app is
  foregrounded** AND **there is no network path**, all three holding continuously for the
  grace period, which is measured from the **latest** of the three onsets. That last part
  is what stops a clause being satisfied retroactively: a user who spent three minutes in
  another app with the network off would otherwise meet an error the instant they looked
  at the screen, having never been given the grace period while they could see it. The
  clock is injected, so the whole decision is testable without a device.
- `LogEvent.modelDownloadOffline(name:path:secondsWithoutProgress:)` — the line whose
  absence created the issue. A background session waiting for connectivity emits nothing,
  which is why the evidence in #492 is three minutes of empty log under a frozen bar.

**DictusApp**

- `DownloadConnectivityWatch` — asks the two questions a transfer cannot answer about
  itself. `NWPathMonitor` for the route, counting only `.unsatisfied` and never
  `.requiresConnection` (a VPN or on-demand interface can still be brought up, so the
  transfer is not necessarily dead). `didBecomeActive` / `didEnterBackground` for the
  foreground, deliberately **not** `willResignActive`, which fires for a control centre
  pull with the user still watching the bar. Both start unknown, so nothing can fire
  before a real reading. Ticks every 2 s, and only while a run is live.
- `BackgroundModelDownloadService` — records when a byte last arrived, starts the watch
  with the first run and stops it with the last, and on a tick fails any run the predicate
  condemns: log the line, cancel the parked tasks, resume the caller with
  `DownloadError.stalled`.

**No new user-facing copy.** `DownloadError.stalled`'s string —
*"The download stalled. Check your internet connection and try again."* — already existed
at `ModelRepoDownloader.swift:188` and has simply been unreachable on this path since the
transfer moved to a background session. Against #313's contract it holds up: it is a
`String(localized:)` written for a user, it carries no raw error text, and it names the one
thing the user can actually do. It reaches the screen through machinery that already exists
— `ModelManager` sets `.error`, `ModelDownloadPage` shows the message and brings the install
button back as Retry, `ModelLoadingOverlay` dismisses itself on `.error`.

### Three deliberate non-choices

- **No wall-clock timeout.** That is what #449 removed and it would fire on a legitimate
  backgrounding again. The foreground clause is what a backgrounding fails.
- **No `waitsForConnectivity = false`.** A background session ignores it, and turning it
  off would break the case #449 exists to protect.
- **No retry loop.** The transfer resumed correctly on its own when the network came back
  (08:11:49 in the issue's evidence); nothing about the transfer needs fixing. The run is
  failed rather than retried because the predicate has *already established* there is no
  route, so a retry two seconds later could only park again and spend the file's remaining
  attempts saying nothing. No failure on the download phase deletes anything
  (`ModelCleanupPolicy.shouldCleanUpFiles` requires `downloadPhaseCompleted`), so Retry
  resumes at the last **chunk boundary** that landed — not at the byte the transfer
  reached. The chunks still in flight go with the run, which is up to 64 MB re-paid
  (32 MB a chunk, two in flight). Measured on device on 2026-09-06: a cut inside the first
  chunk of a 176 MB `weight.bin` re-paid 49 MB and the bar legitimately restarted at 0%.

A run nobody is awaiting is also left alone — one that `restore()` rebuilt and no screen
has claimed. There is nowhere to deliver an error, and the issue is explicit that a stall
the user cannot act on should not be reported.

### Why the bar can fall from 10% to 0% having lost almost nothing

Worth writing down once, because it looks like a second bug and is not one, and it predates
this PR entirely. `DownloadRun.emitProgress` reports `manifest.receivedBytes + live`: the
bytes **in flight** are counted in the bar alongside the durable ones. So the percentage a
user sees during a transfer is ahead of what is actually banked, by as much as the two
in-flight chunks — up to 64 MB.

When an interruption discards those chunks, the bar drops by everything it was over-counting
at once. The device run of 2026-09-06 shows the shape: 51 MB announced at the cut, 2 MB on
the retry. Only 2 MB had ever been durable; the other 49 MB existed solely in system
temporary files. Nothing banked was destroyed — the manifest held 2 MB before the cut and
2 MB after it. The bar over-promised, then told the truth.

None of this is changed by this PR. It is recorded here so the next reader of a log like
that one does not open it as a resume bug.

### The race CodeRabbit found, fixed in 54d6c94

A tick is raised on the watcher's queue and acted on on the download session's delegate
queue, and `now` was sampled when the operation ran rather than when the tick was raised.
So a reading taken while the device was offline could be judged, seconds later, against a
clock that had meanwhile passed the grace period, and cancel a download that was by then
neither backgrounded-free nor offline — the #449 false alarm through another door.

The gap is correlated with the case, not incidental to it: the moment connectivity returns
is exactly the moment that delegate queue fills up, because every parked task resumes at
once. The path monitor's update can land before the first byte does, so `lastProgressDate`
is still old at that point and nothing else would have refused the decision.

`DownloadConnectivityWatch` now keeps its two conditions in one lock-protected
`DownloadStallConditions` any thread may read; the tick carries a copy rather than being
the only way to see it. `reportOfflineStalls` re-reads it one line before the loop, and
`DownloadStallPolicy.conditionsHeldContinuously` refuses a reading whose onsets have moved
or gone `nil` — each onset is written once per transition, so identity of the instant is
what says the condition was never interrupted between the two readings. `hasStalled` is
untouched, which is why the device results above still stand.

## Acceptance criteria

| Criterion | Status | Evidence |
| --- | --- | --- |
| Airplane mode surfaces a message and a Retry within a bounded time, stated in the PR | **Verified on device, 4/4, on both builds** | Device 2026-09-06, iPhone 15 Pro Max / iOS 26.6.1. Three runs on `rev c2489bc@HEAD`: `modelDownloadOffline noProgress=16s` (Small), then `noProgress=15s` and `noProgress=17s` (Parakeet). **A fourth on `rev 54d6c94@HEAD`, after the race fix** — airplane mode at 10% on Whisper Small, 14:32:17, `noProgress=18s`, then completion after the Retry at 14:33:45. Each was followed by `modelDownloadFailed` carrying the stalled string. All four are consistent with 15 s of grace plus one 2 s tick, measured from the last of the three conditions; the spread is the lag of the path reading behind the last byte, which is what `noProgress` includes and the grace period does not. A Retry tapped while still offline failed cleanly in 6 s through the ordinary URLSession error, not through this path. |
| Backgrounding still resumes silently — the #449 false alarm does not come back | **Verified on device, at 8× the asked duration** | Same session: backgrounded 13:43:56 → 14:00:07, **16 min 11 s** rather than the two minutes the issue asks for. `modelDownloadProgress percent=20` immediately before, `percent=30` on return, then 100% in 55 s. **Zero `modelDownloadOffline`, zero `modelDownloadFailed`** across the whole window. |
| The two are distinguished by a predicate, not a longer timeout | **Verified** | `DownloadStallPolicy` is three clauses with a max()-of-onsets clock, now 18 unit tests. The grace period went **down**, from 30 s to 15 s. The device pair above is the same predicate answering both ways on the same build. |
| Verified on device on both paths: airplane mode, and a plain backgrounding of two minutes | **Verified on device, both paths** | The two rows above, from two exported logs on one build. |

**Coverage of the race fix, stated plainly:** criterion 1 has been re-run on `54d6c94`
(the fourth measurement above) and passes. Criterion 2's 16-minute backgrounding was run on
`c2489bc` only. The fix adds a revalidation in front of the same decision and leaves
`hasStalled` untouched, so it can only make the reporting *more* reluctant, never more
eager — a backgrounding that reported nothing before cannot start reporting now. Step 3 of
the manual list is the cheap re-check if you want it before merging.

## Verification run here

- `xcodebuild build -scheme DictusApp -destination 'generic/platform=iOS Simulator'` —
  **BUILD SUCCEEDED** (this builds the embedded keyboard, widgets and core).
- `cd DictusCore && swift test` — **1651 tests, 1 skipped, 0 failures.**
- `swiftlint lint --strict` — **0 violations, 0 serious in 251 files.**
- **Headless simulator, real download, no false alarm.** iPhone 17 / iOS 26.5, created and
  deleted for this run so no other worktree's device was touched. Whisper Small (Quantized),
  217 MB, downloaded end to end with the watch running: 24 `modelDownloadChunk` lines, all
  `206` with validated ETags, `modelDownloadCompleted` 20 s after the start, and
  **0 `modelDownloadOffline` lines, 0 `modelDownloadStalled` lines**. The app was still
  alive afterwards, so the new `NWPathMonitor` and timer do not crash the download path.
  This is the online half only — the offline half is not reachable from a simulator.

Re-run in full after the race fix in 54d6c94 and after merging `develop` into the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTeVma6QXvLHg579PZVN5B


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monitoring for model downloads that stop progressing while the app is open and offline.
  * Downloads now have a 15-second grace period before being cancelled with a stalled-download error.
  * Receiving data or resuming a download restarts the progress grace period.

* **Bug Fixes**
  * Prevented outdated connectivity information from cancelling downloads after conditions change.
  * Prevented downloads from remaining indefinitely stalled without network connectivity.

* **Logging**
  * Added warning logs for model downloads cancelled after prolonged offline inactivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

