### PR TITLE
Let the bus name the tap's format, and the buffer name the converter's (refs #417)

### DIFF
--- a/DictusApp/Audio/UnifiedAudioEngine.swift
+++ b/DictusApp/Audio/UnifiedAudioEngine.swift
@@ -19,6 +19,16 @@ extension Notification.Name {
     static let dictusWarmStateReleased = Notification.Name("DictusWarmStateReleased")
 }
 
+/// Which of the two Objective-C calls in `startEngine()` raised an NSException.
+///
+/// The raw values are the tokens already written to the persistent log
+/// (`installTap NSException:` / `engine.start NSException:`), so a log an agent greps
+/// and an error payload it reads spell the same fact the same way (#255, #417).
+enum ObjCAudioStartCall: String {
+    case installTap
+    case engineStart = "engine.start"
+}
+
 /// Errors that can occur during audio engine operations.
 enum AudioEngineError: Error, DiagnosableError {
     case permissionDenied
@@ -39,10 +49,18 @@ enum AudioEngineError: Error, DiagnosableError {
     /// hardware is unavailable".
     case audioHardwareUnavailable(reason: String)
 
-    /// `installTap` or `engine.start` raised an Objective-C exception. The payload is the
-    /// exception's own text and is diagnostic only — it is an AVFoundation sentence that
-    /// names formats and sample rates.
-    case installTapFailed(String)
+    /// `installTap` or `engine.start` raised an Objective-C exception. `reason` is the
+    /// exception's own text — an AVFoundation sentence naming formats and sample rates —
+    /// and `call` names which of the two raised it.
+    ///
+    /// WHY `call` is carried (#417): AVAudioEngine defers tap creation on a stopped engine
+    /// until `start()`, so the same exception text can come from either site, and the two
+    /// mean different things — a tap that could not be installed, versus a format that
+    /// drifted after it was. Only the persistent log told them apart, and that distinction
+    /// is what made #417 diagnosable at all. Diagnostic only, like `phoneCallActive`'s
+    /// evidence: both cases show the user the same sentence, because from their side they
+    /// are the same event.
+    case installTapFailed(call: ObjCAudioStartCall, reason: String)
 
     /// User-facing text. Written to `DictationErrorChannel` and displayed by whichever
     /// surface the user is on — the keyboard's toolbar, the app's failure screen, or both.
@@ -77,8 +95,8 @@ enum AudioEngineError: Error, DiagnosableError {
             return "a call holds the microphone — \(evidence)"
         case .audioHardwareUnavailable(let reason):
             return "input node reports an unusable format after the engine rebuild — \(reason)"
-        case .installTapFailed(let reason):
-            return "installTap/engine.start raised: \(reason)"
+        case .installTapFailed(let call, let reason):
+            return "\(call.rawValue) raised: \(reason)"
         }
     }
 }
@@ -98,6 +116,14 @@ enum AudioEngineError: Error, DiagnosableError {
 /// buffers for heartbeat/energy (background survival) but discards the actual audio data.
 /// This eliminates the 64M idle sample accumulation bug (#38).
 @MainActor
+// WHY the exemption (#417): this class body was at 648 of the 650-line budget before the
+// converter rebuild was added, so any fix landing in it trips the rule. The threshold's own
+// rationale in .swiftlint.yml is that it exists "to catch a NEW type or function ballooning"
+// and explicitly not to police the large classes that already exist — raising the global
+// number to fit this one would weaken it everywhere for a class it was never aimed at, and
+// carving the audio-thread half into an extension is a restructuring of the file that the
+// same rationale calls the highest-risk change available. Scoped here, and only here.
+// swiftlint:disable:next type_body_length
 class UnifiedAudioEngine: ObservableObject {
     // MARK: - Published State
 
@@ -146,11 +172,27 @@ class UnifiedAudioEngine: ObservableObject {
     /// Accumulated audio samples in 16kHz mono Float32 (WhisperKit/Parakeet expected format).
     private var audioSamples: [Float] = []
 
-    /// Converter from hardware sample rate (typically 48kHz) to 16kHz mono.
-    /// WHY nonisolated(unsafe): Written once from main thread in startEngine(),
-    /// read from audio callback thread in processBuffer(). Write completes before
-    /// the audio tap is installed, so no race condition.
+    /// Converter from the hardware format (typically 48kHz mono) to 16kHz mono.
+    ///
+    /// WHY nonisolated(unsafe): `startEngine()` pre-builds one from the format the input
+    /// node reported, and from then on `processBuffer()` owns it — it rebuilds from the
+    /// buffer's own format whenever the two disagree (#417). Main writes it again only to
+    /// clear it, in the two places that bump `engineGeneration` and remove the tap first,
+    /// so an in-flight callback bails out before it can observe the nil.
+    ///
+    /// WHY the pre-build survived the move to the tap: it is what keeps the audio thread
+    /// allocation-free in the normal case. The format the node reports is the right one
+    /// almost always; when it is not, the tap pays a single build and says so.
     private nonisolated(unsafe) var converter: AVAudioConverter?
+
+    /// The last buffer format `AVAudioConverter(from:to:)` refused, if any.
+    ///
+    /// WHY it is remembered (#417): the tap runs on a real-time thread and buffers arrive
+    /// at roughly 100 Hz. Without the memo, a format nothing can convert would be retried
+    /// — allocating — on every one of them, for as long as that route lasts. Cleared
+    /// wherever `converter` is, so a fresh engine inherits no verdict from the dead one.
+    /// `AudioConverterCachePolicy` holds the rule.
+    private nonisolated(unsafe) var lastUnconvertibleInputFormat: AVAudioFormat?
 
     /// Target format: 16kHz mono Float32 — what WhisperKit and Parakeet expect.
     ///
@@ -544,6 +586,7 @@ class UnifiedAudioEngine: ObservableObject {
         engineGeneration &+= 1
         engine = AVAudioEngine()
         converter = nil
+        lastUnconvertibleInputFormat = nil
     }
 
     // MARK: - Session & Permissions (ported from AudioRecorder)
@@ -903,6 +946,7 @@ class UnifiedAudioEngine: ObservableObject {
         )
         sessionConfigured = false
         converter = nil
+        lastUnconvertibleInputFormat = nil
         lastIdleStartTime = nil
         idleReleaseWorkItem = nil
 
@@ -951,18 +995,30 @@ class UnifiedAudioEngine: ObservableObject {
 
         let (inputNode, hwFormat) = try resolveUsableInputFormat(context: context)
 
-        // Create converter from hardware format to 16kHz mono
-        guard let conv = AVAudioConverter(from: hwFormat, to: targetFormat) else {
-            // Logged for the same reason as the guards above (#123): a start that
-            // fails here leaves no trace at all, and the format that could not be
-            // converted is the only thing that would explain it.
-            PersistentLog.log(.dictationFailed(
-                error: "no converter from sr=\(hwFormat.sampleRate) ch=\(hwFormat.channelCount) to 16kHz mono"
+        // Pre-build the converter from the format the node just reported, to 16kHz mono.
+        //
+        // WHY this is best effort and no longer throws (#417): since the tap installs with
+        // `format: nil`, `hwFormat` is advisory. The format that matters is the one on the
+        // first buffer, and `processBuffer` rebuilds from it when the two disagree. Refusing
+        // to start here would refuse a dictation the bus was about to serve correctly.
+        //
+        // The pre-build stays because it is what keeps the audio thread allocation-free in
+        // the normal case: the node's format is the bus's format almost always, so the first
+        // recording buffer finds a converter that already matches and builds nothing.
+        //
+        // The log line stays for the reason #123 put it there: a start that produces no
+        // converter used to leave no trace at all, and the format is the only thing that
+        // would explain it. It is a diagnostic now, not a failure — the tap gets the last word.
+        converter = AVAudioConverter(from: hwFormat, to: targetFormat)
+        lastUnconvertibleInputFormat = nil
+        if converter == nil {
+            PersistentLog.log(.diagnosticProbe(
+                component: "UnifiedAudioEngine",
+                instanceID: context,
+                action: "converterPrebuildFailed",
+                details: "no converter from sr=\(hwFormat.sampleRate) ch=\(hwFormat.channelCount) to 16kHz mono"
             ))
-            throw NSError(domain: "UnifiedAudioEngine", code: 1,
-                          userInfo: [NSLocalizedDescriptionKey: "Cannot create audio converter from \(hwFormat) to 16kHz mono"])
         }
-        converter = conv
 
         // Remove any stale tap before installing a new one.
         // WHY: If a previous startEngine() installed a tap but engine.start() threw
@@ -980,10 +1036,19 @@ class UnifiedAudioEngine: ObservableObject {
         // belong to the dead engine and must be discarded — otherwise they race
         // with the new engine's tap on shared `nonisolated(unsafe)` audio-thread
         // state (issue #106 review).
+        //
+        // WHY `format: nil` rather than `hwFormat` (#417): nil means "use the bus's own
+        // format", so the value can no longer be stale and a mismatch is impossible by
+        // construction. `hwFormat` was read by `resolveUsableInputFormat` sixty lines up,
+        // and an interruption — a native call, or Siri — renegotiates the input node inside
+        // that window. Measured six times on device (2026-09-02 with Siri listening,
+        // 2026-09-03 during a call): `installTap NSException: Failed to create tap due to
+        // format mismatch, <AVAudioFormat 1 ch, 48000 Hz, Float32>`, on a format that is
+        // individually valid and that every pre-flight guard therefore accepts.
         let installedGeneration = engineGeneration
         do {
             try ObjCExceptionCatcher.catchException {
-                inputNode.installTap(onBus: 0, bufferSize: 4096, format: hwFormat) { [weak self] buffer, _ in
+                inputNode.installTap(onBus: 0, bufferSize: 4096, format: nil) { [weak self] buffer, _ in
                     guard let self else { return }
                     guard installedGeneration == self.engineGeneration else { return }
                     self.processBuffer(buffer)
@@ -992,7 +1057,7 @@ class UnifiedAudioEngine: ObservableObject {
         } catch {
             let reason = (error as NSError).localizedDescription
             PersistentLog.log(.dictationFailed(error: "installTap NSException: \(reason)"))
-            throw AudioEngineError.installTapFailed(reason)
+            throw AudioEngineError.installTapFailed(call: .installTap, reason: reason)
         }
 
         // engine.start() can throw both Swift errors (AUIOClient_StartIO) and
@@ -1010,7 +1075,7 @@ class UnifiedAudioEngine: ObservableObject {
             inputNode.removeTap(onBus: 0)
             let reason = (error as NSError).localizedDescription
             PersistentLog.log(.dictationFailed(error: "engine.start NSException: \(reason)"))
-            throw AudioEngineError.installTapFailed(reason)
+            throw AudioEngineError.installTapFailed(call: .engineStart, reason: reason)
         }
         if let swiftStartError {
             inputNode.removeTap(onBus: 0)
@@ -1241,7 +1306,7 @@ class UnifiedAudioEngine: ObservableObject {
             return
         }
 
-        guard let converter else { return }
+        guard let converter = converterMatching(buffer.format) else { return }
 
         // Calculate output frame count: input frames * (target rate / source rate) + 1
         let ratio = 16000.0 / buffer.format.sampleRate
@@ -1339,6 +1404,74 @@ class UnifiedAudioEngine: ObservableObject {
 
             // Maintain a rolling window of energy values (last 30 = matches barCount in BrandWaveform)
             self.bufferEnergy = self.makeWaveformSnapshot()
+        }
+    }
+
+    /// The converter for this buffer, built or rebuilt when the one we hold reads a
+    /// different format. Nil means the buffer cannot be converted and must be dropped.
+    ///
+    /// ### Why the format comes from the buffer (#417)
+    ///
+    /// The tap installs with `format: nil`, so the bus decides what it delivers and nothing
+    /// we read beforehand is authoritative. `startEngine()` still pre-builds a converter from
+    /// the format the node reported, which is the same format in every ordinary start — so
+    /// the ordinary path lands on `.reuse` and allocates nothing.
+    ///
+    /// It also closes a second, quieter failure the issue named: before this, a route change
+    /// mid-recording left the converter reading a format the hardware had stopped producing,
+    /// and it went on converting from it without a word.
+    ///
+    /// ### Why allocating on the audio thread is acceptable here
+    ///
+    /// This runs on a real-time thread, and `AVAudioConverter(from:to:)` allocates. It is
+    /// bounded to one build per distinct format — a start, or a route renegotiation — and
+    /// `AudioConverterCachePolicy` is what bounds it: without the failure memo, a format
+    /// nothing can convert would allocate on every buffer at roughly 100 Hz.
+    ///
+    /// The same callback already encodes JSON at 5 Hz and writes the persistent log at 1 Hz,
+    /// so a build at route-change frequency is strictly cheaper than what runs here anyway.
+    /// The alternative — hop to main and drop buffers until it answers — would lose audio at
+    /// the start of the recording, which is the worst place to lose it.
+    private nonisolated func converterMatching(_ bufferFormat: AVAudioFormat) -> AVAudioConverter? {
+        switch AudioConverterCachePolicy.decide(
+            heldInputFormat: converter?.inputFormat,
+            lastUnconvertibleFormat: lastUnconvertibleInputFormat,
+            bufferFormat: bufferFormat
+        ) {
+        case .reuse:
+            return converter
+
+        case .skipUnconvertibleFormat:
+            return nil
+
+        case .build:
+            let previous = converter?.inputFormat
+            guard let rebuilt = AVAudioConverter(from: bufferFormat, to: targetFormat) else {
+                // This is the case that silently loses the recording: no converter means no
+                // samples accumulate, and the user gets an empty transcription with nothing
+                // to explain it. Logged as a failure for that reason, once per format —
+                // `lastUnconvertibleInputFormat` is what keeps it from repeating at 100 Hz.
+                converter = nil
+                lastUnconvertibleInputFormat = bufferFormat
+                PersistentLog.log(.dictationFailed(
+                    error: "no converter from the bus format sr=\(bufferFormat.sampleRate)"
+                        + " ch=\(bufferFormat.channelCount) to 16kHz mono"
+                ))
+                return nil
+            }
+            converter = rebuilt
+            lastUnconvertibleInputFormat = nil
+
+            // The whole point of #417 is that the format we read and the format the bus
+            // delivers can differ, and we had no way to see it. This line is that evidence.
+            PersistentLog.log(.diagnosticProbe(
+                component: "UnifiedAudioEngine",
+                instanceID: "shared",
+                action: "converterBuiltFromBusFormat",
+                details: "from=\(previous.map { "sr=\($0.sampleRate) ch=\($0.channelCount)" } ?? "none")"
+                    + " to=sr=\(bufferFormat.sampleRate) ch=\(bufferFormat.channelCount)"
+            ))
+            return rebuilt
         }
     }
 

--- a/DictusCore/Sources/DictusCore/AudioConverterCachePolicy.swift
+++ b/DictusCore/Sources/DictusCore/AudioConverterCachePolicy.swift
@@ -1,0 +1,77 @@
+// DictusCore/Sources/DictusCore/AudioConverterCachePolicy.swift
+// What an audio tap should do with the converter it is holding when a buffer arrives.
+import Foundation
+
+/// What a tap callback should do with the sample-rate converter it currently holds.
+public enum AudioConverterCacheDecision: Equatable, Sendable {
+    /// The held converter already reads the format this buffer is in. Convert with it.
+    case reuse
+    /// There is no converter for this format yet. Build one from the buffer's own format.
+    case build
+    /// This exact format already failed to produce a converter. Drop the buffer without
+    /// trying again — see `AudioConverterCachePolicy` for why the memo exists.
+    case skipUnconvertibleFormat
+}
+
+/// Decides whether an audio tap must rebuild its converter for an incoming buffer (issue #417).
+///
+/// ### Why this is in DictusCore and not next to the engine
+///
+/// Same reason as `AudioInputFormatPolicy` and `IdleReleasePolicy`: `UnifiedAudioEngine` is
+/// `@MainActor`, owns a live `AVAudioEngine` and lives in the DictusApp target, so nothing
+/// on its capture path can be exercised from a test. This decision is pure — it compares a
+/// format to two remembered ones — and it is what makes the fix correct, so it is the part
+/// that has to be assertable.
+///
+/// ### The bug this encodes
+///
+/// `startEngine()` used to read the input node's format, then sixty lines later hand that
+/// same format to `installTap`. Measured on device six times (2026-09-02 and 2026-09-03,
+/// iPhone16,2 / iOS 26.6.1): while a native call or Siri holds the session, the input node
+/// renegotiates inside that window and `installTap` raises
+/// `Failed to create tap due to format mismatch, <AVAudioFormat 1 ch, 48000 Hz, Float32>` —
+/// a format that is individually valid, and that every pre-flight guard therefore accepts.
+///
+/// The tap now installs with `format: nil`, so the bus supplies its own format and a mismatch
+/// is impossible by construction. The consequence is that the converter can no longer be built
+/// ahead of time from a format we merely read: the authoritative format is the one on the first
+/// buffer. That also fixes a second, quieter failure — a mid-recording route change, where the
+/// converter used to keep converting from a format the hardware had stopped producing.
+///
+/// ### Why the unconvertible-format memo
+///
+/// The tap callback runs on a real-time audio thread and `.build` allocates. A format that
+/// `AVAudioConverter(from:to:)` refuses would otherwise be retried on every single buffer —
+/// roughly a hundred allocation attempts a second, on that thread, for as long as the route
+/// lasts. Remembering the one format that failed bounds it to a single attempt, while leaving
+/// any *other* format free to be tried: the failure is a property of the format, not of the tap.
+public enum AudioConverterCachePolicy {
+
+    /// - Parameters:
+    ///   - heldInputFormat: `AVAudioConverter.inputFormat` of the converter the tap is
+    ///     holding, or nil if it holds none.
+    ///   - lastUnconvertibleFormat: the last format `AVAudioConverter(from:to:)` refused,
+    ///     or nil if none has been refused since the tap was installed.
+    ///   - bufferFormat: `AVAudioPCMBuffer.format` of the buffer that just arrived.
+    /// - Returns: what to do with the held converter.
+    ///
+    /// Generic over the format type rather than typed to `AVAudioFormat` so the call site
+    /// keeps AVFoundation's own equality — `AVAudioFormat.isEqual` compares the sample rate,
+    /// the channel count, the common format, interleaving *and* the channel layout, and
+    /// re-implementing that here would only test the re-implementation.
+    public static func decide<Format: Equatable>(
+        heldInputFormat: Format?,
+        lastUnconvertibleFormat: Format?,
+        bufferFormat: Format
+    ) -> AudioConverterCacheDecision {
+        // Reuse first: a held converter for this format settles the question, and no
+        // sequence can produce both a held converter and a failure memo for one format.
+        if let heldInputFormat, heldInputFormat == bufferFormat {
+            return .reuse
+        }
+        if let lastUnconvertibleFormat, lastUnconvertibleFormat == bufferFormat {
+            return .skipUnconvertibleFormat
+        }
+        return .build
+    }
+}

--- a/DictusCore/Sources/DictusCore/AudioInputFormatPolicy.swift
+++ b/DictusCore/Sources/DictusCore/AudioInputFormatPolicy.swift
@@ -21,7 +21,8 @@ public enum AudioInputFormatFailure: String, Equatable, Sendable {
 
 /// What a caller should do with the format its audio input node just reported.
 public enum AudioInputFormatDecision: Equatable, Sendable {
-    /// The format is usable. Build the converter and install the tap on it.
+    /// The format is usable. Install the tap on that node — since #417 the tap takes the
+    /// bus's own format rather than this one, which is kept as the converter's first guess.
     case proceed
     /// The format is dead. Throw the whole engine away, build a new one, and read the
     /// format again from the new node. Returned at most once per start attempt — see

--- a/DictusCore/Tests/DictusCoreTests/AudioConverterCachePolicyTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/AudioConverterCachePolicyTests.swift
@@ -1,0 +1,160 @@
+import XCTest
+@testable import DictusCore
+
+/// Coverage for the converter-reuse decision behind the tap format-mismatch fix (issue #417).
+///
+/// These tests exist because the code that consumes the decision cannot be unit-tested: it is
+/// the body of an `AVAudioEngine` tap callback, on a real-time thread, inside a `@MainActor`
+/// class in the DictusApp target. The decision itself is the substance of the fix — the tap
+/// now installs with `format: nil` and learns its input format from the buffers — so it is
+/// the part worth pinning down.
+///
+/// The policy is generic over an `Equatable` format so the engine can pass `AVAudioFormat`
+/// and keep AVFoundation's own equality. These tests stand in a `Format` of their own, which
+/// is the point: what is being asserted is the branching, not `AVAudioFormat.isEqual`.
+final class AudioConverterCachePolicyTests: XCTestCase {
+
+    /// Stands in for `AVAudioFormat`. Named after the two fields that actually differ between
+    /// the routes Dictus sees — 48 kHz mono built-in mic, 16 kHz mono bluetooth HFP.
+    private struct Format: Equatable {
+        let sampleRate: Double
+        let channels: Int
+    }
+
+    private let builtInMic = Format(sampleRate: 48000, channels: 1)
+    private let bluetoothHFP = Format(sampleRate: 16000, channels: 1)
+    private let stereo = Format(sampleRate: 48000, channels: 2)
+
+    // MARK: - reuse
+
+    func testAConverterForThisFormatIsReused() {
+        // The normal case, and the one that has to stay allocation-free: `startEngine`
+        // pre-built a converter from the format the node reported, the bus delivers that
+        // same format, nothing is built on the audio thread.
+        XCTAssertEqual(
+            AudioConverterCachePolicy.decide(
+                heldInputFormat: builtInMic,
+                lastUnconvertibleFormat: nil,
+                bufferFormat: builtInMic
+            ),
+            .reuse
+        )
+    }
+
+    func testAHeldConverterWinsOverAFailureMemoForTheSameFormat() {
+        // Cannot arise from the call site — a format that failed to build leaves no
+        // converter — but the order of the two checks should not depend on that.
+        XCTAssertEqual(
+            AudioConverterCachePolicy.decide(
+                heldInputFormat: builtInMic,
+                lastUnconvertibleFormat: builtInMic,
+                bufferFormat: builtInMic
+            ),
+            .reuse
+        )
+    }
+
+    // MARK: - build
+
+    func testTheFirstBufferBuildsTheConverter() {
+        // `startEngine`'s pre-build is best effort: when it returned nil there is nothing
+        // held, and the first buffer's own format is the authoritative one.
+        XCTAssertEqual(
+            AudioConverterCachePolicy.decide(
+                heldInputFormat: nil,
+                lastUnconvertibleFormat: nil,
+                bufferFormat: builtInMic
+            ),
+            .build
+        )
+    }
+
+    func testAMidRecordingRouteChangeRebuilds() {
+        // The second failure this fix closes: before #417 the converter kept converting
+        // from 48 kHz after the route moved to a 16 kHz bluetooth headset.
+        XCTAssertEqual(
+            AudioConverterCachePolicy.decide(
+                heldInputFormat: builtInMic,
+                lastUnconvertibleFormat: nil,
+                bufferFormat: bluetoothHFP
+            ),
+            .build
+        )
+    }
+
+    func testAChannelCountChangeAloneRebuilds() {
+        // Same sample rate, different channel count — still a different converter.
+        XCTAssertEqual(
+            AudioConverterCachePolicy.decide(
+                heldInputFormat: builtInMic,
+                lastUnconvertibleFormat: nil,
+                bufferFormat: stereo
+            ),
+            .build
+        )
+    }
+
+    func testAFailureMemoDoesNotBlockADifferentFormat() {
+        // The memo is a property of one format, not a latch on the tap: a route that moves
+        // away from the unconvertible format must get its converter built.
+        XCTAssertEqual(
+            AudioConverterCachePolicy.decide(
+                heldInputFormat: nil,
+                lastUnconvertibleFormat: stereo,
+                bufferFormat: builtInMic
+            ),
+            .build
+        )
+    }
+
+    // MARK: - skip
+
+    func testTheFormatThatAlreadyFailedIsNotRetried() {
+        XCTAssertEqual(
+            AudioConverterCachePolicy.decide(
+                heldInputFormat: nil,
+                lastUnconvertibleFormat: stereo,
+                bufferFormat: stereo
+            ),
+            .skipUnconvertibleFormat
+        )
+    }
+
+    func testAnUnconvertibleFormatIsAttemptedExactlyOnce() {
+        // The guarantee the audio thread depends on: buffers arrive at roughly 100 Hz, and
+        // only the first of them may attempt an allocation.
+        var lastUnconvertible: Format?
+        var decisions: [AudioConverterCacheDecision] = []
+        for _ in 0..<10 {
+            let decision = AudioConverterCachePolicy.decide(
+                heldInputFormat: nil,
+                lastUnconvertibleFormat: lastUnconvertible,
+                bufferFormat: stereo
+            )
+            decisions.append(decision)
+            // Stands in for the call site: the build was attempted and refused.
+            if decision == .build { lastUnconvertible = stereo }
+        }
+        XCTAssertEqual(decisions.filter { $0 == .build }.count, 1)
+        XCTAssertEqual(decisions.last, .skipUnconvertibleFormat)
+    }
+
+    // MARK: - a settled route stops deciding anything
+
+    func testASettledRouteReusesForever() {
+        // The mirror of the test above, on the healthy path: once the converter matches the
+        // bus, no later buffer may ask for a build.
+        var held: Format? = builtInMic
+        var decisions: [AudioConverterCacheDecision] = []
+        for _ in 0..<10 {
+            let decision = AudioConverterCachePolicy.decide(
+                heldInputFormat: held,
+                lastUnconvertibleFormat: nil,
+                bufferFormat: builtInMic
+            )
+            decisions.append(decision)
+            if decision == .build { held = builtInMic }
+        }
+        XCTAssertTrue(decisions.allSatisfy { $0 == .reuse })
+    }
+}


### PR DESCRIPTION
## What this was for

A dictation fails outright, and the log says:

```
installTap NSException: Failed to create tap due to format mismatch,
<AVAudioFormat 1 ch, 48000 Hz, Float32>
```

`1 ch, 48000 Hz, Float32` is the built-in microphone's ordinary format, which is why every
pre-flight guard in `startEngine()` accepts it. The Austrian tester who reported it was told
the microphone was unavailable and answered, correctly, that nothing else was holding it.

The 2026-09-06 triage comment settled the open question with six device captures
(iPhone16,2 / iOS 26.6.1 — 2026-09-02 with Siri listening, 2026-09-03 during a native call
on the earpiece): the exception comes from `installTap`, not `engine.start`, and the trigger
is an active audio interruption renegotiating the input node between the format read and the
tap install. So the format we hand to `installTap` is stale by the time it is used.

This PR is scope step 1 and step 3 of that issue. Step 2 — the user-facing message — belongs
to #313 / #418 and is deliberately untouched; it has in fact already landed on develop, so
`installTapFailed` no longer carries the hardcoded French sentence the issue was filed on.

**#483 does not replace this.** CallKit lets the keyboard refuse the mic tap when a *call*
holds the microphone, but Siri produces the same exception and is not a call.

## To test by hand

The device validation cannot be run headless — it needs a real iPhone and Siri.

1. Install this branch on the iPhone and open Dictus once so the engine warms up.
2. Trigger Siri (hold the side button, or "Dis Siri") and leave it listening.
3. While Siri is still listening, tap the mic button in the app.
   **Expect:** dictation starts. No "Dictation could not start" message.
4. Dismiss Siri, dictate a sentence, stop.
   **Expect:** the text is inserted and is not truncated or garbled.
5. Open the debug log and search for `installTap NSException`.
   **Expect:** no occurrence dated from this session.
6. Same run, search for `converterBuiltFromBusFormat`.
   **Expect:** either nothing (the pre-built converter matched, which is the ordinary case)
   or one line naming the two formats. Both are correct — the line is evidence that the
   format we read and the format the bus delivers can differ, which is the thing we
   previously had no way to see.
7. Repeat steps 2-5 with an incoming phone call instead of Siri (answer it, then tap the
   mic once the call is under way).
   **Expect:** the call guard refuses with "The microphone is busy on a call", which is the
   correct refusal — not an `installTap NSException`.
8. Mid-recording route change: start a dictation on the built-in mic, then connect AirPods
   while still speaking, and finish the sentence.
   **Expect:** the audio after the switch is transcribed rather than dropped or garbled.
   This is the second, quieter failure the issue named — before this change the converter
   kept converting from a format the hardware had stopped producing.

## What changed

**`DictusApp/Audio/UnifiedAudioEngine.swift`**

- `installTap(onBus:bufferSize:format:)` gets `nil` instead of the captured `hwFormat`. The
  bus supplies its own format and a mismatch becomes impossible by construction.
- `processBuffer` resolves its converter against `buffer.format` through a new
  `converterMatching(_:)`, rebuilding when the two disagree.
- The converter built in `startEngine()` stays, as a pre-build, and no longer throws when it
  cannot be made. Since the tap takes the bus's format, `hwFormat` is advisory — refusing to
  start on it would refuse a dictation the bus was about to serve correctly. The pre-build is
  what keeps the audio thread allocation-free in the ordinary start, where the node's format
  *is* the bus's format. Its old failure throw becomes a `converterPrebuildFailed` diagnostic
  probe, and the tap logs the case that actually loses the recording.
- `AudioEngineError.installTapFailed` now carries which of the two Objective-C calls raised
  the exception (`ObjCAudioStartCall`). Both sites mapped to one payload and only the
  persistent log told them apart — that distinction is what made this issue diagnosable.
  Diagnostic only: `errorDescription` is byte-for-byte unchanged.

**`DictusCore/Sources/DictusCore/AudioConverterCachePolicy.swift`** (new, with tests)

The reuse/build/skip decision, extracted the way `AudioInputFormatPolicy` was and for the
same reason: the code that consumes it is a real-time tap callback inside a `@MainActor`
class in the DictusApp target, and nothing there can be exercised from a test. Generic over
an `Equatable` format so the call site passes `AVAudioFormat` and keeps AVFoundation's own
equality — `isEqual` compares the channel layout too, and re-implementing that here would
only test the re-implementation.

### Allocation on the audio thread

Building a converter in the tap callback is the crux of this change, so, explicitly:

- **Ordinary case: zero allocations.** The pre-build from `hwFormat` matches what the bus
  delivers, the policy answers `.reuse`, nothing is built.
- **Exception case: one build per distinct format** — a start whose pre-build was wrong, or
  a route renegotiation. Not per buffer.
- **The third decision case exists for exactly this.** Without the `skipUnconvertibleFormat`
  memo, a format `AVAudioConverter(from:to:)` refuses would be retried — allocating — on
  every buffer, at roughly 100 Hz, for as long as that route lasts.
- **Precedent in the same callback:** it already runs `JSONEncoder().encode` at 5 Hz and
  `PersistentLog.log` at 1 Hz. A build at route-change frequency is cheaper than what runs
  there anyway.
- **The alternative is worse.** Hopping to main and dropping buffers until it answers would
  lose audio at the start of the recording, which is the worst place to lose it.

Ownership: `converter` and the new `lastUnconvertibleInputFormat` are written by the audio
thread, and by main only to clear them — in the two places (`replaceEngine`,
`releaseWarmState`) that bump `engineGeneration` and remove the tap first, so an in-flight
callback bails out before it can observe the nil. That is the shape the file already
documented for this field.

## Acceptance criteria

| Criterion | Status | Evidence |
| --- | --- | --- |
| Scope 1a — `installTap` no longer receives a captured format | Done | `UnifiedAudioEngine.swift:1051` is the only `installTap` in the repo and now passes `format: nil` |
| Scope 1b — converter built from the first buffer's format, rebuilt on mismatch | Done | `processBuffer` → `converterMatching(buffer.format)` (`:1309`, `:1435`); 9 tests in `AudioConverterCachePolicyTests` |
| Scope 3 — the two catch sites stay distinguishable | Done | `installTapFailed(call: .installTap, …)` `:1060` / `(call: .engineStart, …)` `:1078`; `diagnosticDescription` prints the call's own name |
| Scope 2 — user-facing copy | Out of scope, untouched | `errorDescription` for `.installTapFailed` is unchanged in the diff (#313 / #418) |
| Build (three targets, one scheme) | Green | `xcodebuild build -scheme DictusApp -destination 'generic/platform=iOS Simulator'` → `** BUILD SUCCEEDED **` |
| Tests | Green | `cd DictusCore && swift test` → `Executed 1660 tests, with 1 test skipped and 0 failures` |
| Lint | Green | `swiftlint lint --strict` → `Found 0 violations, 0 serious in 252 files` |
| Device: Siri + mic tap, no `installTap NSException` | **Not verified** | Needs a real iPhone and Siri — no headless form. See "To test by hand". |

## One thing worth a second opinion

The class body of `UnifiedAudioEngine` was at **648 of the 650-line `type_body_length`
budget** before this change, so any fix landing in it trips the rule. I scoped a
`// swiftlint:disable:next type_body_length` to that one class with the reason written above
it, rather than raise the global threshold — `.swiftlint.yml`'s own rationale says the number
exists "to catch a NEW type or function ballooning" and explicitly not to police the large
classes that already exist, and the same rationale calls restructuring these files the
highest-risk change available. Say the word if you would rather have the number raised or the
audio-thread half carved into an extension.

## Coordination with #513

PR #513 (`fix/483-callkit-call-detection`) edits the same file. It is not merged and was not
pulled in. `git merge-tree --write-tree HEAD origin/fix/483-callkit-call-detection` exits 0
with no conflict: its hunks are the `phoneCallActive` doc block and
`refuseIfACallHoldsTheMicrophone`, mine are `installTapFailed`, the converter properties,
the tap install and `processBuffer`. Whichever lands second merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTeVma6QXvLHg579PZVN5B
