### PR TITLE
Arm the mirror detector at every keyboard edit site (refs #548)

### DIFF
--- a/DictusCore/Tests/DictusCoreTests/CountingSiteReplayTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/CountingSiteReplayTests.swift
@@ -285,6 +285,47 @@ final class CountingSiteReplayTests: XCTestCase {
         XCTAssertEqual(doc.deleteCalls, 0)
     }
 
+    // MARK: - #548: a desync caused by a user-initiated site is not hidden
+
+    func testAWordDeleteThatTheMirrorIgnoresProtectsTheNextCorrection() {
+        // The gap #548 closes, asserted on the document. Before this, `handleWordDelete`
+        // edited and told the detector nothing, so the correction that followed counted
+        // against a mirror nobody had flagged — #530's exact failure, reached through a
+        // site #530 deliberately left counting.
+        //
+        // Here the word delete removes seven characters from the document and the
+        // mirror registers none of them.
+        let doc = FakeDocument(document: "Ok je vais", mirrorPhantomSuffix: "s")
+        let state = MirrorSyncState()
+        state.observe(before: 40, after: 40, deleted: 7, inserted: 0)
+        XCTAssertTrue(state.isSuspect, "the word delete must report itself")
+
+        let outcome = AutocorrectCountingSite.apply(
+            editor: doc, word: "vaiss", correction: "vais", mirror: state
+        )
+
+        XCTAssertEqual(outcome, .refused(reason: MirrorGatedReplacement.suspectReason))
+        XCTAssertEqual(doc.document, "Ok je vais", "untouched — no delete, no insert")
+        XCTAssertEqual(doc.deleteCalls, 0)
+    }
+
+    func testATapThatTheMirrorReflectsLeavesTheNextCorrectionAlone() {
+        // The other half, and the one that keeps #530's criterion 9 honest: a
+        // suggestion tap the mirror follows faithfully must leave the detector calm,
+        // so the next correction is made in full exactly as develop makes it.
+        let doc = FakeDocument(document: "je pense quee")
+        let state = MirrorSyncState()
+        state.observe(before: 20, after: 24, deleted: 4, inserted: 8)   // bar-replace
+        XCTAssertFalse(state.isSuspect)
+
+        let outcome = AutocorrectCountingSite.apply(
+            editor: doc, word: "quee", correction: "que", mirror: state
+        )
+
+        XCTAssertEqual(outcome, .applied(deleted: 4))
+        XCTAssertEqual(doc.document, "je pense que ")
+    }
+
     // MARK: - The seam itself
 
     func testTheFakeKeepsDocumentAndMirrorApart() {

--- a/DictusCore/Tests/DictusCoreTests/EditSiteArmingTests.swift
+++ b/DictusCore/Tests/DictusCoreTests/EditSiteArmingTests.swift
@@ -1,0 +1,151 @@
+// DictusCore/Tests/DictusCoreTests/EditSiteArmingTests.swift
+// Every keyboard edit site must tell the mirror detector what it did (issue #548).
+//
+// #530 shipped a detector that only learns about an edit if that edit reports it.
+// Three sites edited the document and reported nothing, so a desync they caused was
+// invisible to the sites that refuse — #530's failure through a door left open for
+// the replacements but never meant to be open for the detection.
+//
+// These tests are about the ARITHMETIC each site hands the detector, which is where
+// the risk is. A site that over-states its deletions arms the detector on healthy
+// typing, and that is #530's criterion 9 — the regression that would hurt most.
+//
+// The shapes below mirror the production call sites one for one. They are integer
+// facts, so they are tested as integers; what the sites DO with the document is
+// covered by CountingSiteReplayTests against a FakeDocument.
+
+import XCTest
+@testable import DictusCore
+
+final class EditSiteArmingTests: XCTestCase {
+
+    /// One site's report, named as the production call site names it.
+    private struct EditShape {
+        let site: String
+        let deleted: Int
+        let inserted: Int
+    }
+
+    /// Every site armed by #548, with the arithmetic it reports.
+    private static let armedSites: [EditShape] = [
+        EditShape(site: "handleWordDelete-fallback", deleted: 1, inserted: 0),
+        EditShape(site: "handleWordDelete", deleted: 7, inserted: 0),
+        EditShape(site: "prediction-tap", deleted: 0, inserted: 6),
+        EditShape(site: "emoji-insert", deleted: 0, inserted: 1),
+        EditShape(site: "emoji-delete", deleted: 1, inserted: 0),
+        EditShape(site: "reject-correction-space", deleted: 0, inserted: 1),
+        EditShape(site: "bar-undo", deleted: 9, inserted: 12),
+        EditShape(site: "bar-replace", deleted: 4, inserted: 8)
+    ]
+
+    // MARK: - Criterion 4: healthy typing still never arms
+
+    func testNoArmedSiteRaisesSuspicionWhenTheMirrorReflectsItFaithfully() {
+        // The one that matters most. Every site's `deleted` is counted off the mirror
+        // itself in production, so a faithful mirror always agrees — but the whole
+        // point of #548 is that these numbers are newly load-bearing, so they are
+        // checked rather than assumed.
+        for shape in Self.armedSites {
+            for before in 0...60 {
+                let state = MirrorSyncState()
+                let deleted = min(shape.deleted, before)
+                let after = before - deleted + shape.inserted
+
+                state.observe(
+                    before: before, after: after,
+                    deleted: shape.deleted, inserted: shape.inserted
+                )
+
+                XCTAssertFalse(
+                    state.isSuspect,
+                    "\(shape.site) armed on a faithful mirror at before=\(before)"
+                )
+            }
+        }
+    }
+
+    func testAnEmptyMirrorNeverArmsWhateverTheSiteClaimsToDelete() {
+        // The word-delete fallback runs precisely when the mirror is empty, and a
+        // delete that had nothing to consume must not look like a desync.
+        for shape in Self.armedSites {
+            let state = MirrorSyncState()
+            state.observe(before: 0, after: shape.inserted,
+                          deleted: shape.deleted, inserted: shape.inserted)
+            XCTAssertFalse(state.isSuspect, "\(shape.site) armed on an empty mirror")
+        }
+    }
+
+    func testAMirrorThatMovesLessThanTheInsertNeverArms() {
+        // A grapheme that merges into the one before it — a combining accent, an
+        // emoji modifier. The mirror ends SHORTER than the edit implies, which is the
+        // recoverable direction and must not raise suspicion.
+        for shape in Self.armedSites where shape.inserted > 0 {
+            let state = MirrorSyncState()
+            let before = 40
+            let after = before - min(shape.deleted, before) + shape.inserted - 1
+
+            state.observe(before: before, after: after,
+                          deleted: shape.deleted, inserted: shape.inserted)
+
+            XCTAssertFalse(state.isSuspect, "\(shape.site) armed on a merging grapheme")
+        }
+    }
+
+    // MARK: - Criterion 2: an unreflected edit at any site raises suspicion
+
+    func testEveryArmedSiteRaisesSuspicionWhenTheMirrorIgnoresItsDelete() {
+        // The signal #548 exists to stop these sites from swallowing: the keyboard
+        // deleted, and the mirror did not move.
+        for shape in Self.armedSites where shape.deleted > 0 {
+            let state = MirrorSyncState()
+            let before = 40
+            // The mirror takes the insert but not the delete.
+            let after = before + shape.inserted
+
+            state.observe(before: before, after: after,
+                          deleted: shape.deleted, inserted: shape.inserted)
+
+            XCTAssertTrue(
+                state.isSuspect,
+                "\(shape.site) hid a desync — the detector was never told"
+            )
+        }
+    }
+
+    func testASiteThatOnlyInsertsStillRaisesSuspicionOnASurplus() {
+        // The insert-only sites — the prediction tap, the emoji key, the rejected
+        // correction — cannot hide a missed delete, but they can still catch a mirror
+        // that gained characters nobody wrote.
+        for shape in Self.armedSites where shape.deleted == 0 {
+            let state = MirrorSyncState()
+            let before = 40
+            let after = before + shape.inserted + 1
+
+            state.observe(before: before, after: after,
+                          deleted: shape.deleted, inserted: shape.inserted)
+
+            XCTAssertTrue(state.isSuspect, "\(shape.site) missed a surplus")
+        }
+    }
+
+    // MARK: - The point of arming: the automatic sites then refuse
+
+    func testSuspicionRaisedAtAUserInitiatedSiteMakesTheNextCorrectionRefuse() {
+        // This is the whole chain #548 restores. A word delete desyncs the mirror; the
+        // user types a misspelling and presses space; the correction that follows must
+        // refuse rather than count against a mirror nobody flagged.
+        let state = MirrorSyncState()
+        state.observe(before: 40, after: 40, deleted: 7, inserted: 0)   // word delete, ignored
+        XCTAssertTrue(state.isSuspect)
+
+        XCTAssertEqual(
+            MirrorGatedReplacement.check(
+                mirrorSuspect: state.isSuspect, context: "le quee", word: "quee"
+            ),
+            .failed(reason: MirrorGatedReplacement.suspectReason)
+        )
+        XCTAssertFalse(
+            AutoFullStop.shouldSubstitute(context: "le quee ", mirrorSuspect: state.isSuspect)
+        )
+    }
+}

--- a/DictusKeyboard/DictusKeyboardBridge.swift
+++ b/DictusKeyboard/DictusKeyboardBridge.swift
@@ -126,7 +126,7 @@ final class DictusKeyboardBridge: NSObject,
     ///
     /// Grapheme count, matching what a delete count is expressed in: one
     /// deleteBackward() removes one grapheme, so the two are the same unit.
-    private func mirrorLength() -> Int {
+    func mirrorLength() -> Int {
         #if DEBUG
         let start = DispatchTime.now().uptimeNanoseconds
         defer { MirrorReadCost.sample(nanos: DispatchTime.now().uptimeNanoseconds - start) }
@@ -140,7 +140,7 @@ final class DictusKeyboardBridge: NSObject,
     /// `before` must be read immediately before the edit and this called immediately
     /// after it, with nothing in between that yields the run loop: that is what makes
     /// a discrepancy attributable to the mirror rather than to a host callback.
-    private func observeMirror(before: Int, deleted: Int = 0, inserted: Int = 0) {
+    func observeMirror(before: Int, deleted: Int = 0, inserted: Int = 0) {
         mirrorSync.observe(
             before: before,
             after: mirrorLength(),
@@ -477,8 +477,15 @@ final class DictusKeyboardBridge: NSObject,
         suggestionState?.pendingUndo = nil
         guard let proxy = controller?.textDocumentProxy,
               let before = proxy.documentContextBeforeInput, !before.isEmpty else {
-            // Fallback: single character delete if no text context
+            // Fallback: single character delete if no text context.
+            // Armed like every other edit (#548). It can never actually raise
+            // suspicion — the guard above only fails when the mirror is empty, so
+            // `min(deleted, before)` is zero and the edit is consistent by
+            // construction — but a site that reports nothing is a site that can hide
+            // a desync later, and uniformity is cheaper than remembering why.
+            let mirrorBefore = mirrorLength()
             controller?.textDocumentProxy.deleteBackward()
+            observeMirror(before: mirrorBefore, deleted: 1)
             #if DEBUG
             MirrorProbe.shared.record(.deleteBackward)
             MirrorProbe.shared.probe(
@@ -507,9 +514,14 @@ final class DictusKeyboardBridge: NSObject,
 
         // Delete trailing spaces + word (at least 1 character)
         let total = trailingSpaces + charsInWord
+        // #548: `before` is the mirror read at the top of this function and nothing
+        // has yielded the run loop since, so it IS the pre-edit mirror length —
+        // reusing it satisfies #530's bracketing rule and costs no extra IPC.
+        let mirrorBefore = before.count
         for _ in 0..<max(1, total) {
             proxy.deleteBackward()
         }
+        observeMirror(before: mirrorBefore, deleted: max(1, total))
         #if DEBUG
         MirrorProbe.shared.record(.replace(deleted: max(1, total), inserted: ""))
         MirrorProbe.shared.probe(
@@ -786,7 +798,11 @@ final class DictusKeyboardBridge: NSObject,
     /// "correct" a perfectly valid prediction.
     func handlePredictionTap(word: String) {
         let proxy = controller?.textDocumentProxy
+        // #548: the edit is reported before the trailing space settles the suspicion.
+        // Order matters — settling first would discard whatever this insert revealed.
+        let mirrorBefore = mirrorLength()
         proxy?.insertText(word + " ")
+        observeMirror(before: mirrorBefore, inserted: (word + " ").count)
         mirrorSync.noteBoundaryInserted(reason: "prediction-tap-space", atLength: mirrorLength())
         lastInsertedCharacter = " "
         #if DEBUG

--- a/DictusKeyboard/KeyboardRootView.swift
+++ b/DictusKeyboard/KeyboardRootView.swift
@@ -205,14 +205,19 @@ struct KeyboardRootView: View {
             GeometryReader { geo in
                 EmojiPickerView(
                     onEmojiInsert: { emoji in
+                        // #548: armed like every other keyboard edit.
+                        let mirrorBefore = bridge?.mirrorLength() ?? 0
                         state.controller?.textDocumentProxy.insertText(emoji)
+                        bridge?.observeMirror(before: mirrorBefore, inserted: emoji.count)
                         #if DEBUG
                         MirrorProbe.shared.record(.insert(emoji))
                         #endif
                         HapticFeedback.keyTapped()
                     },
                     onDelete: {
+                        let mirrorBefore = bridge?.mirrorLength() ?? 0
                         state.controller?.textDocumentProxy.deleteBackward()
+                        bridge?.observeMirror(before: mirrorBefore, deleted: 1)
                         #if DEBUG
                         MirrorProbe.shared.record(.deleteBackward)
                         #endif
@@ -472,7 +477,13 @@ struct KeyboardRootView: View {
         if suggestionState.mode == .corrections {
             if index == 0 {
                 suggestionState.rejectedWords.insert(suggestion.lowercased())
+                // #548: reported, but deliberately NOT treated as a settling boundary.
+                // Adding `noteBoundaryInserted` here would change when suspicion
+                // clears, which is behaviour, and #548 is only about what the detector
+                // is told. Which sites should settle is a separate question.
+                let mirrorBefore = bridge?.mirrorLength() ?? 0
                 proxy.insertText(" ")
+                bridge?.observeMirror(before: mirrorBefore, inserted: 1)
             } else {
                 replaceCurrentWord(
                     proxy: proxy,
@@ -561,6 +572,10 @@ struct KeyboardRootView: View {
         let matchLength = matchedWithSpace ? correctedWithSpace.count : undo.correctedWord.count
         let deleteCount = matchLength + afterCorrection.count
 
+        // #548: `deleteCount` is measured off `context`, the mirror read at the top of
+        // this function, so it can never exceed the mirror's length and a healthy undo
+        // is consistent by construction.
+        let mirrorBefore = bridge?.mirrorLength() ?? 0
         for _ in 0..<deleteCount {
             proxy.deleteBackward()
         }
@@ -570,6 +585,11 @@ struct KeyboardRootView: View {
             proxy.insertText(" ")
         }
         proxy.insertText(afterCorrection)
+        bridge?.observeMirror(
+            before: mirrorBefore,
+            deleted: deleteCount,
+            inserted: undo.originalWord.count + (matchedWithSpace ? 1 : 0) + afterCorrection.count
+        )
 
         #if DEBUG
         MirrorProbe.shared.record(.replace(
@@ -639,6 +659,9 @@ struct KeyboardRootView: View {
         replacement: String,
         addSpace: Bool
     ) {
+        // #548: both callers derive `deleteCount` from AutocorrectReplacement.check
+        // over the live mirror, so it is never larger than the mirror holds.
+        let mirrorBefore = bridge?.mirrorLength() ?? 0
         for _ in 0..<deleteCount {
             proxy.deleteBackward()
         }
@@ -646,6 +669,11 @@ struct KeyboardRootView: View {
         if addSpace {
             proxy.insertText(" ")
         }
+        bridge?.observeMirror(
+            before: mirrorBefore,
+            deleted: deleteCount,
+            inserted: replacement.count + (addSpace ? 1 : 0)
+        )
         #if DEBUG
         MirrorProbe.shared.record(
             .replace(deleted: deleteCount, inserted: replacement + (addSpace ? " " : ""))

--- a/DictusKeyboard/KeyboardState.swift
+++ b/DictusKeyboard/KeyboardState.swift
@@ -863,6 +863,13 @@ class KeyboardState: ObservableObject {
     /// The App Group key is deliberately NOT read here: the caller clears it before
     /// calling, which is what stops a redelivered Darwin notification from inserting
     /// the same text twice.
+    /// NOT ARMED for #530's mirror detector, and the reason is plumbing rather than
+    /// principle (#548). A bracket here would be valid — this is one synchronous
+    /// insert — but `MirrorSyncState` lives on `DictusKeyboardBridge`, `bridge` is
+    /// private on KeyboardViewController, and this type holds only a
+    /// `UIInputViewController`. Reaching it means widening that surface across a
+    /// subsystem boundary, which is more than the bracketing #548 is scoped to.
+    /// Worth revisiting if a desync is ever traced to a dictation insert.
     func insertDictation(_ transcription: String) {
         controller?.textDocumentProxy.insertText(transcription)
         PersistentLog.log(.keyboardTextInserted)
@@ -1121,6 +1128,14 @@ class KeyboardState: ObservableObject {
             return
         }
 
+        // NOT ARMED for #530's mirror detector, and here the reason is structural
+        // rather than plumbing (#548). These chunks are separated by
+        // `DispatchQueue.main.async`, so a before/after pair would straddle a run-loop
+        // turn and a host callback could land between the two reads — which is exactly
+        // what #530's attributability rule forbids, since the discrepancy could then
+        // belong to the host rather than to this burst. The burst has its own
+        // verification instead: `DictationUndo.verify` re-proves the remainder against
+        // the live context after every chunk (#266).
         let batch = min(remaining, Self.dictationUndoChunkSize)
         for _ in 0..<batch {
             proxy.deleteBackward()


### PR DESCRIPTION
## What this was for

#530 shipped a detector: when the keyboard issues an edit that `documentContextBeforeInput` does
not reflect, the mirror is suspect and the two automatic counting sites refuse until it clears.
**The detector only learns about an edit if that edit reports it** — and several sites edited the
document and reported nothing. A desync they caused was invisible to the sites that refuse, which
is #530's original failure reached through a door left open for the *replacements* but never meant
to be open for the *detection*.

## To test by hand

1. Delete a word with the word-delete gesture (hold backspace until it eats whole words), then
   immediately type a misspelling and press space. **Expect no merged words, ever.** A correction
   that is refused and left alone is the acceptable outcome here, not a failure. *(criterion 6)*
2. Tap a word in the suggestion bar, then immediately type a misspelling and press space. Same
   expectation. *(criterion 7)*
3. Tap the undo chip to reject an autocorrect, then type a misspelling and press space. Same again.
4. Insert an emoji from the emoji picker, then type a misspelling and press space. Same again.
5. **The regression that matters most.** Ordinary typing — no word delete, no suggestion tap, no
   emoji — for a few sentences including a double space to end one. **Expect autocorrect and the
   auto-period to behave exactly as they do today.** Nothing may feel damped or skipped. *(8)*
6. With "Autocorrect debug logs" ON, after steps 1-4: `grep -E 'MIRROR-SUSPECT|MIRROR-SETTLED'`.
   **Expect few or no new `MIRROR-SUSPECT` lines during step 5.** A burst of them on ordinary
   typing would mean one of the eight sites is miscounting, and is the one thing worth reporting
   back immediately.

## What changed

The audit found **ten** edit sites, not the three the issue named. Eight are now armed —
`handleWordDelete` and its fallback, the prediction tap, emoji insert, emoji delete, the
rejected-correction space, `performUndo`, and `applyReplacement` (both paths).

Two are **not** armed and carry the reason in code, per criterion 1. `insertDictation` would be a
valid bracket, but `MirrorSyncState` lives on the bridge, `bridge` is private on
`KeyboardViewController`, and `KeyboardState` holds only a `UIInputViewController` — arming it
means widening that surface across a subsystem boundary, which is more than bracketing. The
dictation undo burst has a second and stronger reason: its chunks are separated by
`DispatchQueue.main.async`, so a before/after pair would straddle a run-loop turn and a host
callback could land between the reads — exactly what #530's attributability rule forbids. That
burst re-proves itself against the live context after every chunk instead (#266).

## Behaviour is unchanged, and it is proved rather than intended

The entire production diff is **2 lines removed** — both `private func` declarations, widened so
the root view can call them — and **26 added**, all of them `mirrorBefore` reads and
`observeMirror` calls. **Not one `insertText` or `deleteBackward` was added, removed, or
reordered.** The three sites still count and still act exactly as today (criterion 3).

## The arithmetic, which is where the risk was

Every site's `deleted` is counted off the mirror itself — `handleWordDelete` from the context it
read at the top of the same synchronous turn, `performUndo` from a range match inside that
context, `applyReplacement` from `AutocorrectReplacement.check`. So `deleted` can never exceed the
mirror's length, and a faithful mirror is consistent by construction.

`EditSiteArmingTests` sweeps all eight shapes across mirror lengths 0 to 60 and asserts none arms,
plus the two harmless cases that could look like a desync and must not: an empty mirror (the
word-delete fallback runs precisely there) and a grapheme that merges into the one before it.

Two details worth naming: `handleWordDelete` reuses the context it already read instead of taking
a second IPC read — nothing yields the run loop in between, so it *is* the pre-edit length. And the
prediction tap reports its edit **before** the trailing space settles the suspicion; settling first
would discard whatever the insert revealed.

## Deliberately not done

No `noteBoundaryInserted` was added anywhere it is absent today. The rejected-correction space and
the prediction tap both write a boundary, but adding a settle changes when suspicion **clears**,
which is behaviour and outside this issue. Which sites should settle is a separate question,
flagged rather than answered.

## Criteria

| # | Status | Evidence |
|---|---|---|
| 1 | met | All ten sites audited; eight armed, two carry a written reason |
| 2 | met | `EditSiteArmingTests` plus two document-level replays through `FakeDocument` — a word delete the mirror ignores makes the next correction refuse and leave the document untouched |
| 3 | met | Production diff is 2 access-level lines and pure bracketing; no edit call touched |
| 4 | met | All eight shapes swept over mirror lengths 0-60, none arms; empty-mirror and merging-grapheme cases covered |
| 5 | met | 1919 tests, 0 failures; swiftlint 0 violations in 271 files; three targets build, Release too |
| 6-8 | Pierre's | Manual list above |

refs #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155NfNULhoE24Yz5dGPjFTo
