### PR TITLE
Shorten the key popup dismiss delay from 100 ms to 40 ms (refs #507)

### DIFF
--- a/DictusKeyboard/Vendored/Views/KeyboardView.swift
+++ b/DictusKeyboard/Vendored/Views/KeyboardView.swift
@@ -551,6 +551,26 @@ final internal class GiellaKeyboardView: UIView,
     var keyRepeatTimer: Timer?
     var dismissOverlayTimer: Timer?
 
+    /// How long the key popup stays up after the finger lifts.
+    ///
+    /// The vendored giellakbd code scheduled 0.1 s here and gave no reason for it. Measured
+    /// against Apple's keyboard on the same device, same host, same injected press, that put
+    /// our bubble on screen 33% longer than theirs -- and the whole gap was on the dismissal
+    /// side: our popup vanished 60-69 ms *after* the character was already in the field,
+    /// where Apple's vanished in the same frame as the character (#507).
+    ///
+    /// 0.04 rather than 0: the tail we measured was 127-139 ms against a *scheduled* 100 ms,
+    /// so the timer fire plus the layout and render pass costs ~30-40 ms on its own.
+    /// Scheduling 40 lands the visible tail at ~70-80 ms, which is Apple's measured 67-74 ms.
+    /// The target is to match the platform, not to beat it.
+    ///
+    /// WHY a timer at all, at 40 ms: its anti-flicker role during fast typing comes from its
+    /// existence, not its length. `activeKey.willSet` below invalidates it when the next key
+    /// goes down, and `showOverlay` calls `removeAllOverlays()` before drawing the new bubble,
+    /// so the hand-off from one key to the next stays a single redraw at any interval.
+    /// Removing the mechanism instead of shortening it would change that hand-off.
+    private static let overlayDismissDelay: TimeInterval = 0.04
+
     /// Tracks how many times the key repeat timer has fired during the current hold.
     /// Used to switch from character-level to word-level deletion after threshold.
     private var deleteRepeatCount: Int = 0
@@ -588,7 +608,7 @@ final internal class GiellaKeyboardView: UIView,
                 cell.keyView?.active = false
             }
             if newValue == nil, let activeKey = activeKey {
-                dismissOverlayTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: false, block: { [weak self] _ in
+                dismissOverlayTimer = Timer.scheduledTimer(withTimeInterval: Self.overlayDismissDelay, repeats: false, block: { [weak self] _ in
                     self?.removeOverlay(forKey: activeKey.key)
                 })
                 stopKeyRepeat(reason: "touch")


### PR DESCRIPTION
Fixes the dismissal delay measured in #507. `refs #507`

## What this was for

A user reported the keyboard feeling "less responsive" than Apple's. #507 established that typing latency is not where the difference is — the key popup's **lifetime** is. Our bubble stayed on screen about a third longer than Apple's, and the whole difference was on the dismissal side: the letter was already in the text field and our bubble was still there, 60-69 ms later, where Apple's disappeared in the same frame as the character.

The cause was a `dismissOverlayTimer` scheduled at 0.1 s, inherited from the vendored giellakbd-ios code, with no reason recorded for that number.

## The change

One constant. `withTimeInterval: 0.1` → a named `overlayDismissDelay` of `0.04` in `DictusKeyboard/Vendored/Views/KeyboardView.swift`, hoisted next to the timer it feeds and carrying the measurement as a WHY comment, in the shape `wordModeThreshold` already uses in the same file.

40 ms rather than 0, per the brief: the measured tail was 127-139 ms against a *scheduled* 100 ms, so the timer fire plus the layout and render pass costs ~30-40 ms on its own. The target is to match the platform, not to beat it.

The timer is kept as a mechanism. Its anti-flicker role during fast typing comes from its existence, not its length: `activeKey.willSet` invalidates it when the next key goes down, and `showOverlay` calls `removeAllOverlays()` before drawing the new bubble, so the hand-off between consecutive keys stays a single redraw at any interval. The long-press path never reaches this timer at all — `touchesEnded` removes the overlays synchronously there.

No constraint or layout code is touched (#166).

## Measured

Simulator (iPhone 17 Pro, iOS 26.5), French AZERTY, key `G`, Settings search field as host, `axe touch --down --up --delay`, `simctl io recordVideo` (variable-rate, so a frame's timestamp is the moment it rendered), popup presence by pixel diff on a 150×170 box above the key. n=6 per row, one session, same device, same host.

**Popup visible on screen:**

| Injected press | Apple | Dictus before | Dictus after |
| --- | --- | --- | --- |
| 150 ms | **228 ms** (213-248) | **286 ms** (280-292) | **228 ms** (217-240) · confirm run **231 ms** (225-238) |
| 400 ms | **483 ms** (473-503) | not measured | **483 ms** (480-488) |

**Popup disappearance relative to the character landing in the field** (the line a user feels):

| | Apple | Dictus before | Dictus after |
| --- | --- | --- | --- |
| 150 ms | −1 ms (−5..0) | **+64 ms** (+60..+67) | **+10 ms** (+3..+22) · confirm **+6 ms** (0..+8) |
| 400 ms | +0 ms (all six) | not measured | −2 ms (−12..+8) |

"Dictus before" is the *same binary* with the constant put back to 0.1 and rebuilt, measured with the identical harness minutes apart — not the numbers from the issue. It reproduces the issue's 289 ms and +60..69 ms, which is what licenses attributing the rest to this change.

The result lands slightly better than the ~220-230 ms the issue predicted: on Apple's number rather than near it.

## Side observation, reproduced, not fixed here

The frame-cadence difference #507 recorded at the bottom is real and unchanged by this PR: Apple's recordings carry ~292 frames over 17 s with a 36.7 ms median inter-frame gap and gaps up to 502 ms; Dictus's carry ~1060 frames over 15 s at a 16.7 ms median with no gap longer than 33 ms. The Dictus keyboard never stops redrawing while idle. That belongs to its own issue.

## To test by hand

A physical device is the only thing that can settle these; a simulator cannot. Build this branch onto an iPhone, enable the Dictus keyboard, and:

1. Open any text field and type a sentence at your normal speed. **Expect:** no flicker and no double-drawn bubble between consecutive keys — each key's popup replaces the previous one in one redraw, with no gap where neither is showing.
2. Tap a single key quickly, then tap another key slowly and deliberately. **Expect:** in both cases the bubble is gone by the time the letter is in the field, not after it.
3. Press and hold `e` until the accent popup opens, slide to an accent, release. **Expect:** unchanged behaviour — the accent row opens, the pick lands, and the overlay closes on release with no residue. (This path removes the overlay synchronously and never reaches the timer, so it is a regression check rather than a change.)
4. Type quickly on the top row (`a`, `z`, `e`, `r`) and watch the keyboard's height. **Expect:** no height change or jump — #166's no-go zone, confirming nothing in this file was disturbed.

Everything else is covered by the commands in "Measured" above plus `xcodebuild build -scheme DictusApp` (BUILD SUCCEEDED), `cd DictusCore && swift test` (1633 tests, 0 failures, 1 skipped) and `swiftlint lint --strict` (0 violations in 249 files).
