### PR TITLE
Recover the last transcription from the expanded Dynamic Island (refs #531)

### DIFF
--- a/Dictus.xcodeproj/project.pbxproj
+++ b/Dictus.xcodeproj/project.pbxproj
@@ -115,12 +115,14 @@
 		AA00P205 /* PolishDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10P205 /* PolishDebugView.swift */; };
 		AA00P207 /* PolishDebugExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10P207 /* PolishDebugExporter.swift */; };
 		AA0000F6 /* StopStandbyIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB100005 /* StopStandbyIntent.swift */; };
+		AA000531 /* CopyLastTranscriptIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB100006 /* CopyLastTranscriptIntent.swift */; };
 		AA0000G0 /* KeyTapSignposter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1000G0 /* KeyTapSignposter.swift */; };
 		AA000P10 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = AA100P10 /* PrivacyInfo.xcprivacy */; };
 		AA000P20 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = AA100P20 /* PrivacyInfo.xcprivacy */; };
 		BB000001 /* DictusWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB100001 /* DictusWidgetBundle.swift */; };
 		BB000002 /* DictusLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB100002 /* DictusLiveActivity.swift */; };
 		BB000003 /* StopStandbyIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB100005 /* StopStandbyIntent.swift */; };
+		BB000004 /* CopyLastTranscriptIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB100006 /* CopyLastTranscriptIntent.swift */; };
 		BB000010 /* DictusCore in Frameworks */ = {isa = PBXBuildFile; productRef = BB900010 /* DictusCore */; };
 		BB000020 /* DictusWidgets.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = BB200001 /* DictusWidgets.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		EE000001 /* dictus_trie.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EE100001 /* dictus_trie.cpp */; };
@@ -311,6 +313,7 @@
 		BB100003 /* DictusWidgets.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DictusWidgets.entitlements; sourceTree = "<group>"; };
 		BB100004 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BB100005 /* StopStandbyIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopStandbyIntent.swift; sourceTree = "<group>"; };
+		BB100006 /* CopyLastTranscriptIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyLastTranscriptIntent.swift; sourceTree = "<group>"; };
 		BB200001 /* DictusWidgets.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = DictusWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC100030 /* KeyboardMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardMetrics.swift; sourceTree = "<group>"; };
 		CC100050 /* KeySoundPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeySoundPolicy.swift; sourceTree = "<group>"; };
@@ -667,6 +670,7 @@
 				BB100001 /* DictusWidgetBundle.swift */,
 				BB100002 /* DictusLiveActivity.swift */,
 				BB100005 /* StopStandbyIntent.swift */,
+				BB100006 /* CopyLastTranscriptIntent.swift */,
 				BB100003 /* DictusWidgets.entitlements */,
 				BB100004 /* Info.plist */,
 			);
@@ -1052,6 +1056,7 @@
 				AA0000F2 /* SoundFeedbackService.swift in Sources */,
 				AA0000F3 /* SoundSettingsView.swift in Sources */,
 				AA0000F6 /* StopStandbyIntent.swift in Sources */,
+				AA000531 /* CopyLastTranscriptIntent.swift in Sources */,
 				AA0000L0 /* ModelInfo+Localized.swift in Sources */,
 				SS000001 /* SubscriptionManager.swift in Sources */,
 				SS000002 /* PaywallView.swift in Sources */,
@@ -1132,6 +1137,7 @@
 				BB000001 /* DictusWidgetBundle.swift in Sources */,
 				BB000002 /* DictusLiveActivity.swift in Sources */,
 				BB000003 /* StopStandbyIntent.swift in Sources */,
+				BB000004 /* CopyLastTranscriptIntent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DictusApp/LiveActivityManager.swift
+++ b/DictusApp/LiveActivityManager.swift
@@ -398,7 +398,7 @@ class LiveActivityManager {
         }
 
         let attributes = DictusLiveActivityAttributes()
-        let state = DictusLiveActivityAttributes.ContentState(phase: .standby)
+        let state = standbyContent()
         // staleDate: if app is killed without willTerminate firing, iOS auto-removes
         // the DI after this interval. 30s is short enough to clear ghosts quickly (#84).
         let staleDate = Date().addingTimeInterval(staleInterval)
@@ -628,6 +628,13 @@ class LiveActivityManager {
     /// After showing the result briefly, we go back to the "On" standby state
     /// so they can start another recording from the Dynamic Island.
     func endWithResult(preview: String?) {
+        // Written before every guard below, deliberately. The store is what the expanded
+        // island offers back (#531), and it must not depend on the Live Activity being
+        // enabled, on the pill still existing, or on the state machine accepting the
+        // transition -- the dictation happened either way, and #42's desync is exactly the
+        // kind of moment where the user needs the text back.
+        LastTranscriptRecall.record(preview)
+
         guard isEnabled else { return }
 
         // WHY: State machine guard prevents DI desync from concurrent transitions (#42)
@@ -644,7 +651,11 @@ class LiveActivityManager {
         PersistentLog.log(.liveActivityTransition(from: currentPhase.rawValue, to: "ready"))
         currentPhase = .ready  // Update BEFORE async work to prevent races (#49)
         Task {
-            let truncatedPreview = preview.map { String($0.prefix(100)) }
+            // Through the shared derivation since #531, so the transcript the user reads
+            // during this one second and the one the standby row keeps afterwards are cut
+            // the same way -- there is one definition of "the preview" and it lives beside
+            // the full text it is derived from.
+            let truncatedPreview = preview.map { LastTranscriptRecall.preview(of: $0) }
             let state = DictusLiveActivityAttributes.ContentState(
                 phase: .ready,
                 transcriptionPreview: truncatedPreview
@@ -884,6 +895,25 @@ class LiveActivityManager {
 
     // MARK: - Utilities
 
+    /// The standby content, carrying the last dictation's preview (#531).
+    ///
+    /// WHY one helper rather than a preview argument on three call sites: standby is built in
+    /// three places that are visible to the user -- the initial `Activity.request`, the
+    /// auto-return after a result, and the recovery from an abandoned stage -- and a fourth
+    /// that forgot the transcript would show an empty bottom region for a reason the user
+    /// cannot see. Decision 2 is that the transcript stays until the next dictation replaces
+    /// it, and reading it from the store on every standby build is what makes that true
+    /// without any of these sites having to remember.
+    ///
+    /// The `.standby` states handed to `activity.end(dismissalPolicy: .immediate)` deliberately
+    /// do NOT come through here: that content is never drawn.
+    private func standbyContent() -> DictusLiveActivityAttributes.ContentState {
+        DictusLiveActivityAttributes.ContentState(
+            phase: .standby,
+            lastTranscriptPreview: LastTranscriptRecall.preview()
+        )
+    }
+
     /// Return to standby state. Called after result/failure auto-dismiss,
     /// and also when a recording is cancelled from the keyboard.
     func returnToStandby() async {
@@ -899,7 +929,7 @@ class LiveActivityManager {
         PersistentLog.log(.liveActivityTransition(from: currentPhase.rawValue, to: "standby"))
         currentPhase = .standby  // Update BEFORE async work to prevent races (#49)
         syncStateMachine(to: .standby)
-        let state = DictusLiveActivityAttributes.ContentState(phase: .standby)
+        let state = standbyContent()
         // Refresh staleDate on each return to standby (#84: 30s clears ghosts after force-quit)
         let staleDate = Date().addingTimeInterval(staleInterval)
         await activity.update(.init(state: state, staleDate: staleDate))
@@ -947,7 +977,7 @@ class LiveActivityManager {
         PersistentLog.log(.liveActivityTransition(from: abandoned.rawValue, to: "standby-abandoned"))
         currentPhase = .standby  // Update BEFORE async work to prevent races (#49)
         Task {
-            let state = DictusLiveActivityAttributes.ContentState(phase: .standby)
+            let state = self.standbyContent()
             await activity.update(.init(state: state, staleDate: Date().addingTimeInterval(self.staleInterval)))
             DictusLogger.app.info("Live Activity -> standby (abandoned \(abandoned.rawValue, privacy: .public))")
         }

--- a/DictusApp/LiveActivityManager.swift
+++ b/DictusApp/LiveActivityManager.swift
@@ -377,6 +377,23 @@ class LiveActivityManager {
             syncStateMachine(to: currentPhase)
             DictusLogger.app.info("Recovered orphaned Live Activity: \(existing.id, privacy: .public)")
             PersistentLog.log(.liveActivityStarted(id: "orphan-recovered:\(existing.id)"))
+            // An adopted pill keeps the content it was left with, which for a standby one
+            // means the bottom region of whatever process died holding it -- so the last
+            // transcript would be missing from a pill that merely outlived the app, and
+            // present on one that did not (#531). That is exactly the "sometimes there,
+            // sometimes not, for no reason the user can see" state decision 2 rules out, so
+            // the adopted content is brought up to date here.
+            //
+            // WHY only `.standby`: any other phase is a dictation in flight, and stamping
+            // standby over it is #42.
+            if currentPhase == .standby {
+                let refreshed = standbyContent()
+                Task {
+                    await existing.update(
+                        .init(state: refreshed, staleDate: Date().addingTimeInterval(self.staleInterval))
+                    )
+                }
+            }
             // End any extras beyond the first (shouldn't happen, but defense in depth)
             for activity in systemActivities.dropFirst() {
                 Task {

--- a/DictusCore/Sources/DictusCore/DictusLiveActivityAttributes.swift
+++ b/DictusCore/Sources/DictusCore/DictusLiveActivityAttributes.swift
@@ -60,16 +60,49 @@ public struct DictusLiveActivityAttributes: ActivityAttributes {
         /// nil except in .ready phase.
         public var transcriptionPreview: String?
 
+        /// Preview of the last dictation, carried through standby so the expanded Dynamic
+        /// Island can offer it back (#531). nil until a first dictation has happened, which
+        /// is what keeps the bottom region empty on a fresh install.
+        ///
+        /// WHY a second preview field rather than reusing `transcriptionPreview`: that one is
+        /// documented as nil outside `.ready` and both the expanded and the lock screen views
+        /// branch on that. Widening its meaning would put the transcript on the lock screen
+        /// banner, which decision 4 exists to prevent.
+        ///
+        /// The FULL text lives in the App Group under `LastTranscriptRecall` — this is a
+        /// display value and is never what the copy button hands over.
+        public var lastTranscriptPreview: String?
+
+        /// Whether the copy button has just been tapped, which flips it to a checkmark (#531
+        /// decision 5: a Live Activity cannot run a confirmation animation, so the
+        /// confirmation is a state).
+        ///
+        /// WHY Optional for a Bool: ActivityKit persists this state and decodes it with
+        /// whatever binary is running when the activity next renders, so an activity started
+        /// before this field existed is decoded by code that has it. Swift's synthesised
+        /// `init(from:)` calls `decodeIfPresent` for an Optional and `decode` for a
+        /// non-Optional -- a plain `Bool` would throw on that missing key and the pill would
+        /// stop rendering mid-flight. Read through `hasCopiedLastTranscript`, where nil and
+        /// false are the same state.
+        public var lastTranscriptCopied: Bool?
+
+        /// The copy button's state, with nil folded into "not copied".
+        public var hasCopiedLastTranscript: Bool { lastTranscriptCopied ?? false }
+
         public init(
             phase: Phase,
             recordingStartDate: Date? = nil,
             waveformLevels: [Float] = [],
-            transcriptionPreview: String? = nil
+            transcriptionPreview: String? = nil,
+            lastTranscriptPreview: String? = nil,
+            lastTranscriptCopied: Bool? = nil
         ) {
             self.phase = phase
             self.recordingStartDate = recordingStartDate
             self.waveformLevels = waveformLevels
             self.transcriptionPreview = transcriptionPreview
+            self.lastTranscriptPreview = lastTranscriptPreview
+            self.lastTranscriptCopied = lastTranscriptCopied
         }
     }
 

--- a/DictusCore/Sources/DictusCore/LastTranscriptRecall.swift
+++ b/DictusCore/Sources/DictusCore/LastTranscriptRecall.swift
@@ -1,0 +1,90 @@
+// DictusCore/Sources/DictusCore/LastTranscriptRecall.swift
+// The last dictation, kept reachable from the Dynamic Island (#531).
+
+import Foundation
+
+/// The text of the dictation that just happened, held so the user can get it back.
+///
+/// WHY THIS EXISTS: the transcript of a dictation whose insertion went wrong is not lost,
+/// but it is out of reach. The Dynamic Island shows it for one second in `.ready` and then
+/// returns to standby with an empty state, and `HistoryView` — the other place it survives —
+/// is Pro-gated and costs a navigation. #531 puts it under the long press instead, which
+/// needs somewhere durable to read it from.
+///
+/// WHY NOT ONE OF THE EXISTING KEYS: `SharedKeys.lastTranscription` and
+/// `lastPolishedTranscription` are hand-off channels. They exist to be *claimed* — the
+/// keyboard reads them and DictusApp clears them as it hands the next dictation over — so
+/// their absence is a normal, frequent state and says nothing about whether a dictation
+/// happened. This one is written and never claimed: it is replaced by the next dictation and
+/// by nothing else, which is decision 2 of #531 ("no expiry window") expressed in storage.
+///
+/// WHY NOT `TranscriptionHistoryStore`: that store is Pro-gated and does not record a
+/// non-subscriber's dictation at all. The escape hatch has to work for everyone.
+///
+/// WHY THE FULL TEXT IS STORED AND THE PREVIEW DERIVED: the Live Activity carries a ~100
+/// character preview in its `ContentState`, and that preview must never be what the user
+/// gets when they tap Copy. One key holding the whole text, and a pure function deriving
+/// what is shown, is what makes those two impossible to confuse.
+public enum LastTranscriptRecall {
+
+    /// How much of the transcript the Dynamic Island's standby row carries.
+    ///
+    /// The same number the `.ready` preview has always used. It is a display budget, not a
+    /// storage one — ActivityKit caps a `ContentState` payload at 4 KB and two lines of an
+    /// expanded island cannot show more than this anyway.
+    public static let previewLimit = 100
+
+    /// Remember this dictation's text.
+    ///
+    /// WHY blank input is ignored rather than clearing: a dictation that produced nothing —
+    /// an armed mode that failed, a watchdog that cancelled a generation — has not *replaced*
+    /// the previous one, and decision 2 says the transcript stays available until the next
+    /// dictation replaces it. Erasing it here would make the island's bottom region blink out
+    /// for a reason the user cannot see, which is the state the decision exists to prevent.
+    public static func record(_ text: String?, in defaults: UserDefaults = AppGroup.defaults) {
+        guard let text, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        defaults.set(text, forKey: SharedKeys.lastTranscriptRecall)
+        defaults.synchronize()
+    }
+
+    /// The whole text, which is what the copy button puts on the pasteboard.
+    public static func fullText(from defaults: UserDefaults = AppGroup.defaults) -> String? {
+        defaults.string(forKey: SharedKeys.lastTranscriptRecall)
+    }
+
+    /// What the Dynamic Island's standby row shows, or nil when no dictation has happened yet.
+    ///
+    /// Nil is the marker for "empty bottom region", which is the screen as it is today.
+    public static func preview(from defaults: UserDefaults = AppGroup.defaults) -> String? {
+        fullText(from: defaults).map(preview(of:))
+    }
+
+    /// Reduce a transcript to the one or two lines an expanded island can hold.
+    ///
+    /// WHY newlines collapse into spaces: since #141 a polished transcript can carry paragraph
+    /// breaks, and the row is capped at two lines. A leading break would spend one of them on
+    /// nothing.
+    ///
+    /// WHY an ellipsis when it is cut: the copy button hands over the full text, so the row has
+    /// to say that it is showing less than there is. SwiftUI's own truncation only appears when
+    /// the text overflows the line — a transcript cut at exactly the limit would otherwise read
+    /// as complete.
+    public static func preview(of text: String) -> String {
+        let flattened = text
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespaces)
+        guard flattened.count > previewLimit else { return flattened }
+        return String(flattened.prefix(previewLimit)) + "…"
+    }
+
+    /// Forget it. Nothing in the product calls this — the next dictation overwrites the key —
+    /// but the tests need a defined empty state, and so does anyone reasoning about the
+    /// App Group's contents.
+    public static func clear(in defaults: UserDefaults = AppGroup.defaults) {
+        defaults.removeObject(forKey: SharedKeys.lastTranscriptRecall)
+        defaults.synchronize()
+    }
+}

--- a/DictusCore/Sources/DictusCore/SharedKeys.swift
+++ b/DictusCore/Sources/DictusCore/SharedKeys.swift
@@ -8,6 +8,15 @@ public enum SharedKeys {
     public static let lastTranscription = "dictus.lastTranscription"
     public static let lastTranscriptionTimestamp = "dictus.lastTranscriptionTimestamp"
     public static let lastError = "dictus.lastError"
+    /// String: the full text of the last dictation, kept so the user can get it back from
+    /// the expanded Dynamic Island (#531).
+    ///
+    /// **Not a hand-off, which is what separates it from `lastTranscription` above.** That key
+    /// is claimed by the keyboard and cleared by DictusApp on the next hand-off, so its absence
+    /// is an ordinary state. This one is only ever replaced by the next dictation — decision 2
+    /// of #531, "no expiry window", is exactly that sentence. Read and written only through
+    /// `LastTranscriptRecall`, which is where the rule about a blank dictation lives.
+    public static let lastTranscriptRecall = "dictus.lastTranscriptRecall"
 
     // Model management keys (added for Plan 2.3 transcription pipeline)
     public static let activeModel = "dictus.activeModel"

--- a/DictusCore/Tests/DictusCoreTests/LastTranscriptRecallTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/LastTranscriptRecallTests.swift
@@ -1,0 +1,100 @@
+// DictusCore/Tests/DictusCoreTests/LastTranscriptRecallTests.swift
+// Unit tests for the #531 last-transcript store and its preview derivation.
+
+import XCTest
+@testable import DictusCore
+
+final class LastTranscriptRecallTests: XCTestCase {
+
+    /// A private suite, so these never touch the real App Group.
+    private var defaults: UserDefaults!
+    private let suiteName = "dictus.tests.lastTranscriptRecall"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults().removePersistentDomain(forName: suiteName)
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        UserDefaults().removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    // MARK: - Recording
+
+    func testNothingRecordedYieldsNoPreview() {
+        XCTAssertNil(LastTranscriptRecall.fullText(from: defaults))
+        XCTAssertNil(LastTranscriptRecall.preview(from: defaults))
+    }
+
+    func testRecordKeepsTheWholeText() {
+        let long = String(repeating: "a", count: 500)
+        LastTranscriptRecall.record(long, in: defaults)
+        XCTAssertEqual(LastTranscriptRecall.fullText(from: defaults), long)
+    }
+
+    func testTheNextDictationReplacesThePrevious() {
+        LastTranscriptRecall.record("first", in: defaults)
+        LastTranscriptRecall.record("second", in: defaults)
+        XCTAssertEqual(LastTranscriptRecall.fullText(from: defaults), "second")
+    }
+
+    /// Decision 2: only the next dictation replaces it. A dictation that produced nothing
+    /// has not replaced anything, and must not blank the island's bottom region.
+    func testBlankInputLeavesThePreviousTranscriptInPlace() {
+        LastTranscriptRecall.record("kept", in: defaults)
+        LastTranscriptRecall.record(nil, in: defaults)
+        LastTranscriptRecall.record("", in: defaults)
+        LastTranscriptRecall.record("   \n  ", in: defaults)
+        XCTAssertEqual(LastTranscriptRecall.fullText(from: defaults), "kept")
+    }
+
+    func testClearRemovesIt() {
+        LastTranscriptRecall.record("gone", in: defaults)
+        LastTranscriptRecall.clear(in: defaults)
+        XCTAssertNil(LastTranscriptRecall.fullText(from: defaults))
+    }
+
+    // MARK: - Preview derivation
+
+    func testShortTextIsItsOwnPreview() {
+        XCTAssertEqual(LastTranscriptRecall.preview(of: "Alors ouais."), "Alors ouais.")
+    }
+
+    func testLongTextIsCutAtTheLimitAndMarked() {
+        let long = String(repeating: "x", count: 250)
+        let preview = LastTranscriptRecall.preview(of: long)
+        XCTAssertEqual(preview.count, LastTranscriptRecall.previewLimit + 1)
+        XCTAssertTrue(preview.hasSuffix("…"))
+        XCTAssertEqual(preview.dropLast(), String(long.prefix(LastTranscriptRecall.previewLimit))[...])
+    }
+
+    func testTextExactlyAtTheLimitIsNotMarked() {
+        let exact = String(repeating: "x", count: LastTranscriptRecall.previewLimit)
+        XCTAssertEqual(LastTranscriptRecall.preview(of: exact), exact)
+    }
+
+    func testParagraphBreaksCollapseIntoSpaces() {
+        XCTAssertEqual(
+            LastTranscriptRecall.preview(of: "Première ligne.\n\nSeconde ligne."),
+            "Première ligne. Seconde ligne."
+        )
+    }
+
+    func testLeadingAndTrailingWhitespaceIsDropped() {
+        XCTAssertEqual(LastTranscriptRecall.preview(of: "\n  Bonjour  \n"), "Bonjour")
+    }
+
+    /// The preview a stored transcript produces is the same one the pure function gives,
+    /// and it is never the text the copy button hands over.
+    func testStoredPreviewIsShorterThanTheStoredText() {
+        let long = String(repeating: "mot ", count: 100)
+        LastTranscriptRecall.record(long, in: defaults)
+        let preview = LastTranscriptRecall.preview(from: defaults)
+        XCTAssertEqual(preview, LastTranscriptRecall.preview(of: long))
+        XCTAssertEqual(LastTranscriptRecall.fullText(from: defaults), long)
+        XCTAssertNotEqual(preview, LastTranscriptRecall.fullText(from: defaults))
+    }
+}

--- a/DictusWidgets/CopyLastTranscriptIntent.swift
+++ b/DictusWidgets/CopyLastTranscriptIntent.swift
@@ -1,0 +1,80 @@
+// DictusWidgets/CopyLastTranscriptIntent.swift
+// LiveActivityIntent that puts the last transcription on the clipboard (#531).
+//
+// WHY LiveActivityIntent (not AppIntent):
+// Button(intent:) inside a Live Activity requires a LiveActivityIntent. A regular
+// AppIntent opens the app, which is the navigation this feature exists to avoid.
+//
+// WHY IN BOTH DictusApp AND DictusWidgets TARGETS:
+// LiveActivityIntent.perform() executes in the HOST APP process, not the widget
+// extension. A type compiled only into DictusWidgets cannot be found at runtime and
+// the button does nothing, silently -- there is no build error and no log line. This
+// file therefore carries membership in both targets, exactly like StopStandbyIntent.swift.
+// If you add another intent, check its membership before believing a green build.
+//
+// Measured before any of this was written (probe branch, iPhone 17 Pro simulator, iOS 26.5):
+// a LiveActivityIntent's UIPasteboard write lands while DictusApp is backgrounded.
+import AppIntents
+import ActivityKit
+import Foundation
+import UIKit
+import DictusCore
+
+struct CopyLastTranscriptIntent: LiveActivityIntent {
+    static var title: LocalizedStringResource = "Copy last transcription"
+    static var description = IntentDescription("Copy the last Dictus transcription to the clipboard")
+
+    func perform() async throws -> some IntentResult {
+        // The FULL text, never the preview the island renders. The whole point of the
+        // button is that the user gets the dictation back, not the first hundred
+        // characters of it.
+        guard let text = LastTranscriptRecall.fullText(), !text.isEmpty else {
+            // Nothing has been dictated yet, so the button is not on screen -- unless the
+            // pill outlived the store. Writing an empty string here would replace whatever
+            // the user had on their clipboard with nothing, which is worse than a no-op.
+            DictusLogger.app.info("Copy last transcript: nothing stored, pasteboard untouched")
+            return .result()
+        }
+
+        await MainActor.run {
+            UIPasteboard.general.string = text
+        }
+        DictusLogger.app.info("Last transcript copied from the Dynamic Island (\(text.count, privacy: .public) chars)")
+
+        // Confirmation is a state, not an animation: a Live Activity re-renders from its
+        // ContentState and cannot run one (#531 decision 5). Flip the button to a checkmark,
+        // hold it long enough to be read, then flip it back.
+        //
+        // WHY the wait is awaited here rather than left to a detached task: awaiting inside
+        // perform() is what keeps this process alive to run the second half. If iOS suspends
+        // it anyway, the checkmark simply survives until the next standby rebuild -- the
+        // failure is cosmetic and self-healing.
+        await setCopiedFlag(true)
+        try? await Task.sleep(nanoseconds: 2_000_000_000) // 2s
+        await setCopiedFlag(false)
+
+        return .result()
+    }
+
+    /// Flip the copy button's state on every standby pill.
+    ///
+    /// WHY it goes through ActivityKit directly instead of LiveActivityManager: this file is
+    /// compiled into DictusWidgets too, and the manager only exists in DictusApp. The same
+    /// reason StopStandbyIntent ends its activities here rather than calling
+    /// `stopStandbyActivity()`.
+    ///
+    /// WHY only `.standby`: any other phase means a dictation started while the checkmark was
+    /// up, and pushing a stale ContentState over it would put the Island back on a screen the
+    /// dictation had already left (#42).
+    private func setCopiedFlag(_ copied: Bool) async {
+        for activity in Activity<DictusLiveActivityAttributes>.activities
+        where activity.content.state.phase == .standby {
+            var state = activity.content.state
+            state.lastTranscriptCopied = copied
+            // The staleDate is carried over rather than refreshed: standby sits stale by
+            // design (nothing updates it and staleInterval is 30s), and extending it from
+            // here would hide a genuinely dead pill from the manager's own liveness checks.
+            await activity.update(.init(state: state, staleDate: activity.content.staleDate))
+        }
+    }
+}

--- a/DictusWidgets/DictusLiveActivity.swift
+++ b/DictusWidgets/DictusLiveActivity.swift
@@ -255,6 +255,13 @@ struct DictusLiveActivity: Widget {
         switch context.state.phase {
         case .recording:
             EmptyView()
+        case .standby:
+            // The dictation that just happened, offered back (#531). Nil until a first one
+            // has happened, and that nil is the screen exactly as it was before: an empty
+            // bottom region with power and mic untouched above it.
+            if let preview = context.state.lastTranscriptPreview {
+                lastTranscriptRow(preview: preview, copied: context.state.hasCopiedLastTranscript)
+            }
         case .ready:
             if let preview = context.state.transcriptionPreview {
                 Text(preview)
@@ -266,6 +273,38 @@ struct DictusLiveActivity: Widget {
         default:
             EmptyView()
         }
+    }
+
+    /// The standby row: the last transcript, and one tap to get all of it (#531).
+    ///
+    /// WHY the button carries an icon and no label: DictusWidgets has no string catalogue --
+    /// every string in this file is hardcoded English -- so a "Copy" label would be the one
+    /// new string in the project that no French user can read. The two buttons it sits under
+    /// are icons for the same reason, and a glyph needs no translation.
+    ///
+    /// WHY the confirmation is a swapped glyph: a Live Activity re-renders from its
+    /// ContentState and runs no animation of its own, so the confirmation has to be a state
+    /// the intent writes back (#531 decision 5).
+    private func lastTranscriptRow(preview: String, copied: Bool) -> some View {
+        HStack(spacing: 10) {
+            Text(preview)
+                .font(.system(size: 13))
+                .foregroundColor(.white.opacity(0.8))
+                .lineLimit(2)
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button(intent: CopyLastTranscriptIntent()) {
+                Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(copied ? Color(hex: 0x22C55E) : .white)
+                    .frame(width: 32, height: 32)
+                    .background(copied ? Color.white.opacity(0.15) : Color(hex: 0x3D7EFF))
+                    .clipShape(Circle())
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 8)
     }
 
     // MARK: - Lock Screen Banner
@@ -289,6 +328,11 @@ struct DictusLiveActivity: Widget {
 
                 switch context.state.phase {
                 case .standby:
+                    // Deliberately still just "On" (#531 decision 4). The state now carries
+                    // the last transcript, and this banner is the one surface that must not
+                    // render it: a lock screen banner cannot be expanded, so there is no
+                    // gesture to reveal it behind -- it would simply be the user's last
+                    // dictation, legible on a locked phone.
                     Text("On")
                         .font(.system(size: 13))
                         .foregroundColor(.white.opacity(0.6))


### PR DESCRIPTION
refs #531

## What this was for

When an insertion goes wrong — the keyboard drops the text, the wrong app is focused, the field
rejects it — the transcript is not lost, but it is out of reach. The Dynamic Island shows it for
exactly one second in `.ready` and then returns to standby with an empty state; History covers the
archive case and is Pro-gated behind a navigation. This is the opposite: a zero-navigation escape
hatch for the dictation that just happened. Long press the island, read the transcript, tap Copy,
get the **full** text back.

## To test by hand

The simulator cannot produce speech, so every criterion that starts with a real dictation is here.
Install the branch on the phone, and make sure Dictus has been in the background at least once so
the standby pill exists.

1. **Before any dictation, on a fresh install** — long press the Dynamic Island. Expect: Dictus /
   On, the power and mic buttons on the right, and **nothing** underneath them. (Covered on the
   simulator, listed here because it is one long press away.)
2. **Dictate normally, let the text land in a field**, background the app, long press the island.
   Expect: the first ~100 characters of the dictation on one or two lines, with a blue copy button
   at the right of the row. A dictation longer than that ends with `…`.
3. **Tap the copy button, then paste into Notes.** Expect: the **whole** dictation, not the
   truncated preview. This is the criterion the whole feature turns on.
4. **Watch the button as you tap it.** Expect: it swaps to a green checkmark for about two seconds
   and goes back to the copy glyph. *Not verified anywhere* — the pasteboard write is measured,
   the glyph swap was never caught on camera on the simulator. If it never flips, say so: the
   copy still works and the fix is a number.
5. **Lock the phone.** Expect: the banner reads `Dictus / On` with power and mic, and **no
   transcript**. (Verified on the simulator, but this is the privacy one — worth one look on the
   real device.)
6. **Dictate a second time**, then long press again. Expect: the new dictation, not the old one.
7. **Dictate something that produces nothing** (arm a Smart Mode that fails, or cancel during
   polish), then long press. Expect: the **previous** transcript is still there. A dictation that
   produced nothing has not replaced anything.
8. **Let the phone sit for several minutes with Dictus suspended**, then long press. Expect: the
   transcript is still there. The probe only backgrounded the app for seconds; a simulator does not
   reclaim processes the way a device does.
9. **Kill Dictus from the app switcher.** Expect: the island disappears entirely — no pill, no long
   press, no button. That is the feature's boundary, not a bug.

## What changed

| | |
|---|---|
| `DictusCore/Sources/DictusCore/LastTranscriptRecall.swift` | New. The durable store: full text in, preview derived. |
| `DictusCore/Sources/DictusCore/SharedKeys.swift` | `lastTranscriptRecall`, documented as *not* a hand-off. |
| `DictusCore/Sources/DictusCore/DictusLiveActivityAttributes.swift` | `lastTranscriptPreview` and `lastTranscriptCopied` on `ContentState`. |
| `DictusApp/LiveActivityManager.swift` | Records on `endWithResult`; one `standbyContent()` feeds every visible standby. |
| `DictusWidgets/CopyLastTranscriptIntent.swift` | New. The `LiveActivityIntent`, in **both** targets. |
| `DictusWidgets/DictusLiveActivity.swift` | The row in `expandedBottom` for `.standby`. |
| `Dictus.xcodeproj/project.pbxproj` | Dual target membership for the new intent. |
| `DictusCore/Tests/DictusCoreTests/LastTranscriptRecallTests.swift` | 11 tests on the store and the preview. |

Three decisions worth reading before the diff:

**The store is not one of the existing keys.** `lastTranscription` and `lastPolishedTranscription`
are hand-off channels — claimed by the keyboard, cleared by DictusApp on the next hand-off — so
their absence is an ordinary state and says nothing about whether a dictation happened. The new key
is written and claimed by nobody: replaced by the next dictation and by nothing else, which is
decision 2 in storage form. It is also independent of `TranscriptionHistoryStore`, which does not
record a non-subscriber's dictation at all.

**Both new `ContentState` fields are Optional, the `Bool` included.** ActivityKit persists this
state and decodes it with whatever binary renders the activity next, so an activity started before
an app update is decoded by code that has the fields. Swift's synthesised decoder calls
`decodeIfPresent` for an Optional and `decode` for a non-Optional — a plain `Bool` would throw on
the missing key. This is reasoned, not measured: `DictusLiveActivityAttributes` is `#if os(iOS)`
and needs ActivityKit, and the repo's suite runs on macOS, so there is no way to unit-test the
decode.

**The intent got its own file rather than joining `StopStandbyIntent.swift`.** The probe put it
there to inherit target membership for free; shipped code follows the repo's one-file-one-
responsibility rule instead, and the membership is added by hand in the project file. A missing
membership produces **no build error** — only a button that silently does nothing — so it is
verified by both targets' object files, not by a green build:

```
Dictus.build/Debug-iphonesimulator/DictusApp.build/Objects-normal/arm64/CopyLastTranscriptIntent.o
Dictus.build/Debug-iphonesimulator/DictusWidgets.build/Objects-normal/arm64/CopyLastTranscriptIntent.o
```

## One thing found while validating, and fixed

`startStandbyActivity` adopts an orphaned activity — one that outlived the app process — with
whatever content it was left holding. So the transcript row was present on a pill the app had
created and absent on a pill it had merely re-adopted: same phone, same dictation, two different
screens, for a reason the user cannot see. That is exactly the state decision 2 rules out.
Measured before the fix (fresh app process behind a surviving pill): power and mic, empty bottom
region, transcript sitting in the App Group the whole time. After: the row is there. Only
`.standby` is refreshed — any other adopted phase is a dictation in flight, and stamping standby
over it is #42.

## Two deliberate deviations from the issue

**The copy button carries an icon, not the word `Copy` the mock draws.** `DictusWidgets` has no
string catalogue — every string in that file is hardcoded English — so a `Copy` label would be the
one new string in the project no French user can read. The two buttons it sits under are icons for
the same reason. One line to change if you want the word.

**`.ready` now uses the same preview derivation as the standby row.** It was a bare
`String(prefix(100))`; it is now the shared function, which collapses newlines and appends `…` when
it cuts. Two truncation rules for the same string in the same view would drift.

## Acceptance criteria

| Criterion (issue "Device validation") | Status | Evidence |
|---|---|---|
| Bottom region empty before any dictation, power and mic unchanged | **Verified** | Simulator, store empty: expanded island shows Dictus / On / power / mic and nothing else |
| Transcript present in the expanded island | **Verified** | Simulator, store seeded with 192 characters: the row renders, cut at 100 with `…` |
| Copy yields the **full** text, not the preview | **Verified** | Clipboard seeded `SENTINEL_BEFORE_COPY_531`; after the tap, 192 characters ending in `…a cote de la plaque.` |
| Lock screen reads `On`, no transcript | **Verified** | Simulator locked with a transcript stored: banner shows Dictus / On / power / mic |
| Copy confirmation flips to a checkmark | **NOT verified** | The `perform()` that wrote the pasteboard also calls it, but the swap was never caught in a screenshot. Manual step 4. |
| A new dictation replaces the transcript | **NOT verified** | Needs a real dictation. Manual step 6. |
| A real dictation feeds the store at all | **NOT verified** | No simulator produces speech. Manual steps 2-3. |
| Long suspension | **NOT verified** | The probe's own note. Manual step 8. |

`cd DictusCore && swift test` — 1802 tests, 1 skipped, 0 failures.
`swiftlint lint --strict` — 0 violations in 265 files.
`xcodebuild build -scheme DictusApp` for the iPhone 17 Pro simulator — BUILD SUCCEEDED, all three
targets plus the widget extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C78XD4CAdZZ58WMTHNYrAH
