### PR TITLE
Stop the keyboard's idle mic glow from holding a 60 fps compositing loop open (refs #510)

### DIFF
--- a/DictusCore/Sources/DictusCore/Design/AnimatedMicButton.swift
+++ b/DictusCore/Sources/DictusCore/Design/AnimatedMicButton.swift
@@ -41,15 +41,38 @@ public struct AnimatedMicButton: View {
     /// recording on every screen of this product.
     public let badge: SmartModeBadge?
 
+    /// Whether the resting glow breathes, or simply sits at a fixed opacity.
+    ///
+    /// `true` — the default, and the app's behaviour — is the 2 s `repeatForever`
+    /// this button was written for: the recording screen is large, it is the thing
+    /// the user is looking at, and the breathing is what says the mic is live.
+    ///
+    /// `false` exists for the keyboard extension (#510). The glow's `repeatForever`
+    /// is the *only* reason the keyboard never stops compositing: measured on an
+    /// iPhone 17 Pro simulator, idle with nothing being touched, Dictus redrew at
+    /// 66 fps with no gap longer than 35 ms, against 18.8 fps and half-second gaps
+    /// for Apple's keyboard in the same field. Disabling this one line dropped it to
+    /// 10.5 fps, twice in a row, with nothing else changed. The maintainer's call is
+    /// that a 56×36 pill is too small for the effect to be perceptible anyway, so a
+    /// keyboard extension under a ~50 MB ceiling should not hold a compositing loop
+    /// open for its whole lifetime to draw it.
+    ///
+    /// It gates the idle glow only. `startRecordingAnimation` and
+    /// `startTranscribingAnimation` are untouched in both modes: those run during a
+    /// dictation, where the motion carries state the user needs.
+    public let animatesIdleGlow: Bool
+
     public let onTap: () -> Void
 
     public init(status: DictationStatus,
                 isPill: Bool = false,
                 badge: SmartModeBadge? = nil,
+                animatesIdleGlow: Bool = true,
                 onTap: @escaping () -> Void) {
         self.status = status
         self.isPill = isPill
         self.badge = badge
+        self.animatesIdleGlow = animatesIdleGlow
         self.onTap = onTap
     }
 
@@ -315,6 +338,17 @@ public struct AnimatedMicButton: View {
 
     private func startIdleAnimation() {
         pulseScale = 1.0
+
+        guard animatesIdleGlow else {
+            // 0.45 is the midpoint of the 0.3-0.6 range the animation sweeps, so the
+            // static ring reads as the average of what was breathing there rather than
+            // as either extreme -- neither a glow that looks extinguished nor one stuck
+            // at its peak. Assigned outside `withAnimation` on purpose: the whole point
+            // is that Core Animation is left with nothing live to composite (#510).
+            glowOpacity = 0.45
+            return
+        }
+
         withAnimation(.easeInOut(duration: 2).repeatForever(autoreverses: true)) {
             glowOpacity = 0.6
         }

--- a/DictusKeyboard/Views/ToolbarView.swift
+++ b/DictusKeyboard/Views/ToolbarView.swift
@@ -324,6 +324,7 @@ struct ToolbarView: View {
             status: dictationStatus,
             isPill: true,
             badge: effectiveSmartMode?.badge,
+            animatesIdleGlow: false,
             onTap: {
                 guard !fanGestureDidOpen else {
                     fanGestureDidOpen = false
@@ -529,9 +530,14 @@ struct ToolbarView: View {
     /// effect — the group is not sliding, it is *reaching* — and it is why this is
     /// two amplitudes on one animation rather than one `offset` on the `HStack`.
     ///
-    /// It repeats forever in a keyboard extension, which is the cost. It is the cost
-    /// the idle mic glow already pays in the same view, and this one stops existing
-    /// the moment the user performs the gesture once.
+    /// It repeats forever in a keyboard extension, which is the cost — and since #510
+    /// it is the only thing in this bar still paying it: the mic's idle glow used to
+    /// repeat here too and no longer does, so whenever this hint is on screen it holds
+    /// the compositing loop open by itself. What keeps it affordable is that it stops
+    /// existing the moment the user performs the gesture once.
+    ///
+    /// The curve is still described above as the mic's own. That is now a statement
+    /// about the app's recording screen, which is where the breathing survives.
     private var discoveryHint: some View {
         HStack(spacing: 6) {
             Text(
@@ -603,7 +609,7 @@ struct ToolbarView: View {
             HStack {
                 Spacer()
 
-                AnimatedMicButton(status: .idle, isPill: true, onTap: {})
+                AnimatedMicButton(status: .idle, isPill: true, animatesIdleGlow: false, onTap: {})
                     .disabled(true)
                     .opacity(0.4)
             }


### PR DESCRIPTION
refs #510

## What this was for

The keyboard extension never stopped redrawing. With Dictus on screen and nobody touching anything, the display updated ~60 times a second for as long as the keyboard was up, while Apple's keyboard in the same field went quiet within two frames of the last event. One line caused it: the mic's idle glow is a 2 s `repeatForever`, so Core Animation had a live animation for the whole session.

Nothing here is a performance claim. The measurements are on a simulator, where rendering is the Mac's work, and the issue is explicit that they say nothing about iPhone CPU, battery or thermals. The argument for removing it is that a keyboard extension living under a ~50 MB ceiling was holding a continuous compositing loop open to animate a glow nobody can see in a 56×36 pill. The maintainer decided on 2026-09-05 to remove it, scoped to the keyboard.

## What changed

`AnimatedMicButton` gets an `animatesIdleGlow: Bool = true` parameter. The default is today's behaviour, so **DictusApp is untouched** — its recording screen draws the same button, the pill is large, the screen is the point, and the breathing stays. The keyboard passes `false` at both of its call sites, and `startIdleAnimation` then assigns the glow statically at 0.45 (the midpoint of the 0.3–0.6 range the animation sweeps) instead of wrapping it in `withAnimation`.

Two call sites in the keyboard, not one: `micPill`, and the disabled mic in `fullAccessBar` — the latter is the one that was actually on screen throughout the issue's measurement.

Only the idle glow is gated. `startRecordingAnimation` and `startTranscribingAnimation` are untouched, and `discoveryHint`'s `repeatForever` in `ToolbarView` is out of scope and unchanged. Its doc comment did claim "It is the cost the idle mic glow already pays in the same view", which this change makes false, so the comment is corrected — the animation is not.

## Acceptance criteria

**Verification 1 — idle redraw measurement.** Reproduced headlessly on the iPhone 17 Pro simulator (iOS 26.5), Settings search field, French AZERTY, idle with no touches. `xcrun simctl io recordVideo` emits a frame only when the display changes, so frames over a fixed window = redraw count. Both builds measured in the same session, minutes apart, on the same device and field:

| Build on screen | frames | window | rate | median gap | longest gap |
| --- | --- | --- | --- | --- | --- |
| Apple keyboard (same-session control) | 116 | 11.3 s | 10.2 fps | 38.3 ms | 502 ms |
| Dictus, `develop` (pre-fix), run A | 813 | 11.8 s | **69.1 fps** | 16.7 ms | **35 ms** |
| Dictus, `develop` (pre-fix), run B | 801 | 11.7 s | **68.7 fps** | 16.7 ms | **35 ms** |
| Dictus, this branch, run 1 | 121 | 11.6 s | **10.5 fps** | 38.3 ms | **502 ms** |
| Dictus, this branch, run 2 | 116 | 11.2 s | **10.3 fps** | 38.3 ms | **500 ms** |
| Dictus, this branch, after reinstall | 120 | 11.5 s | **10.5 fps** | 38.3 ms | **500 ms** |

The pre-fix rows reproduce the issue's 66 fps / 16.7 ms / 35 ms. The fixed rows land on Apple's own control to within 0.3 fps, with the half-second caret-blink gap restored. Expected band was 10–20 fps with the longest gap in the hundreds of milliseconds: met.

**Verification 2 — the #507 popup measurement must not move.** Same protocol: key `G`, `axe touch --down --up --delay 0.15`, n=6, one second apart, popup presence by pixel diff on a box directly above the key, transitions read off the variable-rate recorder's frame timestamps.

| | n | median | range |
| --- | --- | --- | --- |
| This branch | 6 | **232 ms** | 217–237 ms |

Expected ~230 ms visible for a 150 ms press: met, and it sits between the issue's own two rows (234 ms glow on, 230 ms glow off).

**Verification 3 — device check.** Not done; it needs a physical iPhone and a human eye. See below.

**Build, test, lint.** `cd DictusCore && swift test` → 1633 tests, 1 skipped, 0 failures. `swiftlint lint --strict` → 0 violations in 249 files. `xcodebuild` on all three schemes (`DictusApp`, `DictusKeyboard`, `DictusCore`) → BUILD SUCCEEDED. No `Localizable.xcstrings` churn.

## To test by hand

Everything below needs a physical device or a human eye; nothing here was verified by the commands above.

1. Install this branch on the iPhone and open the **app's recording screen**. The large round mic must still *breathe* — its ring glow fading in and out on a ~2 s cycle. This is the regression that matters: the app was meant to be untouched. If it is static, the default did not hold.
2. Start a recording from that screen. The mic must turn red and pulse (ring scaling) exactly as before.
3. Let it transcribe. The blue shimmer must still sweep across the button during transcription/polish, and the brief green flash must still appear when the result lands.
4. Open the **Dictus keyboard** in any text field and leave it alone. The mic pill's ring must be **static** — a visible, steady blue ring at a middling brightness, not breathing, and above all not looking switched off or dead. This is the one subjective call the change hangs on: 0.45 was chosen as the midpoint of what used to breathe, and only your eye can say whether it reads as intentional. If it reads as dead, the value is one constant in `startIdleAnimation`.
5. From the keyboard, tap the mic and dictate. During recording the pill must go red and pulse; during transcription it must shimmer. Only the *idle* glow was gated, so any loss of motion during a dictation is a defect.
6. In a field where Full Access is not granted, check the "Accès complet requis" bar: the greyed-out mic at its right must also be static.
7. Long-press the mic to open the Smart Mode fan, arm a mode, and confirm the corner badge still draws on the pill and the fan still opens/arms normally — the gesture is attached to the same button whose initializer changed.
8. If the "Hold the mic for Smart Modes" hint is still showing for you, note that it is now the only thing in the toolbar animating forever. Out of scope here and deliberately unchanged, but it is worth knowing that a keyboard showing that hint does not get the full benefit of this change.

## Caveats

- Every number above is from a simulator, where rendering is the Mac's work. **They say nothing about iPhone CPU, battery, thermals, or the extension's memory ceiling**, and no such claim is made — the issue is explicit on this point.
- The simulator used is the `Dictus 507 verify` device left booted by the #507 work. This branch's build was installed over what was there. Installing the app drops the extension out of the field and iOS falls back to Apple's keyboard, so Dictus was re-selected (long-press globe → pick Dictus) and confirmed by screenshot before every measurement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - The microphone controls in the toolbar no longer use a continuously repeating idle glow animation.
  - Recording and transcription animations remain unchanged.
  - The discovery hint is now the only continuously repeating animation in the toolbar.
  - Idle, ready, and failed microphone states display a steady glow instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->