### PR TITLE
Measure the pause route against the speaker's own marks (refs #550)

### DIFF
--- a/docs/research/550-paragraph-placement/README.md
+++ b/docs/research/550-paragraph-placement/README.md
@@ -41,6 +41,22 @@ The instrument is `swift run polish-harness paragraph`, documented in
 **The answer is in `findings.md` and it is no.** One arm holds all four bars 70 of 70
 and returns the same answer as a rule that calls no model at all in 56 of those 70.
 
+### 3. The pause hypothesis, re-measured against the speaker, 2026-09-12
+
+`pauses/` holds the round that answers the question the falsification left open. The
+first round killed *pauses explain Typeless*; this one tests *pauses serve the speaker*,
+with his own paragraph marks as the reference instead of the competitor's output.
+
+Five new fixtures, each with its audio, its Dictus raw and polished text, and the breaks
+the maintainer wants, collected from the numbered text **before any measurement was shown
+to him**. Sixteen sentence boundaries, each carrying a silence measured by cutting the
+audio at the pauses and transcribing every speech segment on its own, so nothing is
+interpolated from a speaking rate.
+
+**It holds on the three spontaneous dictations and breaks on the two read-aloud ones.**
+The half-second rule the issue body opened on invents as many breaks as it finds. Start
+with `pauses/findings.md`.
+
 ### And one thing settled on the side
 
 `timings-probe/` answers the issue body's first technical step — is

--- a/docs/research/550-paragraph-placement/pauses/README.md
+++ b/docs/research/550-paragraph-placement/pauses/README.md
@@ -1,0 +1,41 @@
+# Pause placement — the deterministic route (#550)
+
+The second half of #550. The model half is `../findings.md`, closed by PR #551. This
+folder is the pause half: does a silence in the speaker's own delivery say where he
+wants a paragraph.
+
+**Read `findings.md` first.** It carries the verdict, the method and the limits.
+
+| File | What it is |
+|---|---|
+| `findings.md` | The round: method, the sixteen-boundary table, two candidate rules, limits |
+| `reference.md` | The speaker's own paragraph marks and how they were collected before any measurement |
+| `transcripts.md` | The five fixtures, Dictus raw and Dictus polished |
+| `boundaries.json` | The measured table, machine-readable |
+| `detect.py` | Silence detection and speech segmentation |
+| `score.py` | Scores candidate rules against `boundaries.json`. Reported, never barred |
+
+## Re-running
+
+`detect.py` needs the source audio, which is not committed; see `reference.md` for the
+digests.
+
+```
+mkdir wav
+ffmpeg -i "Texte A - Pause.m4a" -ac 1 -ar 16000 "wav/Texte A - Pause.wav"   # and the rest
+python3 detect.py            # writes segments.json
+python3 score.py             # needs only boundaries.json
+```
+
+Mapping the silences onto sentence boundaries means cutting the audio at the reported
+silences and transcribing each speech segment on its own, then reading which Dictus
+sentences each segment covers. `whisper.cpp` with `ggml-small` and `-l fr` was used. That
+step is manual on purpose: it is the step that makes the table trustworthy, and it is
+where an automated alignment would reintroduce the interpolation error that limited
+fixture 7.
+
+## Status
+
+No code ships from this round. The bars are in the issue, declared before any Swift is
+written, and they are to be scored on a fixture set that does not include A through E and
+that includes a second speaker.

--- a/docs/research/550-paragraph-placement/pauses/boundaries.json
+++ b/docs/research/550-paragraph-placement/pauses/boundaries.json
@@ -1,0 +1,68 @@
+{
+  "_comment": "Every sentence boundary of the five fixtures, the silence measured on it, and the reference. Silences come from detect.py plus segment-by-segment transcription; a boundary falling inside a speech segment carries 0.0. The reference was collected from the numbered polished text, before any measurement was shown to the speaker.",
+  "collected": "2026-09-12",
+  "speaker": "maintainer, single voice",
+  "fixtures": {
+    "A": {
+      "register": "read aloud",
+      "audioSeconds": 19.69,
+      "polishedChars": 245,
+      "reference": [2],
+      "boundaries": [
+        {"after": 1, "silence": 1.29},
+        {"after": 2, "silence": 1.15},
+        {"after": 3, "silence": 1.35}
+      ],
+      "longMidSentenceSilences": []
+    },
+    "B": {
+      "register": "read aloud",
+      "audioSeconds": 17.39,
+      "polishedChars": 315,
+      "reference": [1],
+      "boundaries": [
+        {"after": 1, "silence": 0.86}
+      ],
+      "longMidSentenceSilences": [1.04]
+    },
+    "C": {
+      "register": "spontaneous",
+      "audioSeconds": 25.58,
+      "polishedChars": 262,
+      "reference": [2],
+      "boundaries": [
+        {"after": 1, "silence": 0.0},
+        {"after": 2, "silence": 1.96},
+        {"after": 3, "silence": 0.0}
+      ],
+      "longMidSentenceSilences": [1.01]
+    },
+    "D": {
+      "register": "spontaneous",
+      "audioSeconds": 59.97,
+      "polishedChars": 644,
+      "reference": [1, 5],
+      "boundaries": [
+        {"after": 1, "silence": 2.0},
+        {"after": 2, "silence": 0.3},
+        {"after": 3, "silence": 0.54},
+        {"after": 4, "silence": 0.91},
+        {"after": 5, "silence": 1.44},
+        {"after": 6, "silence": 0.86}
+      ],
+      "longMidSentenceSilences": [2.59, 1.47]
+    },
+    "E": {
+      "register": "spontaneous",
+      "audioSeconds": 48.11,
+      "polishedChars": 772,
+      "reference": [1],
+      "boundaries": [
+        {"after": 1, "silence": 1.6},
+        {"after": 2, "silence": 0.74},
+        {"after": 3, "silence": 0.48}
+      ],
+      "longMidSentenceSilences": [1.4]
+    }
+  }
+}

--- a/docs/research/550-paragraph-placement/pauses/detect.py
+++ b/docs/research/550-paragraph-placement/pauses/detect.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Silence detection and speech segmentation for the #550 pause round.
+
+Reads 16 kHz mono WAV files from ./wav and writes segments.json: for each
+fixture, the interior silences and the complementary speech segments.
+
+The segments are meant to be cut and transcribed one by one, so that every
+pause is bracketed by its exact text on both sides. Nothing here interpolates
+a character offset from a speaking rate; that is what limited fixture 7.
+
+Usage:
+    ffmpeg -i "Texte A - Pause.m4a" -ac 1 -ar 16000 "wav/Texte A - Pause.wav"
+    python3 detect.py
+"""
+import wave, array, math, glob, os, json
+
+HOP = 0.010          # frame step, seconds
+WIN = 0.025          # frame window, seconds
+FRAC = 0.55          # threshold placed this far from the noise floor to the speech peak
+MERGE_MAXGAP = 0.25  # two silences separated by less than this...
+MERGE_DROP = 10.0    # ...and by a peak this many dB under speech level are one silence
+MINSIL = 0.25        # silences shorter than this are not reported
+
+
+def pct(xs, p):
+    s = sorted(xs)
+    k = (len(s) - 1) * p
+    f = int(k)
+    c = min(f + 1, len(s) - 1)
+    return s[f] + (s[c] - s[f]) * (k - f)
+
+
+def analyse(path):
+    w = wave.open(path, 'rb')
+    sr = w.getframerate()
+    a = array.array('h')
+    a.frombytes(w.readframes(w.getnframes()))
+    hop, win = int(sr * HOP), int(sr * WIN)
+    nf = (len(a) - win) // hop + 1
+
+    db = []
+    for i in range(nf):
+        seg = a[i * hop:i * hop + win]
+        s = 0
+        for v in seg:
+            s += v * v
+        db.append(20 * math.log10(math.sqrt(s / len(seg)) / 32768.0 + 1e-9))
+
+    # The five fixtures span 20.0 dB to 33.7 dB of dynamic range. A single
+    # absolute threshold in dB does not work across them, so it is placed
+    # relative to each recording's own floor and peak.
+    floor, peak = pct(db, 0.10), pct(db, 0.95)
+    thr = floor + (peak - floor) * FRAC
+    speech = [d for d in db if d >= thr]
+    level = pct(speech, 0.50) if speech else peak
+    dur = len(a) / sr
+
+    sil = [d < thr for d in db]
+    runs, i = [], 0
+    while i < len(sil):
+        if sil[i]:
+            j = i
+            while j < len(sil) and sil[j]:
+                j += 1
+            runs.append([i * HOP, j * HOP])
+            i = j
+        else:
+            i += 1
+
+    # The breath rule. A single pause is otherwise reported as two: measured at
+    # 12 dB under speech in fixture A and 15 to 19 dB in fixture D.
+    merged = []
+    for r in runs:
+        if merged:
+            gs, ge = merged[-1][1], r[0]
+            gi, gj = int(gs / HOP), max(int(ge / HOP), int(gs / HOP) + 1)
+            top = max(db[gi:gj]) if gj > gi else floor
+            if ge - gs <= MERGE_MAXGAP and top < level - MERGE_DROP:
+                merged[-1][1] = r[1]
+                continue
+        merged.append(r)
+
+    inter = [(s, e) for s, e in merged
+             if e - s >= MINSIL and s > 0.10 and e < dur - 0.15]
+    return inter, dur, floor, peak, thr, level
+
+
+def main():
+    out = {}
+    for p in sorted(glob.glob('wav/*.wav')):
+        name = os.path.basename(p)[:-4]
+        inter, dur, fl, pk, thr, lvl = analyse(p)
+        segs, prev = [], 0.0
+        for s, e in inter:
+            segs.append((prev, s))
+            prev = e
+        segs.append((prev, dur))
+        out[name] = {
+            'duration': round(dur, 3),
+            'noiseFloorDb': round(fl, 1),
+            'speechPeakDb': round(pk, 1),
+            'thresholdDb': round(thr, 1),
+            'silences': [[round(s, 3), round(e, 3), round(e - s, 3)] for s, e in inter],
+            'segments': [[round(a, 3), round(b, 3)] for a, b in segs],
+        }
+        print(f"{name:18s} range={pk-fl:4.1f}dB thr={thr:6.1f}dB  {len(inter)} silences")
+    json.dump(out, open('segments.json', 'w'), indent=1)
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/research/550-paragraph-placement/pauses/findings.md
+++ b/docs/research/550-paragraph-placement/pauses/findings.md
@@ -1,0 +1,199 @@
+# Pause placement — measured on five paired samples (#550)
+
+**Instrument:** `detect.py`. **Measured table:** `boundaries.json`. **Scoring:** `score.py`,
+reported and never barred. **Fixtures:** `transcripts.md`. **Reference:** `reference.md`.
+**Where:** Mac, 2026-09-12, on audio exported from the device.
+
+Nothing here ran inside the app. The measurement uses an external voice-activity
+detector over exported audio, not `ASRResult.tokenTimings`. What it establishes is
+that the signal carries the information, which is what was in doubt.
+
+---
+
+## The verdict
+
+**The rule holds on the three spontaneous dictations and breaks on the two read-aloud
+ones.** On C, D and E a threshold on the silence sitting at a sentence boundary finds
+all four wanted breaks and invents none. Pooled over all five fixtures no threshold
+separates the two classes, because in fixture A the speaker paused at every boundary
+and wants a break at one, and the one he wants is the shortest of the three.
+
+**All six wanted breaks carry a real pause.** None is at zero. The first pass reported
+zero at two of them and that was an instrument failure, corrected below.
+
+## Method
+
+The time-to-text mapping that limited fixture 7 is gone. Nothing is interpolated from
+a constant speaking rate.
+
+1. Decode to 16 kHz mono. Frame at 10 ms with a 25 ms window, take RMS in dB.
+2. Per file, put the silence threshold at the 10th percentile of frame energy plus
+   55 % of the distance to the 95th. The five files span 20,0 dB to 33,7 dB of dynamic
+   range; one absolute threshold in dB does not work across them.
+3. Merge two silence runs separated by a gap under 250 ms whose peak sits more than
+   10 dB below speech level. Without this a single pause is reported as two.
+4. **Cut at the surviving silences and transcribe each speech segment separately**
+   (whisper.cpp `ggml-small`, `-l fr`). Every pause is then bracketed by its exact text
+   on both sides.
+5. Map segments onto the Dictus polished sentences. For each sentence boundary report
+   the silence on it, zero when the boundary falls inside a segment.
+
+### The instrument failure, recorded
+
+The first pass placed the threshold at 25 % of the dynamic range and reported **zero**
+silence at the boundaries wanted in A and in B, which would have read as a falsification.
+It was the detector. Cutting at the candidate positions and transcribing the halves
+shows the pause in both:
+
+```
+A_left  : J'ai pris un café, puis j'ai regardé rapidement mes messages.
+A_right : Ensuite, je me suis mis au travail.        silence 9,45 -> 10,60 s
+B_left  : alors que parfois prendre quelques minutes pour réfléchir permet
+          simplement de mieux faire les choses.
+B_right : [Ce n'est] pas forcément plus long, c'est juste une autre manière
+          de travailler.                            silence 12,66 -> 13,52 s
+```
+
+The two quiet recordings, A and B, are also the two with the narrowest dynamic range,
+20,0 dB and 21,2 dB against 29,3 dB to 33,7 dB for the others. A voice-activity
+detector calibrated on loud spontaneous speech under-reports on them.
+
+## The measurement
+
+Sixteen sentence boundaries. Full data in `boundaries.json`.
+
+| Fixture | Boundary | Silence | Wanted |
+|---|---|---:|---|
+| A | after 1 | 1,29 s | no |
+| A | after 2 | 1,15 s | **yes** |
+| A | after 3 | 1,35 s | no |
+| B | after 1 | 0,86 s | **yes** |
+| C | after 1 | 0,00 s | no |
+| C | after 2 | 1,96 s | **yes** |
+| C | after 3 | 0,00 s | no |
+| D | after 1 | 2,00 s | **yes** |
+| D | after 2 | 0,30 s | no |
+| D | after 3 | 0,54 s | no |
+| D | after 4 | 0,91 s | no |
+| D | after 5 | 1,44 s | **yes** |
+| D | after 6 | 0,86 s | no |
+| E | after 1 | 1,60 s | **yes** |
+| E | after 2 | 0,74 s | no |
+| E | after 3 | 0,48 s | no |
+
+**Spontaneous only.** Wanted breaks are 1,44 / 1,60 / 1,96 / 2,00 s; unwanted boundaries
+top out at 0,91 s. Any threshold in [0,95 s ; 1,40 s] gives four found, none missed,
+none invented.
+
+**Fixture A.** Three boundaries at 1,29 / 1,15 / 1,35 s, one break wanted, and it is the
+shortest. No threshold exists. In read-aloud speech his pauses do not encode his
+paragraph intent.
+
+**Fixture B.** The wanted break is 0,86 s, equal to the centisecond to the unwanted
+D-after-6. Pooled, the two classes overlap and no absolute threshold separates them.
+
+## The sentence-boundary condition is the robust part
+
+Speaker-independent by construction, and it holds on all five.
+
+| Fixture | Duration | Position | Outcome |
+|---|---:|---|---|
+| D | 2,59 s | mid-sentence | correctly rejected |
+| D | 1,47 s | mid-sentence | correctly rejected |
+| E | 1,40 s | mid-sentence | correctly rejected |
+| B | 1,04 s | mid-sentence | correctly rejected |
+| C | 1,01 s | mid-sentence | correctly rejected |
+
+The longest silence in the corpus, 2,59 s, is a hesitation inside a sentence of fixture
+D and is longer than every wanted break. Five such silences would be false positives
+without the boundary condition. This reproduces fixture 7's counter-example on five new
+instances.
+
+## Speaker calibration
+
+Raised by the maintainer: a threshold in seconds cannot suit every human.
+
+He is right that a per-**user** setting is wrong, and his own data shows why. One
+speaker, two registers, a factor of 2,2 apart:
+
+| Fixture | Register | Characters per second of speech |
+|---|---|---:|
+| A | read | 22,1 |
+| B | read | 28,6 |
+| C | spontaneous | 13,1 |
+| D | spontaneous | 14,7 |
+| E | spontaneous | 20,9 |
+
+**But normalising by the dictation's own median silence makes the separation worse.**
+On short fixtures the median is carried by the very pauses being detected, so the ratio
+collapses. The absolute threshold wins on this data. One speaker cannot settle the
+question; the obvious normalisation is measured and it loses.
+
+## Two candidate rules, compared on the same sixteen points
+
+Both constants in both rules were chosen after seeing the table. **Neither is a result.**
+What follows is a comparison, not a score.
+
+Run `score.py` to reproduce.
+
+| Rule | All five | Spontaneous only |
+|---|---|---|
+| silence ≥ 0,50 s at a boundary | 6 found, 6 invented, 0 missed | 4 found, 4 invented, 0 missed |
+| silence ≥ 1,00 s | 5 found, 2 invented, 1 missed | 4 found, 0 invented, 0 missed |
+| silence ≥ 1,40 s | 4 found, 0 invented, 2 missed | 4 found, 0 invented, 0 missed |
+| floor 1,00 s and contrast ×1,5 | 4 found, 0 invented, 2 missed | 4 found, 0 invented, 0 missed |
+
+The half-second rule the body of this issue opened on **invents as many breaks as it
+finds**. It is dead as stated.
+
+The absolute threshold and the contrast rule reach the same confusion matrix. **They
+differ in how precisely the constant has to be known.**
+
+- *Absolute*: zero false positives requires a threshold above 1,35 s, and catching
+  D-after-5 requires it at or below 1,44 s. **A window 0,09 s wide.**
+- *Contrast* — a boundary fires when its silence clears a floor and exceeds the median
+  of the other sentence-boundary silences of the same dictation by a factor: the
+  highest false positive sits at ×1,11 and the lowest true positive at ×1,67.
+  **A window half as wide again as the value itself**, and it holds with the floor
+  anywhere from 0,80 s to 1,00 s.
+
+Contrast ratios, all sixteen boundaries:
+
+| Fixture | Boundary | Silence | Contrast | Wanted |
+|---|---|---:|---:|---|
+| C | after 2 | 1,96 s | ∞ | **yes** |
+| E | after 1 | 1,60 s | 2,62 | **yes** |
+| D | after 1 | 2,00 s | 2,33 | **yes** |
+| D | after 5 | 1,44 s | 1,67 | **yes** |
+| A | after 3 | 1,35 s | 1,11 | no |
+| D | after 4 | 0,91 s | 1,06 | no |
+| A | after 1 | 1,29 s | 1,03 | no |
+| D | after 6 | 0,86 s | 0,95 | no |
+| A | after 2 | 1,15 s | 0,87 | **yes**, missed |
+| E | after 2 | 0,74 s | 0,71 | no |
+| D | after 3 | 0,54 s | 0,59 | no |
+| E | after 3 | 0,48 s | 0,41 | no |
+| D | after 2 | 0,30 s | 0,33 | no |
+| C | after 1 | 0,00 s | 0,00 | no |
+| C | after 3 | 0,00 s | 0,00 | no |
+| B | after 1 | 0,86 s | undefined | **yes**, missed |
+
+Both rules turn the two read-aloud fixtures into misses rather than wrong breaks, which
+is the cheap direction: a miss leaves today's single block. The contrast rule reaches it
+with margin; the absolute threshold reaches it by landing inside a 0,09 s window that
+this corpus happens to define.
+
+## Limits
+
+- **One speaker, four wanted breaks over three spontaneous fixtures.** A clean separation
+  on four positives and eight negatives can be luck.
+- Every constant was chosen after seeing this table. Nothing here is scored.
+- The register split into read and spontaneous was declared by the maintainer before the
+  audio was touched, so the stratification is not post-hoc. The **exclusion** of A and B
+  from the spontaneous column is still a choice made while looking at the numbers, and it
+  is reported both ways above for that reason.
+- Measured on exported `.m4a`, not on what the app holds. The `tokenTimings` question is
+  untouched and still gates the implementation.
+- The audio is not committed. It is the maintainer's voice on a public repository, and
+  the transcripts carry everything the measurement needs. SHA-256 digests are in
+  `reference.md` so the same files can be identified if they are ever needed again.

--- a/docs/research/550-paragraph-placement/pauses/reference.md
+++ b/docs/research/550-paragraph-placement/pauses/reference.md
@@ -1,0 +1,51 @@
+# The reference, and how it was collected
+
+The speaker was shown the five Dictus-polished texts with numbered sentences and asked
+one question: after which sentence do you want a blank line. He was shown no silence
+data, no candidate breaks and no measurement of any kind. The audio had already been
+analysed at that point and the result was withheld on purpose.
+
+His answer, verbatim, 2026-09-12:
+
+```
+A : 2
+B : 1
+C : 2
+D : 1,5
+E : 1
+```
+
+Six breaks over sixteen sentence boundaries.
+
+## Why the reference had to come first
+
+Deriving the rule from the pauses and then declaring that the pauses mark the paragraphs
+validates the hypothesis with the signal that produced it. #437 records what happens when
+a bar moves after the numbers are in. The reference is the bar here, so it was collected
+before anything was shown.
+
+## The register split
+
+Declared by the maintainer in his first message, before the audio was touched:
+
+> pour les textes A et B, je suis parti des textes qu'on avait déjà utilisés dans l'IQ au
+> début pour Typeless, version avec pause
+
+against C, D and E, which he recorded as natural dictation. A and B are read aloud from
+text written earlier; C, D and E are composed while speaking. The split is not a post-hoc
+stratification, and it is the split the measurement turns on.
+
+## Source files
+
+Audio, not committed. SHA-256:
+
+```
+6fc69eba4afc74f098f47426af2f78fefd3f9cf897fed0cc7354710decd6322f  Texte A - Pause.m4a
+e37a96843f4376bb4c8d11742f85d2f5bb0a2cf0197d894d9646c8b1a6e88738  Texte B - Pause.m4a
+8a7f8aea8f616bb8b57b8ff7c75902053b3f8d7f7024fc66751433a010b5ce3b  Test C.m4a
+51304b9f399f921b36229fe609166dcdb7afaf2e0beb61183ee228c93f357225  Test D.m4a
+1cece2a4df52a3bfead6345a0aeb9460dcf58463e252ac0f33750623c2a0d742  Test E.m4a
+```
+
+Transcriptions: `dictus-polish-debug-20260912-001017.json`, events 209 to 213, exported
+from the app's Polish debug log. Reproduced in `transcripts.md`.

--- a/docs/research/550-paragraph-placement/pauses/score.py
+++ b/docs/research/550-paragraph-placement/pauses/score.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Score candidate paragraphing rules against boundaries.json.
+
+Reported, never barred. The constants below were chosen after seeing the data
+and this round does not claim they generalise. Their only job is to make the
+two rules comparable on the same sixteen points.
+
+Usage: python3 score.py
+"""
+import json
+
+DATA = json.load(open('boundaries.json'))['fixtures']
+SPONTANEOUS = [k for k, v in DATA.items() if v['register'] == 'spontaneous']
+
+
+def median(xs):
+    if not xs:
+        return None
+    s = sorted(xs)
+    n = len(s)
+    return s[n // 2] if n % 2 else (s[n // 2 - 1] + s[n // 2]) / 2
+
+
+def confusion(fires, keys):
+    tp = fp = fn = 0
+    for k in keys:
+        f = DATA[k]
+        want = set(f['reference'])
+        for b in f['boundaries']:
+            hit = fires(k, b)
+            if hit and b['after'] in want:
+                tp += 1
+            elif hit:
+                fp += 1
+            elif b['after'] in want:
+                fn += 1
+    return tp, fp, fn
+
+
+def absolute(threshold):
+    return lambda k, b: b['silence'] >= threshold
+
+
+def contrast(floor, factor):
+    def fires(k, b):
+        if b['silence'] < floor:
+            return False
+        others = [o['silence'] for o in DATA[k]['boundaries'] if o['after'] != b['after']]
+        if not others:
+            return False          # a single boundary offers no comparison
+        m = median(others)
+        if m == 0:
+            return True
+        return b['silence'] / m >= factor
+    return fires
+
+
+def row(label, fires):
+    for scope, keys in (('all five', list(DATA)), ('spontaneous only', SPONTANEOUS)):
+        tp, fp, fn = confusion(fires, keys)
+        print(f"  {label:26s} {scope:18s} found {tp}  invented {fp}  missed {fn}")
+
+
+def main():
+    print("Absolute threshold on the silence at a sentence boundary")
+    for t in (0.50, 0.85, 1.00, 1.20, 1.40):
+        row(f"threshold {t:.2f}s", absolute(t))
+    print()
+    print("Contrast against the same dictation's other boundaries")
+    for floor, factor in ((1.00, 1.5), (1.00, 1.3), (0.80, 1.5)):
+        row(f"floor {floor:.2f}s x{factor}", contrast(floor, factor))
+    print()
+    print("Mid-sentence silences the boundary condition rejects")
+    for k, f in DATA.items():
+        for d in f['longMidSentenceSilences']:
+            print(f"  fixture {k}: {d:.2f}s")
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/research/550-paragraph-placement/pauses/transcripts.md
+++ b/docs/research/550-paragraph-placement/pauses/transcripts.md
@@ -1,0 +1,64 @@
+# The five fixtures, raw and polished
+
+Source: `dictus-polish-debug-20260912-001017.json`, events 209 to 213. Parakeet
+`parakeet-tdt-0.6b-v3`, Normal polish, French, 2026-09-11 between 21:59 and 22:06 UTC.
+Fixture A was dictated twice; the first attempt was cut short and is event 208.
+
+Reference breaks were collected on 2026-09-12 from the numbered polished text, before
+any silence measurement was shown to the speaker.
+
+---
+
+## A — read aloud, 19,7 s, reference: after sentence 2
+
+**Raw and polished are identical.**
+
+> Ce matin, j'ai commencé ma journée assez tranquillement. J'ai pris un café, puis j'ai regardé rapidement mes messages. Ensuite, je me suis mis au travail. Rien de vraiment particulier aujourd'hui, mais finalement la matinée est passée assez vite.
+
+## B — read aloud, 17,4 s, reference: after sentence 1
+
+**Raw**
+
+> Je trouve qu'on passe beaucoup de temps à vouloir aller vite, faire les choses rapidement, répondre immédiatement, passer à la suivante alors que parfois prendre quelques minutes pour réfléchir permettre simplement de mieux faire les choses. Ce n'est pas forcément plus long, c'est juste une autre manière de travailler.
+
+**Polished** — one grammar repair, `permettre` to `permet`.
+
+> Je trouve qu'on passe beaucoup de temps à vouloir aller vite, faire les choses rapidement, répondre immédiatement, passer à la suivante alors que parfois prendre quelques minutes pour réfléchir permet simplement de mieux faire les choses. Ce n'est pas forcément plus long, c'est juste une autre manière de travailler.
+
+## C — spontaneous, 25,6 s, reference: after sentence 2
+
+**Raw**
+
+> Ok, donc là bah écoute, je vais faire ce que tu m'as demandé, je vais faire des audios un peu plus naturels pour qu'on puisse essayer d'avancer sur cette issue. C'est vrai que ça m'embête. Je voudrais vraiment qu'on arrive à essayer de trouver un compromis force. paragraphes de taille.
+
+**Polished** — the dangling `paragraphes de taille.` is dropped.
+
+> Ok, donc là, bah écoute, je vais faire ce que tu m'as demandé. Je vais faire des audios un peu plus naturels pour qu'on puisse essayer d'avancer sur cette issue. C'est vrai que ça m'embête. Je voudrais vraiment qu'on arrive à essayer de trouver un compromis force.
+
+The last five seconds of the audio are lost to a physical noise during the recording,
+confirmed by the speaker. Transcription, not paragraphing.
+
+## D — spontaneous, 60,0 s, reference: after sentences 1 and 5
+
+**Raw** — Parakeet switches to English mid-dictation.
+
+> Dans le cas où on n'arriverait vraiment pas à gérer ça de manière efficace, il faudra quand même qu'on réfléchisse à se soit laisser le mode normal comme ça. Et dans tous les cas, je pense que là où on peut essayer de se rattraper, c'est sur les sport modes. Parce que comme tu l'as dit, on peut... Enfin, on va pouvoir. And we'll unless the LLM, just enjoying the coherence of text. But that would permettrait peut-être de faire des trucs un petit peu plus poussés qui donneront quand même envie aux utilisateurs de payer en fait pour les smart modes parce que tout l'enjeu est là. Sans smart mode, il n'y a aucun intérêt d'acheter Dictus Pro.
+
+**Polished**
+
+> Dans le cas où on n'arriverait vraiment pas à gérer ça de manière efficace, il faudra quand même qu'on réfléchisse à se laisser le mode normal comme ça. Et dans tous les cas, je pense que là où on peut essayer de se rattraper, c'est sur les modes sportifs. Parce que comme tu l'as dit, on peut. Enfin, on va pouvoir. Et nous allons, sauf si le modèle, juste en profitant de la cohérence du texte. Mais cela permettrait peut-être de faire des trucs un peu plus poussés qui donneront quand même envie aux utilisateurs de payer en fait pour les modes intelligents parce que tout l'enjeu est là. Sans mode intelligent, il n'y a aucun intérêt d'acheter Dictus Pro.
+
+Two observations that belong to other issues, not to this one. The raw output mixes
+English into French, which is the #456 family. And the polish translates the product
+terms the speaker used in English: `sport modes` becomes `modes sportifs` and
+`smart modes` becomes `modes intelligents`. That is a word change, not whitespace.
+
+## E — spontaneous, 48,1 s, reference: after sentence 1
+
+**Raw**
+
+> Parce que concrètement, dans les fonctionnalités premium actuellement, à part les smart modes, on a le vocabulaire perso, mais honnêtement, c'est sympa, mais je trouve que c'est encore un petit peu archaïque c'est à dire que l'utilisateur doit saisir manuellement les textes qu'il veut qui soient remplacés donc ça veut dire qu'il faut qu'il puisse les identifier en amont parce qu'en plus le c'est assez strict, sinon le llm ne touche pas ça. And on a l'historique de transcription, which honnêtement aurait pu être dans la version gratuite. But c'était histoire de faire une différence par rapport au payant quoi donc voilà à réfléchir moi je mettais vraiment beaucoup d'espoir dans les sport mode donc j'espère vraiment qu'on va arriver à faire quelque chose de correct
+
+**Polished**
+
+> Parce que concrètement, dans les fonctionnalités premium actuellement, à part les smart modes, on a le vocabulaire personnel, mais honnêtement, c'est sympa, mais je trouve que c'est encore un petit peu archaïque, c'est à dire que l'utilisateur doit saisir manuellement les textes qu'il veut qui soient remplacés, donc ça veut dire qu'il faut qu'il puisse les identifier en amont, parce qu'en plus, c'est assez strict, sinon le LLM ne touche pas ça. Et on a l'historique de transcription, qui honnêtement aurait pu être dans la version gratuite. Mais c'était histoire de faire une différence par rapport au payant, donc voilà à réfléchir. Moi, je mettais vraiment beaucoup d'espoir dans les sport modes, donc j'espère vraiment qu'on va arriver à faire quelque chose de correct.


### PR DESCRIPTION
Documents only. No Swift, no behaviour change.

## What this is

The second half of #550. The model half closed with PR #551; this is the deterministic
pause route, measured for the first time against the speaker's own paragraph intent
instead of the competitor's output.

Five paired fixtures delivered 2026-09-12, each with source audio, Dictus raw and
Dictus polished text, plus the breaks the maintainer wants — collected from the numbered
polished text **before any measurement was shown to him**, because the reference is the
bar and #437 records what happens when a bar moves after the numbers arrive.

## The result

**The rule holds on the three spontaneous dictations and breaks on the two read-aloud
ones.** Sixteen sentence boundaries measured.

- Spontaneous C, D, E: wanted breaks at 1,44 / 1,60 / 1,96 / 2,00 s, unwanted boundaries
  top out at 0,91 s. Any threshold in [0,95 s ; 1,40 s] is perfect.
- Fixture A: three boundaries at 1,29 / 1,15 / 1,35 s, one break wanted, and it is the
  shortest. No threshold exists.
- Pooled over all five, the classes overlap to the centisecond.

The half-second rule the issue body opened on **invents as many breaks as it finds**.

What survives everywhere is the sentence-boundary condition. Five mid-sentence silences
are correctly rejected, the longest at 2,59 s, and that is the longest silence in the
whole corpus.

## Method note

Silences are mapped onto sentence boundaries by cutting the audio at the pauses and
transcribing each speech segment separately, so every pause is bracketed by its exact
text. No character offset is interpolated from a constant speaking rate — that assumption
is what limited fixture 7.

An instrument failure is recorded rather than hidden: the first pass reported zero silence
at two of the wanted boundaries and that was the detector, not the data. The two quiet
fixtures have the narrowest dynamic range of the five.

## What is not here

The source audio. It is the maintainer's voice on a public repository and the transcripts
carry everything the measurement needs. SHA-256 digests are in `pauses/reference.md`.

No code ships from this round. The bars are declared on the issue, before any Swift, to be
scored on a fixture set that excludes these five and includes a second speaker.

Full write-up: `docs/research/550-paragraph-placement/pauses/findings.md`.
Issue comment with the same tables: https://github.com/getdictus/dictus-ios/issues/550#issuecomment-5641527006

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C78XD4CAdZZ58WMTHNYrAH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added research documentation on paragraph-break placement using measured pauses and independently collected speaker references.
  - Documented findings across five fixtures, including differences between spontaneous dictation and read-aloud speech.
  - Added transcripts, methodology, limitations, and reproducibility guidance for the study.

- **Research Tools**
  - Added supporting analysis data and scripts for detecting silences, evaluating sentence boundaries, and comparing placement rules.
  - Findings indicate pause-based detection works reliably for spontaneous dictation but is less reliable for read-aloud speech.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->