### PR TITLE
Probe phys_footprint at every stage of the polish path (refs #555)

### DIFF
--- a/DictusKeyboard/KeyboardLifecycleProbe.swift
+++ b/DictusKeyboard/KeyboardLifecycleProbe.swift
@@ -1,6 +1,7 @@
 // DictusKeyboard/KeyboardLifecycleProbe.swift
 import UIKit
 import os
+import DictusCore
 
 /// Observation-only helpers for the #281 investigation.
 ///
@@ -146,4 +147,57 @@ extension UIInputViewController {
         "beingDismissed=\(isBeingDismissed) movingFromParent=\(isMovingFromParent)"
             + " hasParent=\(parent != nil) \(windowAttachmentProbeDetails)"
     }
+}
+
+// MARK: - Memory tick (#555)
+
+extension KeyboardViewController {
+
+    /// Logs `phys_footprint` every ten seconds while the keyboard is on screen (#555).
+    ///
+    /// WHY this exists: `memMB` is otherwise written only when the keyboard appears or
+    /// disappears, so a session spent typing without ever dismissing the keyboard
+    /// produces no readings at all. That makes the two suspects behind the 68 MB
+    /// plateau — plain typing and keyboard-language switching — impossible to tell
+    /// apart, because neither produces an appearance.
+    ///
+    /// WHY recursion rather than a repeating `Timer`: a run-loop `Timer` retains its
+    /// target and outlives the keyboard, which this repo has paid for twice (#390,
+    /// #416). `asyncAfter` with a weak capture and a generation check cannot.
+    ///
+    /// The generation counter is bumped on every appearance and on disappearance, so a
+    /// tick scheduled by an older appearance stops instead of running alongside a newer
+    /// one.
+    ///
+    /// **Measurement only**, and temporary — it belongs with #555 and comes out with it.
+    func startMemoryTick() {
+        MemoryTickGeneration.current &+= 1
+        scheduleMemoryTick(generation: MemoryTickGeneration.current)
+    }
+
+    func stopMemoryTick() {
+        MemoryTickGeneration.current &+= 1
+    }
+
+    private func scheduleMemoryTick(generation: Int) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 10) { [weak self] in
+            guard let self, MemoryTickGeneration.current == generation else { return }
+            PersistentLog.log(.diagnosticProbe(
+                component: "KeyboardMemory",
+                instanceID: self.controllerID,
+                action: "tick",
+                details: "mb=\(MemoryFootprint.residentMB()) lang=\(SupportedLanguage.active.rawValue)"
+            ))
+            self.scheduleMemoryTick(generation: generation)
+        }
+    }
+}
+
+/// The live memory-tick generation (#555).
+///
+/// Process-wide rather than per-controller because only one keyboard is on screen at a
+/// time, and because a stored property would have to live on `KeyboardViewController`,
+/// whose body is already at the `type_body_length` limit. Temporary, like the tick.
+enum MemoryTickGeneration {
+    @MainActor static var current = 0
 }

--- a/DictusKeyboard/KeyboardPolishCoordinator.swift
+++ b/DictusKeyboard/KeyboardPolishCoordinator.swift
@@ -49,6 +49,10 @@ final class KeyboardPolishCoordinator {
     /// Unfreezes the overlay when a generation never comes back.
     private var stageWatchdog: Timer?
 
+    /// Sequence number for the memory probe below, so one dictation's readings can be
+    /// grouped in a log that interleaves several.
+    private var memoryProbeSequence = 0
+
     /// Whether DictusApp has already been told this dictation is over for display
     /// purposes. Reset per claim; see `concludeDisplayForUnreachableDocument`.
     private var hasConcludedDisplay = false
@@ -104,6 +108,8 @@ final class KeyboardPolishCoordinator {
         defaults.removeObject(forKey: SharedKeys.lastTranscriptionSmartModeSkipped)
         defaults.removeObject(forKey: SharedKeys.handoffToken)
         PersistentLog.log(.polishHandoff(step: "claimed", outcome: "pending", chars: raw.count))
+        memoryProbeSequence &+= 1
+        probeMemory("claimed")
 
         activePolish = pending
         hasConcludedDisplay = false
@@ -236,6 +242,7 @@ final class KeyboardPolishCoordinator {
     // MARK: - The run
 
     private func run(_ pending: PendingDictation) async {
+        probeMemory("beforePolish")
         let outcome = await service.polish(
             raw: pending.raw,
             languagePolicy: pending.policy,
@@ -244,9 +251,12 @@ final class KeyboardPolishCoordinator {
             // Recorded, never polished on (#80).
             engineRaw: pending.engineRaw,
             onEngineWillRun: { [weak self] in
+                self?.probeMemory("engineWillRun")
                 self?.announceProcessingStage()
             }
         )
+
+        probeMemory("afterPolish")
 
         // A newer dictation claimed the slot while this generation was in flight
         // (decision 15). It owns the pending record, the stage and the app's
@@ -503,6 +513,47 @@ final class KeyboardPolishCoordinator {
         }
     }
 
+    /// Records `phys_footprint` at one point on the polish path (#555).
+    ///
+    /// WHY this exists: polish-on sessions settle near 68 MB and polish-off ones near
+    /// 35 MB, yet #361 measured twenty engine calls costing 5 MB. Its probe fired
+    /// straight at `AppleFoundationModelsPolishEngine` and never exercised this
+    /// coordinator, the guardrail, the text passes or the insertion — so the ~34 MB
+    /// has an owner nobody has measured. One line per stage names it.
+    ///
+    /// `phys_footprint` is the figure iOS judges a process on for jetsam, which is why
+    /// it is the one worth reading here rather than a heap total.
+    ///
+    /// **Measurement only.** Nothing reads these lines and no behaviour depends on them.
+    private func probeMemory(_ stage: String) {
+        PersistentLog.log(.diagnosticProbe(
+            component: "PolishMemory",
+            instanceID: "\(memoryProbeSequence)",
+            action: stage,
+            details: "mb=\(MemoryFootprint.residentMB())"
+        ))
+    }
+
+    /// The reading that matters most: what the process still holds once the dictation
+    /// is completely over. A stage delta that comes back down is a working set; one
+    /// that does not is what turns six dictations into 68 MB.
+    ///
+    /// Scheduled with `asyncAfter` rather than a run-loop `Timer`, and weakly: a
+    /// `Timer` with `target: self` outlives the keyboard, which this repo has paid for
+    /// twice (#390, #416).
+    private func probeMemoryAtRest() {
+        let sequence = memoryProbeSequence
+        DispatchQueue.main.asyncAfter(deadline: .now() + 30) { [weak self] in
+            guard self != nil else { return }
+            PersistentLog.log(.diagnosticProbe(
+                component: "PolishMemory",
+                instanceID: "\(sequence)",
+                action: "atRest30s",
+                details: "mb=\(MemoryFootprint.residentMB())"
+            ))
+        }
+    }
+
     private func stopStageWatchdog() {
         stageWatchdog?.invalidate()
         stageWatchdog = nil
@@ -625,9 +676,13 @@ final class KeyboardPolishCoordinator {
 
         guard let inserted else {
             KeyboardState.shared.endLocalProcessingStage()
+            probeMemory("finishedNoInsert")
+            probeMemoryAtRest()
             return
         }
         KeyboardState.shared.insertDictation(inserted)
+        probeMemory("finishedInserted")
+        probeMemoryAtRest()
     }
 
     // MARK: - Reading what travelled

--- a/DictusKeyboard/KeyboardViewController.swift
+++ b/DictusKeyboard/KeyboardViewController.swift
@@ -641,6 +641,8 @@ class KeyboardViewController: UIInputViewController {
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
             self?.logLayoutSnapshot(action: "layoutSnapshot_2000ms")
         }
+
+        startMemoryTick()
     }
 
     /// First-run flag for viewDidLayoutSubviews. Used by upstream
@@ -730,6 +732,7 @@ class KeyboardViewController: UIInputViewController {
         // A finger held on backspace when iOS takes the keyboard away never produces a
         // touchesEnded, and the repeat timer was cleared by nothing else (#390).
         giellaKeyboard?.cancelKeyRepeat(reason: "viewDidDisappear")
+        stopMemoryTick()
 
         // Restore system gesture recognizer delay (be a good citizen)
         restoreWindowGestureDelay()


### PR DESCRIPTION
## Why

#555 — "The keyboard extension settles at ~68 MB during use" — has two measurements that disagree.

| Source | Condition | Result |
| --- | --- | --- |
| #361, run B | 20 engine calls | 23 → 28 MB, settles at 27 |
| 2026-09-12 | 6 dictations with polish | 20 → 69 MB, never settles |
| 2026-09-12 | 12 dictations, polish off | 16 → 35 MB |

The polish-off control is sound — twice the dictations, half the footprint — so the cost is on the polish path. But #361's probe fired straight at `AppleFoundationModelsPolishEngine` and never exercised `KeyboardPolishCoordinator`, the guardrail, the text passes or the insertion. The ~34 MB has an owner nobody has measured.

## What this does

One `diagnosticProbe` line per stage, carrying `phys_footprint`:

| Stage | Where |
| --- | --- |
| `claimed` | the keyboard takes the dictation |
| `beforePolish` | immediately before `service.polish` |
| `engineWillRun` | the engine is about to run |
| `afterPolish` | the call returned |
| `finishedInserted` / `finishedNoInsert` | after the text path completes |
| `atRest30s` | 30 s later, dictation completely over |

`atRest30s` is the one that matters: a stage delta that comes back down is a working set, one that does not is what turns six dictations into 68 MB.

`phys_footprint` is the figure iOS judges a process on for jetsam, which is why it is read here rather than a heap total. `MemoryFootprint.residentMB()` already returns it and is already used across this file's neighbours.

The at-rest reading uses `asyncAfter` with a weak capture rather than a run-loop `Timer` — a `Timer` with `target: self` outlives the keyboard, which this repo has paid for twice (#390, #416).

## What this does not do

No behaviour changes. Nothing reads these lines. `diagnosticProbe` is the existing free-form channel, so no new log event, level or category.

## Verification

- `swift test` — 1920 tests, 1 skipped, 0 failures
- `swiftlint lint --strict` — 0 violations across 272 files
- Device build installed on the iPhone as `15b84d9`

Device validation is the purpose of the change rather than a check on it: the next dictation session is what this exists to record.

refs #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZuFwSqDRX29HZSqyrj5i9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Diagnostics**
  * Added measurement-only memory diagnostics during keyboard polishing.
  * Memory usage is recorded at key processing stages and again after a 30-second idle period.
  * Added periodic memory measurements while the keyboard is visible.
  * Monitoring starts when the keyboard appears and stops when it disappears.
  * These diagnostics do not affect keyboard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->